### PR TITLE
Add 404 page

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -20,6 +20,7 @@ Router.map(function () {
     this.route('detail', { path: '/:grant_id' });
   });
   this.route('thanks');
+  this.route('404', { path: '/*path' });
 });
 
 export default Router;

--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -24,6 +24,7 @@ export default Route.extend({
     let newSubmission = this.get('store').createRecord('submission');
 
     const repositories = this.get('store').findAll('repository');
+    const funders = this.get('store').findAll('funder');
     const grants = this.get('store').findAll('grant', {
       include: 'primaryFunder',
     });
@@ -36,6 +37,7 @@ export default Route.extend({
       grants,
       policies,
       journals,
+      funders,
       preLoadedGrant
     });
     return h;

--- a/app/templates/404.hbs
+++ b/app/templates/404.hbs
@@ -1,0 +1,23 @@
+{{outlet}}
+<style>
+.fourohfour {
+  font-size: 10em !important;
+  margin-bottom: 0;
+  height: auto;
+}
+.page-not-found {
+  font-size: 3em !important;
+  margin-top: -40px;
+}
+.helpful-text {
+  font-size: 1.5em !important;
+}
+</style>
+<div class="row text-center" style="padding-top:50px;">
+  <div class="col">
+    <h1 class="fourohfour">404</h1>
+    <h1 class="page-not-found"><small class="muted">Page Not Found</small></h1>
+    <p class="helpful-text"><br>Looks like the page you're looking for doesn't exist :(</p>
+    <p>If you think this might be a problem with the site itself, please {{#link-to 'contact'}}let us know{{/link-to}}.</p>
+  </div>
+</div>

--- a/tests/unit/routes/404-test.js
+++ b/tests/unit/routes/404-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:404', 'Unit | Route | 404', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/tests/unit/routes/404-test.js
+++ b/tests/unit/routes/404-test.js
@@ -5,7 +5,7 @@ moduleFor('route:404', 'Unit | Route | 404', {
   // needs: ['controller:foo']
 });
 
-test('it exists', function(assert) {
+test('it exists', function (assert) {
   let route = this.subject();
   assert.ok(route);
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7365276/39885279-30528154-545a-11e8-8349-af558aa431fe.png)

## Notes

This won't currently work for grant and submission ids that don't exist (i.e. `/submissions/12345`, but it will once we stop using mirage entirely.