### PR TITLE
Modify submission workflow "repositories" step

### DIFF
--- a/app/controllers/submission/show/repositories.js
+++ b/app/controllers/submission/show/repositories.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
@@ -6,6 +7,17 @@ export default Controller.extend({
     addedDeposits: [],
 
     store: service('store'),
+
+    localRepoName: "JHU-IR",
+    depositLocally: true,
+    /**
+     * If local repository is already a part of the submission before this step,
+     * make sure the user can't remove it (computed on init).
+     */
+    forceLocalDeposit: computed(function() {
+        let local = this.get('localRepoName');
+        return this.get('model').get('deposits').filter(d => d.get('repo') === local).length > 0;
+    }),
 
     actions: {
 
@@ -48,6 +60,10 @@ export default Controller.extend({
             this.get('addedDeposits').push(deposit);
         },
 
+        selectLocalDeposit() {
+            this.set('depositLocally', !this.get('depositLocally'));
+        },
+
         /** Determines if the given repo is among the deposits.
          * 
          * @param {string} repo Repository name.
@@ -67,6 +83,9 @@ export default Controller.extend({
          * @returns {Promise} Save promise for the submission and deposits
          */
         saveAll() {
+            if (this.get('localDepositChecked')) {
+                this.actions.addRepo(this.get('localRepoName'));
+            }
             var deposits = this.get('addedDeposits');
             this.set('addedDeposits', []);
 

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -19,7 +19,6 @@
             {{#each nonLocalRepos as |deposit|}}
                 <li class="list-group-item d-flex justify-content-between align-items-center my-1">
                     {{repo-name deposit.repo}}
-                    <span class="badge badge-primary badge-pill">{{deposit.status}}</span>
                 </li>
             {{/each}}
             </ul>

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -1,8 +1,5 @@
 <h2>Repositories</h2>
-<p>
-When complete, your submission will be sent to the following repositories.  You may optionally add additional repositories
-at this time.
-</p>
+
 {{#workflow-group name="repositories" workflow=(workflow-for model "repositories") as |group|}}
     {{#workflow-card step="repos" group=group
         back=(route-action "transitionTo" "submission.show.compliance" model)
@@ -12,6 +9,11 @@ at this time.
             (action "saveWorkflow" model target=group)
             (action "saveAll")
         ))}}
+            <h4 class="mt-3">Required</h4>
+            <p>
+                Based on the information about the funders and journal you have provided, you are required 
+                to deposit your manuscript/article into:
+            </p>
             <ul class="list-group">
             {{#each model.deposits as |deposit|}}
                 <li class="list-group-item d-flex justify-content-between align-items-center my-1">
@@ -20,19 +22,21 @@ at this time.
                 </li>
             {{/each}}
             </ul>
-            <div class="dropdown my-2">
-                {{#remaining-repos addedDeposits=addedDeposits linkedDeposits=model.deposits as |remainingRepos|}}
-                    {{#if remainingRepos.length}}
-                    <button class="btn btn-secondary dropdown-toggle" type="button" id="addRepo" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        Add additional repositories
-                    </button>
-                    <div class="dropdown-menu" aria-labelledby="addRepo">
-                    {{#each remainingRepos as |repo|}}
-                        <button class="dropdown-item" type="button" {{action "addRepo" repo}}>{{repo-name repo}}</button>
-                    {{/each}}
-                    </div>
-                    {{/if}}
-                {{/remaining-repos}}
+            <h4 class="mt-3">Local</h4>
+            <p>
+                If you wish to deposit your manuscript/article into other repository(-ies), please select from 
+                the following list of supported repositories:
+            </p>
+            <div id="local-deposit-list">
+                <ul class="list-group">
+                    <li class="list-group-item d-flex align-items-center my-1">
+                        {{input type="checkbox" id="local-deposit-checkbox" name=localRepoName 
+                                checked=depositLocally
+                                disabled=forceLocalDeposit
+                                change=(action "selectLocalDeposit")}}
+                        <label for="local-deposit-checkbox" class="mb-0 ml-2">{{repo-name localRepoName}}</label>
+                    </li>
+                </ul>
             </div>
     {{/workflow-card}}
 {{/workflow-group}}

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -5,6 +5,7 @@
         back=(route-action "transitionTo" "submission.show.compliance" model)
         cancel=(action "rollback")
         continue=(action (queue
+            (action "maybeDepositLocally")
             (route-action "transitionTo" "submission.show.metadata" model)
             (action "saveWorkflow" model target=group)
             (action "saveAll")
@@ -15,7 +16,7 @@
                 to deposit your manuscript/article into:
             </p>
             <ul class="list-group">
-            {{#each model.deposits as |deposit|}}
+            {{#each nonLocalRepos as |deposit|}}
                 <li class="list-group-item d-flex justify-content-between align-items-center my-1">
                     {{repo-name deposit.repo}}
                     <span class="badge badge-primary badge-pill">{{deposit.status}}</span>
@@ -32,7 +33,6 @@
                     <li class="list-group-item d-flex align-items-center my-1">
                         {{input type="checkbox" id="local-deposit-checkbox" name=localRepoName 
                                 checked=depositLocally
-                                disabled=forceLocalDeposit
                                 change=(action "selectLocalDeposit")}}
                         <label for="local-deposit-checkbox" class="mb-0 ml-2">{{repo-name localRepoName}}</label>
                     </li>


### PR DESCRIPTION
PASS-66

## Changes
* Header and explanation text changes
* List of displayed repositories no longer allows users to arbitrarily add other repositories
* List of displayed repos no longer displays JScholarship
* JScholarship now shows under a 'Local' repositories section with a checkbox
  - Checkbox is checked by default
* New deposit is created to JScholarship when the user clicks _Save and Continue_ only when necessary

![Screenshot](https://i.imgur.com/Dpk1CmD.png)

@htpvu 