### PR TITLE
Rename "OAP Repo id" field on Submissions table to "Ext. Repo Id"

### DIFF
--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -8,7 +8,7 @@ export default Controller.extend({
   columns: [
     { propertyName: 'publication', title: 'Article', component: 'submissions-article-cell' },
     { title: 'Award Number (Funder)', component: 'submissions-award-cell' },
-    { propertyName: 'repositories', title: 'Repo', component: 'submissions-repo-cell' },
+    { propertyName: 'repositories', title: 'Repositories', component: 'submissions-repo-cell' },
     { propertyName: 'submittedDate', title: 'Last Update Date', component: 'date-cell' },
     { propertyName: 'submittedDate', title: 'Submitted Date', component: 'date-cell' },
     {

--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -4,7 +4,6 @@ import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 
 export default Controller.extend({
   currentUser: Ember.inject.service('current-user'),
-
   columns: [
     { propertyName: 'publication', title: 'Article', component: 'submissions-article-cell' },
     { title: 'Award Number (Funder)', component: 'submissions-award-cell' },

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -71,7 +71,7 @@ export default Controller.extend({
   },
   {
     propertyName: 'repoCopies',
-    title: 'OAP Repo Id',
+    title: 'Ext. Repo Id',
     component: 'submissions-repoid-cell',
     disableSorting: true
   },
@@ -88,7 +88,7 @@ export default Controller.extend({
   },
   {
     propertyName: 'repositories',
-    title: 'Repo',
+    title: 'Repositories',
     component: 'submissions-repo-cell'
   },
   {
@@ -109,7 +109,7 @@ export default Controller.extend({
   },
   {
     // propertyName: 'repoCopies',
-    title: 'OAP Repo Id',
+    title: 'Ext. Repo Id',
     component: 'submissions-repoid-cell'
   },
   ],

--- a/app/templates/components/submissions-repo-cell.hbs
+++ b/app/templates/components/submissions-repo-cell.hbs
@@ -1,6 +1,10 @@
 {{#each (await (get record column.propertyName)) as |repo index|}}
 {{if index ', '}}
-  {{repo}}
+  {{#if repo.name}}
+    {{repo.name}}
+  {{else}}
+    {{repo}}
+  {{/if}}
 {{else}}
   Not Available
 {{/each}}


### PR DESCRIPTION
## Fixs https://github.com/OA-PASS/pass-ember/issues/323
- Switch names on submission table
- Standardize repo to repository column name