### PR TITLE
Update mirage config for pass-docker integration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -60,7 +60,7 @@ module.exports = function (environment) {
   };
 
   ENV.fedora = {
-    base: 'http://localhost:8080/fcrepo/rest',
+    base: 'http://localhost:8080/fcrepo/rest/',
     context: 'http://example.org/pass/',
     data: 'http://example.org/pass/',
     elasticsearch: 'http://localhost:9200/pass/_search',

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -100,6 +100,7 @@ export default function () {
   // this.del('/repository-copies/:id');
 
   this.passthrough();
+  this.passthrough(`${ENV.fedora.base}**`);
   // Separate passthrough because search is done on a different port
   this.passthrough(ENV.fedora.elasticsearch); // Default will be something like: http://localhost:9200/pass/_search
 }


### PR DESCRIPTION
I need to tweak the mirage configuration so that Fedora requests are passed through when using in the full docker setup with shib and everything else. It does not seem to break anything when running things as usual. Give it a try.