### PR TITLE
Add progress-checking to submission nav

### DIFF
--- a/app/components/submission-nav.js
+++ b/app/components/submission-nav.js
@@ -8,5 +8,10 @@ export default Component.extend({
     decStep() {
       this.decrementProperty('step');
     },
+    changeStep(step) {
+      if (step <= this.get('maxStep')) {
+        this.set('step', step);
+      }
+    }
   },
 });

--- a/app/components/workflow-wrapper.js
+++ b/app/components/workflow-wrapper.js
@@ -4,6 +4,7 @@ export default Component.extend({
   currentUser: Ember.inject.service('current-user'),
   store: Ember.inject.service('store'),
   step: 1,
+  maxStep: 1,
   isValidated: Ember.A(),
   doiInfo: [],
   includeNIHDeposit: true,
@@ -29,6 +30,9 @@ export default Component.extend({
       //   }
       // });
       this.incrementProperty('step');
+      if (this.get('maxStep') < this.get('step')) {
+        this.set('maxStep', this.get('step'))
+      }
     },
     back() {
       // const sub = this.get('model.newSubmission');

--- a/app/components/workflow-wrapper.js
+++ b/app/components/workflow-wrapper.js
@@ -31,7 +31,7 @@ export default Component.extend({
       // });
       this.incrementProperty('step');
       if (this.get('maxStep') < this.get('step')) {
-        this.set('maxStep', this.get('step'))
+        this.set('maxStep', this.get('step'));
       }
     },
     back() {

--- a/app/templates/components/submission-nav.hbs
+++ b/app/templates/components/submission-nav.hbs
@@ -1,25 +1,30 @@
+<style>
+button {
+  border: none;
+}
+</style>
 <div class="pb-2">
   <div class="steps">
-    <div {{action (mut step) 1}} class="step {{if (eq step 1) 'btn-primary'}}">
+    <button {{action "changeStep" 1}} class="step {{if (eq step 1) 'btn-primary'}}" disabled={{if (gt 1 maxStep) 'disabled'}}>
       1. Basics
-    </div>
-    <div {{action (mut step) 2}} class="step {{if (eq step 2) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 2}} class="step {{if (eq step 2) 'btn-primary'}}" disabled={{if (gt 2 maxStep) 'disabled'}}>
       2. Grants
-    </div>
-    <div {{action (mut step) 3}} class="step {{if (eq step 3) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 3}} class="step {{if (eq step 3) 'btn-primary'}}" disabled={{if (gt 3 maxStep) 'disabled'}}>
       3. Policies
-    </div>
-    <div {{action (mut step) 4}} class="step {{if (eq step 4) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 4}} class="step {{if (eq step 4) 'btn-primary'}}" disabled={{if (gt 4 maxStep) 'disabled'}}>
       4. Repositories
-    </div>
-    <div {{action (mut step) 5}} class="step {{if (eq step 5) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 5}} class="step {{if (eq step 5) 'btn-primary'}}" disabled={{if (gt 5 maxStep) 'disabled'}}>
       5. Metadata
-    </div>
-    <div {{action (mut step) 6}} class="step {{if (eq step 6) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 6}} class="step {{if (eq step 6) 'btn-primary'}}" disabled={{if (gt 6 maxStep) 'disabled'}}>
       6. Files
-    </div>
-    <div {{action (mut step) 7}} class="step {{if (eq step 7) 'btn-primary'}}">
+    </button>
+    <button {{action "changeStep" 7}} class="step {{if (eq step 7) 'btn-primary'}}" disabled={{if (gt 7 maxStep) 'disabled'}}>
       7. Review
-    </div>
+    </button>
   </div>
 </div>

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -7,9 +7,7 @@
     width: 200px;
   }
 </style>
-<p>
-  Attach manuscript/article files to this submission.
-</p>
+<p>Attach manuscript/article files to this submission.</p>
 <div class="form-group row">
   <div class="col-md-12">
     <input type="file" id="file-multiple-input" multiple size="50" onchange= {{action "getFiles"}} class="text-gray-300" style="border-width:2px; cursor:pointer; border-style: dashed; padding:30px; width:100%">

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -45,7 +45,7 @@
               {{input  class="form-control" value=file.description}}
             </td>
             <td class="text-center">
-              <button type="button" class="btn btn-danger" {{action 'removeFile' file}}>remove</button>
+              <button type="button" class="btn btn-outline-danger" {{action 'removeFile' file}}>remove</button>
             </td>
           </tr>
         {{/each}}

--- a/app/templates/components/workflow-wrapper.hbs
+++ b/app/templates/components/workflow-wrapper.hbs
@@ -3,7 +3,7 @@
     <h2 class="font-weight-light col-12">New Submission</h2>
   </div>
   <div class="row">
-    {{submission-nav submission=model step=step class="col-lg-12"}}
+    {{submission-nav submission=model step=step maxStep=maxStep class="col-lg-12"}}
   </div>
   <div class="row justify-content-center">
     <main class="col-lg-12">


### PR DESCRIPTION
Prevents people from skipping ahead farther than they've clicked `next` buttons for. Adds `disabled` attribute to links in submission nav that have not been reached yet in the workflow. Fixes https://github.com/OA-PASS/pass-ember/issues/254.