### PR TITLE
NIH related radios moved into NIH policy card

### DIFF
--- a/app/components/policy-card.js
+++ b/app/components/policy-card.js
@@ -1,4 +1,16 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  // checks if the radio buttons need to be displayed
+  nihAndNotMethodAJournal: Ember.computed(function () { // eslint-ignore-line
+    let nih = false;
+    let methodA = this.get('journal.isMethodA');
+    if (methodA) {
+      return false;
+    }
+    if (this.get('policy.title') === 'National Institute of Health Public Access Policy') {
+      nih = true;
+    }
+    return nih && !methodA;
+  })
 });

--- a/app/components/policy-card.js
+++ b/app/components/policy-card.js
@@ -1,16 +1,20 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  methodAJournal: Ember.computed('journal', function () {
+    return this.get('journal.isMethodA');
+  }),
+  policyIsNIH: Ember.computed('policy', function () {
+    return this.get('policy.title') === 'National Institute of Health Public Access Policy';
+  }),
   // checks if the radio buttons need to be displayed
   nihAndNotMethodAJournal: Ember.computed(function () { // eslint-ignore-line
-    let nih = false;
-    let methodA = this.get('journal.isMethodA');
-    if (methodA) {
-      return false;
+    return this.get('policyIsNIH') && !this.get('methodAJournal');
+  }),
+  didRender() {
+    this._super(...arguments);
+    if (this.get('methodAJournal') && !this.get('removeNIHDeposit')) {
+      this.sendAction('toggleRemoveNIHDeposit', true);
     }
-    if (this.get('policy.title') === 'National Institute of Health Public Access Policy') {
-      nih = true;
-    }
-    return nih && !methodA;
-  })
+  }
 });

--- a/app/components/workflow-policies.js
+++ b/app/components/workflow-policies.js
@@ -30,9 +30,6 @@ export default Component.extend({
     return policies;
   }),
 
-  hasPmcMethod: Ember.computed('model.publication.journal', function () {
-    return !!this.get('model.publication.journal.pmcParticipation');
-  }),
   // checks if the radio buttons need to be displayed
   nihAndNotMethodAJournal: Ember.computed('model.publication.journal', 'activePolicies', function () { // eslint-ignore-line
     let nih = false;

--- a/app/components/workflow-policies.js
+++ b/app/components/workflow-policies.js
@@ -37,5 +37,8 @@ export default Component.extend({
     back() {
       this.sendAction('back');
     },
+    toggleRemoveNIHDeposit(bool) {
+      this.set('removeNIHDeposit', bool);
+    }
   },
 });

--- a/app/components/workflow-policies.js
+++ b/app/components/workflow-policies.js
@@ -29,21 +29,6 @@ export default Component.extend({
     policies = policies.uniqBy('id');
     return policies;
   }),
-
-  // checks if the radio buttons need to be displayed
-  nihAndNotMethodAJournal: Ember.computed('model.publication.journal', 'activePolicies', function () { // eslint-ignore-line
-    let nih = false;
-    let methodA = this.get('model.publication.journal.isMethodA');
-    if (methodA) {
-      return false;
-    }
-    this.get('activePolicies').forEach((policy) => {
-      if (policy.get('title') === 'National Institute of Health Public Access Policy') {
-        nih = true;
-      }
-    });
-    return nih && !methodA;
-  }),
   actions: {
     next() {
       this.sendAction('toggleNIHDeposit', !(this.get('removeNIHDeposit')));

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -51,10 +51,6 @@ export default Component.extend({
   }),
 
   optionalRepositories: Ember.computed('requiredRepositories', function () {
-    // const allRepos = this.get('model.repositories');
-    // const reqRepos = this.get('requiredRepositories');
-    // const ret = diff(allRepos, reqRepos).concat(diff(reqRepos, allRepos));
-    // return ret;
     return this.get('model.repositories').filter(repo => repo.get('name') === 'JScholarship');
   }),
 

--- a/app/templates/components/policy-card.hbs
+++ b/app/templates/components/policy-card.hbs
@@ -30,6 +30,17 @@
               <p>Some journals would submit your article to PMC on your behalf, for a fee. Specific arrangements would be required. Please indicate below whether or not you have made an arrangement with the publisher to have your article deposited by your
                 journal/publisher.
               </p>
+              {{#if nihAndNotMethodAJournal}}
+                {{radio-button value=true name='removeNIHDeposit' checked=removeNIHDeposit}}
+                I have made (or intend to make) an arrangement with the publisher to
+                deposit my article directly to PMC. (You will not need to submit your
+                manuscript to NIHMS as part of this process.)
+                <br>
+                {{radio-button value=false name='removeNIHDeposit' checked=removeNIHDeposit}}
+                I will not make an arrangement with the publisher to deposit my article
+                directly to PMC. (You will need to submit your manuscript to NIHMS as
+                part of this process.)
+              {{/if}}
             </div>
           {{/if}}
         {{/if}}

--- a/app/templates/components/workflow-policies.hbs
+++ b/app/templates/components/workflow-policies.hbs
@@ -7,18 +7,16 @@
     {{#each activePolicies as |policy|}}
       {{policy-card policy=policy journal=model.publication.journal}}
     {{/each}}
-    {{#if hasPmcMethod}}
-      {{#if nihAndNotMethodAJournal}}
-        {{radio-button value=true name='removeNIHDeposit' checked=removeNIHDeposit}}
-        I have made (or intend to make) an arrangement with the publisher to
-        deposit my article directly to PMC. (You will not need to submit your
-        manuscript to NIHMS as part of this process.)
-        <br>
-        {{radio-button value=false name='removeNIHDeposit' checked=removeNIHDeposit}}
-        I will not make an arrangement with the publisher to deposit my article
-        directly to PMC. (You will need to submit your manuscript to NIHMS as
-        part of this process.)
-      {{/if}}
+    {{#if nihAndNotMethodAJournal}}
+      {{radio-button value=true name='removeNIHDeposit' checked=removeNIHDeposit}}
+      I have made (or intend to make) an arrangement with the publisher to
+      deposit my article directly to PMC. (You will not need to submit your
+      manuscript to NIHMS as part of this process.)
+      <br>
+      {{radio-button value=false name='removeNIHDeposit' checked=removeNIHDeposit}}
+      I will not make an arrangement with the publisher to deposit my article
+      directly to PMC. (You will need to submit your manuscript to NIHMS as
+      part of this process.)
     {{/if}}
   </div>
 </div>

--- a/app/templates/components/workflow-policies.hbs
+++ b/app/templates/components/workflow-policies.hbs
@@ -5,19 +5,8 @@
       policies that are applicable to your work:
     </p>
     {{#each activePolicies as |policy|}}
-      {{policy-card policy=policy journal=model.publication.journal}}
+      {{policy-card policy=policy journal=model.publication.journal removeNIHDeposit=removeNIHDeposit}}
     {{/each}}
-    {{#if nihAndNotMethodAJournal}}
-      {{radio-button value=true name='removeNIHDeposit' checked=removeNIHDeposit}}
-      I have made (or intend to make) an arrangement with the publisher to
-      deposit my article directly to PMC. (You will not need to submit your
-      manuscript to NIHMS as part of this process.)
-      <br>
-      {{radio-button value=false name='removeNIHDeposit' checked=removeNIHDeposit}}
-      I will not make an arrangement with the publisher to deposit my article
-      directly to PMC. (You will need to submit your manuscript to NIHMS as
-      part of this process.)
-    {{/if}}
   </div>
 </div>
 

--- a/app/templates/components/workflow-policies.hbs
+++ b/app/templates/components/workflow-policies.hbs
@@ -5,7 +5,7 @@
       policies that are applicable to your work:
     </p>
     {{#each activePolicies as |policy|}}
-      {{policy-card policy=policy journal=model.publication.journal removeNIHDeposit=removeNIHDeposit}}
+      {{policy-card policy=policy journal=model.publication.journal removeNIHDeposit=removeNIHDeposit toggleRemoveNIHDeposit=(action 'toggleRemoveNIHDeposit')}}
     {{/each}}
   </div>
 </div>


### PR DESCRIPTION
To reiterate behavior for NIH grants:
* Method A journals, text is displayed to user saying they do not need to submit to PMC, PMC is removed from the submission repositories list
* Other journals, text is displayed to user saying they can submit to PMC through PASS or make arrangements with journal/publisher
  * If external arrangements are made, remove PMC from submission repositories list
  * else continue with workflow with PMC in the submission repositories list

Sample DOIs to use in the workflow:
* no pmc (Journal is not NIH related, does not have pmcParticipation): 10.1103/PhysRevFluids.1.073604
* method A: 10.1021/acsmedchemlett.7b00397
* method B: 10.1039/c7fo01251a