### PR TITLE
Change look of 'contact author/pi' links in grants/submissions tables

### DIFF
--- a/app/templates/components/pi-list-cell.hbs
+++ b/app/templates/components/pi-list-cell.hbs
@@ -1,6 +1,6 @@
 {{! Format pi and copi list as pi / copi names. Click on PI to do something.}}
 
-<a href='javascript:;' class='' {{action 'sendAction' 'piSelected' record}} title='Click to contact corresponding author/PI'>
+<a href='javascript:;' class='' {{action 'sendAction' 'piSelected' record}} title='Click to contact PI'>
   {{record.pi.name}}
 </a>
 {{#each record.copis as |person index|}}{{if index ', '}}{{person.name}}{{/each}}

--- a/app/templates/components/pi-list-cell.hbs
+++ b/app/templates/components/pi-list-cell.hbs
@@ -1,4 +1,6 @@
 {{! Format pi and copi list as pi / copi names. Click on PI to do something.}}
 
-<button class='btn btm-sm btn-outline-info' {{action 'sendAction' 'piSelected' record}}>{{record.pi.name}}</button>
+<a href='javascript:;' class='' {{action 'sendAction' 'piSelected' record}} title='Click to contact corresponding author/PI'>
+  {{record.pi.name}}
+</a>
 {{#each record.copis as |person index|}}{{if index ', '}}{{person.name}}{{/each}}

--- a/app/templates/components/submissions-author-cell.hbs
+++ b/app/templates/components/submissions-author-cell.hbs
@@ -1,1 +1,3 @@
-<button class='btn btm-sm' {{action 'sendAction' 'authorSelected' record}}>{{record.author.name}}</button>
+<a href='javascript:;' {{action 'sendAction' 'authorSelected' record}} title='Click to contact corresponding author/PI'>
+  {{record.author.name}}
+</a>

--- a/app/templates/components/submissions-author-cell.hbs
+++ b/app/templates/components/submissions-author-cell.hbs
@@ -1,3 +1,3 @@
-<a href='javascript:;' {{action 'sendAction' 'authorSelected' record}} title='Click to contact corresponding author/PI'>
+<a href='javascript:;' {{action 'sendAction' 'authorSelected' record}} title='Click to contact corresponding author'>
   {{record.author.name}}
 </a>


### PR DESCRIPTION
PASS-42

"Contact author/PI" components in the Grants and Submissions tables 
* Now look like normal hyperlinks
* Added on-hover tooltip
