### PR TITLE
Fix sticky grants on submission and incomplete submissions being displayed

### DIFF
--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -9,6 +9,7 @@ export default Route.extend({
     // Explicitly clear the 'grant' query parameter when reloading this route
     if (isExiting) {
       controller.set('grant', undefined);
+      this.get('store').peekAll('submission').forEach(s => s.rollbackAttributes());
     }
   },
 

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -5,6 +5,13 @@ const {
 } = Ember.inject;
 
 export default Route.extend({
+  resetController(controller, isExiting, transition) {
+    // Explicitly clear the 'grant' query parameter when reloading this route
+    if (isExiting) {
+      controller.set('grant', undefined);
+    }
+  },
+
   currentUser: service(),
   model(params) {
     let preLoadedGrant = null;


### PR DESCRIPTION
Issue #238 and another unrelated bug

## Sticky Grants
#### Description
This bug would trigger after a user would start a new submission from the Grants Details page. This would seed the new submission with the specific grant, as expected. If a user would then leave the submission workflow, either finishing the submission or navigating to a different route, then create a new submission from anywhere. In this case, the grant from the first submission would automatically be added to this second new submission. The user would be unable to remove this grant in any way.
#### Solution
So this seems to be caused by Embers particular way of handling query parameters in routes. By default, Ember will make these parameters 'sticky' such that if you were to navigate away from a route then come back to the route, the query parameter would be added back automatically. This behavior must be explicitly disabled by clearing the query parameter on route exit.

## Phantom submissions
#### Description
This bug is related to an older bug, where in-progress submission would appear in other places of the app after a user leaves the submission workflow early. They would appear in the submissions table (as since been worked around), the `#` column in the grants table, and the submissions table in the grant details page.
#### Solution
This is caused by the new submission workflow itself. When starting the workflow, a submission object is created with `store.createRecord`, which will create the record in Ember data, but not in Fedora. If the user backs out of the workflow early, that object is retained in memory by Ember data. By forcing Ember data to perform a `rollbackAttributes` on submission objects that are in memory, we clean out all unsaved in-progress submission objects.

This implementation will "peek" at all submission objects, meaning it will inspect all submission objects in memory and will NOT go back to Fedora. For the objects peeked, do `obj.rollbackAttributes()` which will erase all unsaved changes and remove all unsaved objects. As an in memory operation it should be fast enough.