### PR TITLE
Submission workflow Repositories list population issue

### DIFF
--- a/app/components/policy-compliance-nih.js
+++ b/app/components/policy-compliance-nih.js
@@ -44,14 +44,10 @@ export default Component.extend({
         var self = this;
         register(function () {
             // A never needs deposit, C, D does.  B depends on user input.
-
-            if (pmcMethod === 'A') {
-                self.set('needsDeposit', false);
-            } else if (!pmcMethod || pmcMethod === 'C' || pmcMethod === 'D') {
-                self.set('needsDeposit', true);
-            }
-
-            if (self.get('needsDeposit')) {
+            let mustDeposit = !pmcMethod || pmcMethod === 'C' || pmcMethod === 'D';
+            let answerFromUser = pmcMethod === 'B' && self.get('needsDeposit');
+            
+            if (mustDeposit || answerFromUser) {
                 return self.get('store').createRecord('deposit', {
                     repo: 'PMC',
                     status: 'new'

--- a/app/controllers/submission/show/compliance.js
+++ b/app/controllers/submission/show/compliance.js
@@ -18,7 +18,9 @@ export default Controller.extend({
 
             while (depositGenerators.length) {
                 let deposit = (depositGenerators.pop())();
-                if (deposit) {
+                // Don't add the deposit if it goes to a repository that is already present
+                let repoAlreadyHere = newDeposits.map(d => d.repo).includes(deposit.repo);
+                if (deposit && !repoAlreadyHere) {
                     newDeposits.push(deposit);
                 }
             }
@@ -65,6 +67,8 @@ export default Controller.extend({
                 .map(grant => grant.get('funder'))
                 .map(funder => funder.get('repo'));
             repos.push("JHU-IR");   // Hard code JScholarship in for now
+            // Remove duplicate entries, in case multiple awards go to the same repo
+            repos = repos.filter((el, i, arr) => arr.indexOf(el) == i);
             return repos;
         },
 

--- a/app/controllers/submission/show/compliance.js
+++ b/app/controllers/submission/show/compliance.js
@@ -19,8 +19,7 @@ export default Controller.extend({
             while (depositGenerators.length) {
                 let deposit = (depositGenerators.pop())();
                 // Don't add the deposit if it goes to a repository that is already present
-                let repoAlreadyHere = newDeposits.map(d => d.repo).includes(deposit.repo);
-                if (deposit && !repoAlreadyHere) {
+                if (deposit) {
                     newDeposits.push(deposit);
                 }
             }
@@ -45,7 +44,7 @@ export default Controller.extend({
                     return new Promise(() => newDeposit.rollbackAttributes());
                 }
             })).then(() => submission.save())
-                .then(() => Promise.all(toRemoveFromLinked.map(deposit => deposit.destroyRecord())));
+            .then(() => Promise.all(toRemoveFromLinked.map(deposit => deposit.destroyRecord())));
 
         },
 

--- a/app/controllers/submission/show/compliance.js
+++ b/app/controllers/submission/show/compliance.js
@@ -5,7 +5,7 @@ export default Controller.extend({
     depositGenerators: [],
 
     actions: {
-
+        
         /** Saves the submission deposits that will establish compliance 
          * 
          * @returns {Promise} Save promise for the submission and deposits.
@@ -61,6 +61,10 @@ export default Controller.extend({
          * @returns {Array<string>}
          */
         getPolicies() {
+            // TODO bad work-around that sort of clears 'depositGenerators' every time
+            // this step is rendered, so that it will always contain only information
+            // from the current render.
+            this.set('depositGenerators', []);
             let repos = this.get('model')
                 .get('grants')
                 .map(grant => grant.get('funder'))

--- a/app/templates/submission/show/repositories.hbs
+++ b/app/templates/submission/show/repositories.hbs
@@ -5,9 +5,9 @@
         back=(route-action "transitionTo" "submission.show.compliance" model)
         cancel=(action "rollback")
         continue=(action (queue
-            (action "maybeDepositLocally")
             (route-action "transitionTo" "submission.show.metadata" model)
             (action "saveWorkflow" model target=group)
+            (action "maybeDepositLocally")
             (action "saveAll")
         ))}}
             <h4 class="mt-3">Required</h4>
@@ -16,10 +16,12 @@
                 to deposit your manuscript/article into:
             </p>
             <ul class="list-group">
-            {{#each nonLocalRepos as |deposit|}}
-                <li class="list-group-item d-flex justify-content-between align-items-center my-1">
-                    {{repo-name deposit.repo}}
-                </li>
+            {{#each model.deposits as |deposit|}}
+                {{#if (not-eq "JHU-IR" deposit.repo)}}
+                    <li class="list-group-item d-flex justify-content-between align-items-center my-1">
+                        {{repo-name deposit.repo}}
+                    </li>
+                {{/if}}
             {{/each}}
             </ul>
             <h4 class="mt-3">Local</h4>


### PR DESCRIPTION
## Issue description:
* Sometimes necessary repositories are not populated in the list. Say a submission has one NIH award that will require a deposit to PubMed. In this case, PubMed may not appear in the Repositories list.
* If a submission already has deposits to any repository, they _should_ appear in the Repositories list anyway. If no deposit has yet been created for this award in the submission, it will not appear in the Repo list in its current state.
* If a user goes directly to the Repositories step for any submission that does not have deposits created in the DB, nothing will appear. In this case of direct navigation, only previously created deposits are shown. A user must go through the workflow from at least Policies step, then click Save and Continue in order for PASS to create new deposits.
* A submission is created with an award. User navigates away at the Policies step, then uses the browser Back button and clicks the Save and Continue in the Policies step. Now PubMed will appear twice in the Repositories list, where it should only appear once.
* A submission is created with two awards that follow the same compliance policy. In the Polices tab, the same policy is now displayed twice, where it should only appear once.

## Code changes:
* Fix issue in the NIH policy component logic and how it dealt with the Ember component lifecycle
* Prevent duplicate polices from appearing and from generating duplicate deposits

## Notes on fix:
* User still cannot navigate _directly_ to the submission workflow **Repositories** step. For the correct repositories to appear, it seems that the user must progress through the submissions workflow. More specifically, a user MUST use the "Save and Continue" button from the Policies step in order to reach the Repositories step.
  * The "Save" function in the Policies step (which is triggered from the "Save and Continue" button) is responsible for triggering the registration of each policy. These policies are what create new deposits, so this step is necessary in order to correctly populate the Repositories step.
* The change that keep duplicate polices from appearing and duplicate deposits from being created is a simple workaround and possibly stems from maintaining state in the controller. See [Issue 74](https://github.com/OA-PASS/pass-ember/issues/74). This needs to be addressed in a later PR.

Testing must be done manually in the Submission workflow, both with currently existing and new submissions.