### PR TITLE
Show only content relevant to logged in user in the Grants and Submissions tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - docker-compose up -d
   - bash .wait.sh
 script:
-  - npm test --test-port=4200 && echo "Reporting coveralls" && cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+  - ember test --test-port=4200 && echo "Reporting coveralls" && cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 before_deploy:
   - ember build --environment=surge
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
   - docker-compose up -d
   - bash .wait.sh
 script:
-  - npm test && echo "Reporting coveralls" && cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+  - npm test --test-port=4200 && echo "Reporting coveralls" && cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
 before_deploy:
   - ember build --environment=surge
 deploy:

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -10,46 +10,6 @@ export default Controller.extend({
   messageSubject: '',
   messageText: '',
 
-  /**
-   * Updated way to populate the Grants table. Keys off of the logged in user,
-   * instead of using the route/grant/index#model() in order to do server side
-   * filtering of the visible Grants.
-   *
-   * Old way pulled in all Grants and did client side filtering.
-   */
-  tableModel: Ember.computed('currentUser.user', function () {
-    const user = this.get('currentUser.user');
-
-    if (!user) {
-      return;
-    }
-
-    let results = [];
-    // First search for all Grants associated with the current user
-    this.get('store').query('grant', { match: { pi: user.get('id') } }).then((grants) => {
-      let submissionQuery = { bool: { should: [] } };
-      grants.forEach((grant) => {
-        submissionQuery.bool.should.push({ match: { grants: grant.get('id') } });
-        results.push({
-          grant,
-          submissions: Ember.A()
-        });
-      });
-
-      // Then search for all Submissions associated with the returned Grants
-      this.get('store').query('submission', submissionQuery).then((subs) => {
-        subs.forEach((submission) => {
-          submission.get('grants').forEach((grant) => {
-            let match = results.find(res => res.grant.get('id') === grant.get('id'));
-            if (match) {
-              match.submissions.pushObject(submission);
-            }
-          });
-        });
-      }).then(() => results);
-    });
-  }),
-
   tablePageSize: 5,
   tablePageSizeValues: [5, 10, 25],
 
@@ -115,7 +75,7 @@ export default Controller.extend({
       predefinedFilterOptions: ['Active', 'Ended'],
     },
     {
-      propertyName: 'submissions.content.content.length',
+      propertyName: 'submissions.length',
       title: '#',
       disableFiltering: true,
       component: 'grant-link-cell'
@@ -170,7 +130,7 @@ export default Controller.extend({
       component: 'date-cell'
     },
     {
-      propertyName: 'submissions.content.content.length',
+      propertyName: 'submissions.length',
       title: '#',
       disableFiltering: true,
       component: 'grant-link-cell'

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -10,25 +10,22 @@ export default Controller.extend({
   messageSubject: '',
   messageText: '',
 
-  // tableModel: computed('model', function () {
-  //   return '';
-  // }),
-
   actions: {
-    authorclick(submission) {
-      this.set('messageShow', true);
-      this.set('messageTo', submission.get('user.displayName'));
-      this.set('messageSubject', 'OAP Compliance');
-      this.set('messageText', `Concerning submission ${submission.get('title')}, the status is ${submission.get('aggregatedDepositStatus')}.\nPlease check your PASS dashboard.`);
-    },
+    // PI/coPI Emailing on click - feature removed for release
+    // authorclick(submission) {
+    //   this.set('messageShow', true);
+    //   this.set('messageTo', submission.get('user.displayName'));
+    //   this.set('messageSubject', 'OAP Compliance');
+    //   this.set('messageText', `Concerning submission ${submission.get('title')}, the status is ${submission.get('aggregatedDepositStatus')}.\nPlease check your PASS dashboard.`);
+    // },
   },
 
   // Columns displayed depend on the user role
   columns: computed('currentUser', {
     get() {
-      if (this.get('currentUser.user.roles').includes('admin')) {
+      if (this.get('currentUser.user.isAdmin')) {
         return this.get('adminColumns');
-      } else if (this.get('currentUser.user.roles').includes('submitter')) {
+      } else if (this.get('currentUser.user.isSubmitter')) {
         return this.get('piColumns');
       }
       return [];

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -19,5 +19,8 @@ export default DS.Model.extend({
 
   isSubmitter: Ember.computed('roles', function () {
     return this.get('roles').includes('submitter');
+  }),
+  isAdmin: Ember.computed('roles', function () {
+    return this.get('roles').includes('admin');
   })
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -19,7 +19,7 @@ export default Route.extend(ApplicationRouteMixin, {
       this.transitionTo(route, model);
     },
   },
-  beforeModel() {
+  afterModel() {
     return this._loadCurrentUser();
   },
   sessionAuthenticated() {
@@ -53,7 +53,7 @@ export default Route.extend(ApplicationRouteMixin, {
     }).catch((e) => {
       console.log(e);
       console.log(' >>> Store.findAll("grant") failed, trying to add data.');
-      return this._add_test_data(jhuInstitution);
+      // return this._add_test_data(jhuInstitution);
     });
     // return this._add_test_data(jhuInstitution);
   },
@@ -742,7 +742,7 @@ export default Route.extend(ApplicationRouteMixin, {
       depositDB, repoCopyDB
     );
 
-    RSVP.all(moo.map(o => o.save())).then(() => {
+    return RSVP.all(moo.map(o => o.save())).then(() => {
       policyDB[0].get('repositories').pushObject(repoDB[0]);
       policyDB[1].get('repositories').pushObject(repoDB[1]);
       policyDB[2].get('repositories').pushObject(repoDB[2]);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -62,7 +62,7 @@ export default Route.extend(ApplicationRouteMixin, {
     const store = this.get('store');
 
     const users = [
-      {
+      { // 0
         username: 'eford',
         displayName: 'Ernest Ford',
         email: 'ford@example.com',
@@ -70,7 +70,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Ernest',
         lastName: 'Ford'
       },
-      {
+      { // 1
         username: 'agudzun',
         displayName: 'Anne Gudzune',
         email: 'anne@example.com',
@@ -78,7 +78,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Anne',
         lastName: 'Gudzune'
       },
-      {
+      { // 2
         username: 'spillage',
         displayName: 'Stephen Pillage',
         email: 'illage@example.com',
@@ -86,7 +86,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Stephen',
         lastName: 'Pillage'
       },
-      {
+      { // 3
         username: 'efrey',
         displayName: 'Eric Frey',
         email: 'frey@example.com',
@@ -94,7 +94,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Eric',
         lastName: 'Frey'
       },
-      {
+      { // 4
         username: 'mjaco',
         displayName: 'Michael Jacobs',
         email: 'mjacob@example.com',
@@ -102,7 +102,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Michael',
         lastName: 'Jacobs'
       },
-      {
+      { // 5
         username: 'jwong',
         displayName: 'John Wong',
         email: 'jwong@example.com',
@@ -110,7 +110,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'John',
         lastName: 'Wong'
       },
-      {
+      { // 6
         username: 'tbrown',
         displayName: 'Tiffany Brown',
         email: 'tbrown@example.com',
@@ -118,7 +118,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Tiffany',
         lastName: 'Brown'
       },
-      {
+      { // 7
         username: 'hpeek',
         displayName: 'Hillary Peek',
         email: 'peek@example.com',
@@ -126,7 +126,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Hillary',
         lastName: 'Peek'
       },
-      {
+      { // 8
         username: 'plimo',
         displayName: 'Steve Plimpton',
         email: 'plimo@example.com',
@@ -134,7 +134,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Steve',
         lastName: 'Plimpton'
       },
-      {
+      { // 9
         username: 'zwang',
         displayName: 'Szu Wang',
         email: 'zwang@example.com',
@@ -142,7 +142,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Szu',
         lastName: 'Want'
       },
-      {
+      { // 10
         username: 'ksand',
         displayName: 'Kurt Sanders',
         email: 'ksand@example.com',
@@ -150,7 +150,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Kurt',
         lastName: 'Sanders'
       },
-      {
+      { // 11
         username: 'bradley',
         displayName: 'Robert Bradley',
         email: 'bradley@example.com',
@@ -158,7 +158,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Robert',
         lastName: 'Bradley'
       },
-      {
+      { // 12
         username: 'elewin',
         displayName: 'Erin Lewin',
         email: 'elewin@example.com',
@@ -166,7 +166,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Erin',
         lastName: 'Lewin'
       },
-      {
+      { // 13
         username: 'sayeed.choudhury',
         displayName: 'Sayeed Choudhury',
         email: 'schou@example.com',
@@ -174,7 +174,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Sayeed',
         lastName: 'Choudhury'
       },
-      {
+      { // 14
         username: 'hvu',
         displayName: 'Hanh Vu',
         email: 'hvu@example.com',
@@ -182,7 +182,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Hanh',
         lastName: 'Vu'
       },
-      {
+      { // 15
         username: 'rkelly',
         displayName: 'Kelly R Fisher',
         email: 'r.kelly@example.com',
@@ -190,7 +190,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Kelly',
         lastName: 'Fisher'
       },
-      {
+      { // 16
         username: 'tmac',
         displayName: 'Thomas McDermott',
         email: 'mcdott@example.com',
@@ -198,7 +198,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Thomas',
         lastName: 'McDermott'
       },
-      {
+      { // 17
         username: 'shatsu',
         displayName: 'Sharon Tsui',
         email: 'sharon.tsui@example.com',
@@ -206,7 +206,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Sharon',
         lastName: 'Tsui'
       },
-      {
+      { // 18
         username: 'maciver',
         displayName: 'Martha Mac Iver',
         email: 'martha.mac@example.com',
@@ -214,7 +214,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Martha',
         lastName: 'Mac Iver'
       },
-      {
+      { // 19
         username: 'mirosen',
         displayName: 'Michael Rosenberg',
         email: 'michael.rosenberg@example.com',
@@ -222,7 +222,7 @@ export default Route.extend(ApplicationRouteMixin, {
         firstName: 'Michael',
         lastName: 'Rosenberg'
       },
-      {
+      { // 20
         username: 'jfauerbach',
         displayName: 'James Fauerbach',
         email: 'jfauerbach@example.com',
@@ -369,7 +369,7 @@ export default Route.extend(ApplicationRouteMixin, {
       }
     ];
     const grants = [
-      {
+      { // 0
         awardNumber: 'R01EY027824',
         projectName: 'Regulation of blood-retinal barrier by placental growth factor.',
         startDate: new Date('2017-04-01'),
@@ -377,7 +377,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16129769',
       },
-      {
+      { // 1
         awardNumber: 'R01DK110366',
         projectName: 'Identification and Activation Mechanisms of Vagal and Spinal Nociceptors in Esophageal Mucosa',
         startDate: new Date('2017-08-01'),
@@ -385,7 +385,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16120629',
       },
-      {
+      { // 2
         projectName: 'Optimal magnification and oculomotor strategies in low vision patients',
         awardNumber: 'R01EY026617',
         startDate: new Date('2017-06-01'),
@@ -393,7 +393,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16120539',
       },
-      {
+      { // 3
         projectName: 'UCure urethral strictures',
         awardNumber: '1640778',
         startDate: new Date('2016-06-01'),
@@ -401,7 +401,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16120469',
       },
-      {
+      { // 4
         projectName: 'Psychiatric Epidemiology Training Program',
         awardNumber: 'T32MH014592',
         startDate: new Date('2016-07-01'),
@@ -409,7 +409,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'terminated',
         localKey: '16120459',
       },
-      {
+      { // 5
         projectName: 'Neurologic Sequelae of HIV Subtype A and D Infection and ART Rakai Uganda',
         awardNumber: 'T32MH019545',
         startDate: new Date('2016-07-01'),
@@ -417,7 +417,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16120169',
       },
-      {
+      { // 6
         projectName: 'GEM:  RESPONSE OF GLOBAL IONOSPHERIC CURRENTS TO SUBSTORMS:  IMPLICATION FOR THE ELECTRIC FIELD PENETRATION TO THE INNER MAGNETOSPHERE',
         awardNumber: '1502700',
         startDate: new Date('2016-05-15'),
@@ -425,7 +425,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '1204023',
       },
-      {
+      { // 7
         projectName: 'Fogarty African Bioethics Consortium Post-Doctoral Fellowship Program',
         awardNumber: 'D43TW010512',
         startDate: new Date('2017-06-01'),
@@ -433,7 +433,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16119319',
       },
-      {
+      { // 8
         projectName: 'CAREER: DNA-Templated Assembly of Nanoscale Circuit Interconnects',
         awardNumber: 'CMMI-1253876',
         startDate: new Date('2013-01-01'),
@@ -441,7 +441,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16119219',
       },
-      {
+      { // 9
         projectName: 'Neurologic Sequelae of HIV Subtype A and D Infection and ART Rakai Uganda',
         awardNumber: 'R01MH099733',
         startDate: new Date('2016-03-01'),
@@ -449,7 +449,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16118979',
       },
-      {
+      { // 10
         projectName: 'Telomere maintenance by the telomerase RNA-protein complex',
         awardNumber: 'R01GM118757',
         startDate: new Date('2018-03-04'),
@@ -457,14 +457,14 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'active',
         localKey: '16108389',
       },
-      {
+      { // 11
         projectName: 'Genetics of Fuchs Corneal Dystrophy',
         awardNumber: 'R01EY016835',
         startDate: new Date('2017-03-04'),
         endDate: new Date('2018-08-10'),
         awardStatus: 'active',
       },
-      {
+      { // 12
         projectName: 'P-Adic and Mod P Galois Representations',
         awardNumber: '1564367',
         startDate: new Date('2015-03-04'),
@@ -472,7 +472,7 @@ export default Route.extend(ApplicationRouteMixin, {
         awardStatus: 'terminated',
         localKey: '16086889',
       },
-      {
+      { // 13
         awardNumber: 'R305A170411',
         localKey: '126699',
         projectName: 'Developing a Spacially-enhanced Elementary Curriculum and Teacher Training Series to Improve Science Advancement',
@@ -480,7 +480,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2021-06-30'),
         awardStatus: 'active',
       },
-      {
+      { // 14
         awardNumber: '90073719',
         localKey: '126257',
         projectName: 'FY18 Title IV Award',
@@ -488,7 +488,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2018-06-30'),
         awardStatus: 'active',
       },
-      {
+      { // 15
         awardNumber: 'P0451B99285',
         localKey: '122761',
         projectName: 'FY17 Federal Work Study',
@@ -496,7 +496,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2017-06-30'),
         awardStatus: 'terminated',
       },
-      {
+      { // 16
         awardNumber: 'P022A150076',
         localKey: '123526',
         projectName: 'How Do We Provide High Quality HIV Care and Treatment When THere Are Too Few Health Care Providers in Uganda',
@@ -504,7 +504,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2017-05-31'),
         awardStatus: 'terminated',
       },
-      {
+      { // 17
         awardNumber: 'R305H150081',
         localKey: '120443',
         projectName: 'Continuous Improvement in Schools Equipping Families to Support Students in the Transition to High School',
@@ -512,7 +512,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2019-06-30'),
         awardStatus: 'active',
       },
-      {
+      { // 18
         awardNumber: 'H325T090027',
         localKey: '105336',
         projectName: 'The Johns Hopkins Universtiy Secondary Support Initiative (JHUSSI)',
@@ -520,7 +520,7 @@ export default Route.extend(ApplicationRouteMixin, {
         endDate: new Date('2016-06-30'),
         awardStatus: 'terminated',
       },
-      {
+      { // 19
         awardNumber: 'H133A070045',
         localKey: '101950',
         projectName: 'Johns Hopkins University Burn Injury Model System',
@@ -755,11 +755,11 @@ export default Route.extend(ApplicationRouteMixin, {
       funderDB[4].set('policy', policyDB[0]);
       funderDB[5].set('policy', policyDB[3]);
 
-      grantDB[0].set('pi', userDB[1]);
+      grantDB[0].set('pi', userDB[14]);
       grantDB[0].get('coPis').pushObject(userDB[0]);
       grantDB[0].set('directFunder', funderDB[0]);
       grantDB[0].set('primaryFunder', funderDB[0]);
-      grantDB[1].set('pi', userDB[1]);
+      grantDB[1].set('pi', userDB[14]);
       grantDB[1].set('directFunder', funderDB[2]);
       grantDB[1].set('primaryFunder', funderDB[2]);
       grantDB[2].set('pi', userDB[2]);
@@ -797,7 +797,7 @@ export default Route.extend(ApplicationRouteMixin, {
       [userDB[7], userDB[10]].forEach(u => grantDB[10].get('coPis').pushObject(u));
       grantDB[10].set('directFunder', funderDB[4]);
       grantDB[10].set('primaryFunder', funderDB[4]);
-      grantDB[11].set('pi', userDB[9]);
+      grantDB[11].set('pi', userDB[14]);
       grantDB[11].get('coPis').pushObject(userDB[9]);
       grantDB[11].set('directFunder', funderDB[0]);
       grantDB[11].set('primaryFunder', funderDB[0]);
@@ -817,10 +817,10 @@ export default Route.extend(ApplicationRouteMixin, {
       grantDB[16].set('pi', userDB[17]);
       grantDB[16].set('directFunder', funderDB[5]);
       grantDB[16].set('primaryFunder', funderDB[5]);
-      grantDB[17].set('pi', userDB[18]);
+      grantDB[17].set('pi', userDB[14]);
       grantDB[17].set('directFunder', funderDB[5]);
       grantDB[17].set('primaryFunder', funderDB[5]);
-      grantDB[18].set('pi', userDB[19]);
+      grantDB[18].set('pi', userDB[14]);
       grantDB[18].set('directFunder', funderDB[5]);
       grantDB[18].set('primaryFunder', funderDB[5]);
       grantDB[19].set('pi', userDB[20]);
@@ -863,7 +863,7 @@ export default Route.extend(ApplicationRouteMixin, {
       [grantDB[0], grantDB[3]].forEach(g => submissionDB[0].get('grants').pushObject(g));
       submissionDB[0].get('repositories').pushObject(repoDB[0]);
       submissionDB[0].set('publication', publicationDB[0]);
-      submissionDB[0].set('user', userDB[0]);
+      submissionDB[0].set('user', userDB[14]);
 
       submissionDB[1].get('grants').pushObject(grantDB[0]);
       submissionDB[1].get('repositories').pushObject(repoDB[0]);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -771,7 +771,7 @@ export default Route.extend(ApplicationRouteMixin, {
       grantDB[3].set('directFunder', funderDB[1]);
       grantDB[3].set('primaryFunder', funderDB[1]);
       grantDB[4].set('pi', userDB[6]);
-      [userDB[7], userDB[10]].forEach(u => grantDB[4].get('coPis').pushObject(u));
+      [userDB[7], userDB[10], userDB[14]].forEach(u => grantDB[4].get('coPis').pushObject(u));
       grantDB[4].set('directFunder', funderDB[3]);
       grantDB[4].set('primaryFunder', funderDB[3]);
       grantDB[5].set('pi', userDB[8]);

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -7,6 +7,6 @@ const { service } = Ember.inject;
 export default Route.extend(AuthenticatedRouteMixin, {
 
   model() {
-    return this.get('store').findAll('grant');
+    // return this.get('store').findAll('grant');
   },
 });

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -7,6 +7,16 @@ const { service } = Ember.inject;
 export default Route.extend(AuthenticatedRouteMixin, {
   currentUser: service('current-user'),
 
+  /**
+   * Returns model:
+   *  [
+   *    {
+   *      'grant': { ... },
+   *      'submissions': [ ... ]
+   *    },
+   *    ...
+   *  ]
+   */
   model() {
     const user = this.get('currentUser.user');
     if (!user) {

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -1,12 +1,59 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { hash } from 'rsvp';
+import { hash, defer } from 'rsvp';
 
 const { service } = Ember.inject;
 
 export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: service('current-user'),
 
   model() {
-    // return this.get('store').findAll('grant');
+    const user = this.get('currentUser.user');
+    if (!user) {
+      console.log(' ## No user MOO');
+      return;
+    }
+
+    let promise = defer();
+    const grantQuery = {
+      // sort: [{ awardNumber: { order: 'asc' } }], // TODO
+      query: {
+        bool: {
+          should: [
+            { term: { pi: user.get('id') } },
+            { term: { coPis: user.get('id') } }
+          ]
+        }
+      }
+    };
+
+    // First search for all Grants associated with the current user
+    this.get('store').query('grant', grantQuery).then((grants) => {
+      let results = [];
+      let submissionQuery = { bool: { should: [] } };
+      grants.forEach((grant) => {
+        submissionQuery.bool.should.push({ match: { grants: grant.get('id') } });
+        results.push({
+          grant,
+          submissions: Ember.A()
+        });
+      });
+
+      // Then search for all Submissions associated with the returned Grants
+      this.get('store').query('submission', submissionQuery).then((subs) => {
+        subs.forEach((submission) => {
+          submission.get('grants').forEach((grant) => {
+            let match = results.find(res => res.grant.get('id') === grant.get('id'));
+            if (match) {
+              match.submissions.pushObject(submission);
+            }
+          });
+        });
+
+        promise.resolve(results);
+      });
+    });
+
+    return promise.promise;
   },
 });

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -21,7 +21,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
         bool: {
           should: [
             { term: { pi: user.get('id') } },
-            { term: { coPis: user.get('id') } }
+            // { term: { coPis: user.get('id') } }
           ]
         }
       }

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -20,7 +20,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       query: {
         bool: {
           should: [
-            { term: { pi: user.get('id') } },
+            { match: { pi: user.get('id') } },
             // { term: { coPis: user.get('id') } }
           ]
         }

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -1,23 +1,27 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import RSVP from 'rsvp';
+import _ from 'lodash';
 
 export default Route.extend(AuthenticatedRouteMixin, {
+  currentUser: Ember.inject.service('current-user'),
+
   model() {
-    // TODO: change returned records based on role
-    let submissions = this.store.findAll('submission', {
-      include: 'publication',
-    });
-    let publications = this.store.findAll('publication');
-    let repositories = this.store.findAll('repository');
-    let grants = this.store.findAll('grant');
-    let funders = this.store.findAll('funder');
-    return RSVP.hash({
-      submissions,
-      publications,
-      repositories,
-      grants,
-      funders
-    });
+    const user = this.get('currentUser.user');
+
+    if (user.get('isAdmin')) {
+    // if (true) { // Temp to manually try the 'admin' route
+      return this._doAdmin();
+    } else if (user.get('isSubmitter')) {
+      return this._doSubmitter(user);
+    }
+  },
+
+  _doAdmin() {
+    return this.store.findAll('submission');
+  },
+
+  _doSubmitter(user) {
+    return this.store.query('submission', { match: { user: user.get('id') } });
   },
 });

--- a/app/templates/components/pi-list-cell.hbs
+++ b/app/templates/components/pi-list-cell.hbs
@@ -1,6 +1,5 @@
 {{! Format pi and copi list as pi / copi names. Click on PI to do something.}}
-{{!-- <a href='javascript:;' class='' {{action 'sendAction' 'piSelected' record}} title='Click to contact PI'> --}}
-<style>
+{{!-- <style>
   .pi-list {
     padding: 0 6px;
     margin: 0;
@@ -8,12 +7,9 @@
   }
 </style>
 <ul class="pi-list">
-  {{!-- {{get record (concat '.' column.propertyName '.displayName')}} --}}
   <li>{{record.grant.pi.displayName}}</li>
-  {{!-- </a> --}}
   {{#each (get record 'grant.coPis') as |person|}}
     <li>{{person.displayName}}</li>
-  {{!-- {{else}}
-    Not Available --}}
   {{/each}}
-</ul>
+</ul> --}}
+{{record.grant.pi.displayName}}

--- a/app/templates/components/pi-list-cell.hbs
+++ b/app/templates/components/pi-list-cell.hbs
@@ -1,9 +1,19 @@
 {{! Format pi and copi list as pi / copi names. Click on PI to do something.}}
 {{!-- <a href='javascript:;' class='' {{action 'sendAction' 'piSelected' record}} title='Click to contact PI'> --}}
-  {{record.pi.displayName}}
-{{!-- </a> --}}
-{{#each record.coPis as |person index|}}
-  {{person.name}}
-{{else}}
-  Not Available
-{{/each}}
+<style>
+  .pi-list {
+    padding: 0 6px;
+    margin: 0;
+    min-width: 85px;
+  }
+</style>
+<ul class="pi-list">
+  {{!-- {{get record (concat '.' column.propertyName '.displayName')}} --}}
+  <li>{{record.grant.pi.displayName}}</li>
+  {{!-- </a> --}}
+  {{#each (get record 'grant.coPis') as |person|}}
+    <li>{{person.displayName}}</li>
+  {{!-- {{else}}
+    Not Available --}}
+  {{/each}}
+</ul>

--- a/app/templates/components/submissions-article-cell.hbs
+++ b/app/templates/components/submissions-article-cell.hbs
@@ -1,2 +1,3 @@
 {{#link-to "submissions.detail" record.id class="moo"}}
-{{await record.publicationTitle}}{{/link-to}}
+  {{get record 'publication.title'}}
+{{/link-to}}

--- a/app/templates/components/submissions-repo-cell.hbs
+++ b/app/templates/components/submissions-repo-cell.hbs
@@ -1,9 +1,7 @@
-{{#each (await (get record column.propertyName)) as |repo index|}}
+{{#each (await (get record 'repositories')) as |repo index|}}
 {{if index ', '}}
   {{#if repo.name}}
     {{repo.name}}
-  {{else}}
-    {{repo}}
   {{/if}}
 {{else}}
   Not Available

--- a/app/templates/grants/index.hbs
+++ b/app/templates/grants/index.hbs
@@ -2,7 +2,7 @@
   <div class="col-sm-12">
         <h1 class="font-weight-light">Grants</h1>
         {{models-table
-          data=tableModel
+          data=model
           columns=columns
           themeInstance=themeInstance
           showColumnsDropdown=false

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -16,7 +16,7 @@ table tbody tr td:nth-of-type(6)>div {
   </div>
 </div>
 {{models-table
-  data=model.submissions
+  data=model
   columns=columns
   themeInstance=themeInstance
   showColumnsDropdown=false

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -113,5 +113,6 @@ export function testConfig() {
   this.passthrough(`${ENV.fedora.base}**`);
   // // Separate passthrough because search is done on a different port
   this.passthrough(ENV.fedora.elasticsearch); // Default will be something like: http://localhost:9200/pass/_search
+  this.passthrough(ENV.fedora.elasticsearch.replace('_search', '_stats/indexing'));
   this.post('http://localhost:9999/api-auth-token/', (schema, request) => ({ token: 'f1e0e452b7ed034bdbd6bdcb877228d1d1c0c030' }));
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -34,7 +34,7 @@ export default function () {
 
 export function testConfig() {
   // test-only config, does not apply to development
-  this.post('/api-auth-token/', (schema, request) => ({ token: 'f1e0e452b7ed034bdbd6bdcb877228d1d1c0c030' }));
+  // this.post('/api-auth-token/', (schema, request) => ({ token: 'f1e0e452b7ed034bdbd6bdcb877228d1d1c0c030' }));
 
   // this.get('/deposits');
   // this.post('/deposits');
@@ -84,11 +84,11 @@ export function testConfig() {
   // this.patch('/submissions/:id'); // or this.patch
   // this.del('/submissions/:id');
 
-  this.get('/users');
-  this.post('/users');
-  this.get('/users/:id');
-  this.patch('/users/:id'); // or this.patch
-  this.del('/users/:id');
+  // this.get('/users');
+  // this.post('/users');
+  // this.get('/users/:id');
+  // this.patch('/users/:id'); // or this.patch
+  // this.del('/users/:id');
 
   // this.get('/publications');
   // this.post('/publications');
@@ -108,5 +108,10 @@ export function testConfig() {
   // this.patch('/repository-copies/:id'); // or this.patch
   // this.del('/repository-copies/:id');
 
+  this.urlPrefix = ENV.host;
   this.passthrough();
+  this.passthrough(`${ENV.fedora.base}**`);
+  // // Separate passthrough because search is done on a different port
+  this.passthrough(ENV.fedora.elasticsearch); // Default will be something like: http://localhost:9200/pass/_search
+  this.post('http://localhost:9999/api-auth-token/', (schema, request) => ({ token: 'f1e0e452b7ed034bdbd6bdcb877228d1d1c0c030' }));
 }

--- a/mirage/scenarios/test.js
+++ b/mirage/scenarios/test.js
@@ -12,6 +12,6 @@ export default function (server) {
   // let policy = server.create('policy', { repository });
   // let funder = server.create('funder', { policy });
 
-  // let grant = server.create('grant', { primaryFunder: funder });
+  // let grant = serzzver.create('grant', { primaryFunder: funder });
   let journal = server.create('journal');
 }

--- a/tests/acceptance-helpers.js
+++ b/tests/acceptance-helpers.js
@@ -41,7 +41,7 @@ async function doRequests(defer, intervalTime, maxIterations) {
  * @param {number} intervalTime time to wait before stats requests
  * @param {number} maxIterations maximum number of tries before giving up
  */
-export default async function waitForIndexer(intervalTime = 500, maxIterations = 120) {
+export default async function waitForIndexer(intervalTime = 500, maxIterations = 240) {
   let end = Ember.RSVP.defer();
   doRequests(end, intervalTime, maxIterations);
   return end.promise;

--- a/tests/acceptance-helpers.js
+++ b/tests/acceptance-helpers.js
@@ -1,0 +1,48 @@
+import ENV from 'pass-ember/config/environment';
+import $ from 'jquery';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function doRequests(defer, intervalTime, maxIterations) {
+  let iteration = 0;
+  // See the Elasticsearch _stats API
+  // (https://www.elastic.co/guide/en/elasticsearch/reference/6.2/indices-stats.html)
+  // Example: curl 'http://localhost:9200/pass/_stats/indexing?pretty'
+  const url = ENV.fedora.elasticsearch.replace('_search', '_stats/indexing');
+  let indexingTime = -1;
+
+  while (iteration++ < maxIterations) {
+    // console.log(`> Checking index for activity: ${url}`);
+    let newTime = await $.ajax(url, 'GET', { // eslint-disable-line
+      headers: { 'Content-Type': 'application/json; charset=utf-8' }
+    // }).then(result => result.indices.pass.total.indexing.index_time_in_millis);
+    }).then(result => result.indices.pass.total.indexing.index_total);
+    // console.log(`> Found time: ${newTime}`);
+    if (Math.abs(newTime - indexingTime) == 0) {
+      defer.resolve(true);
+      return;
+    }
+    indexingTime = newTime;
+    await sleep(intervalTime); // eslint-disable-line
+  }
+  defer.reject(true);
+}
+
+/**
+ * Wait for the Elasticsearch indexer to settle by checking the indexer stats.
+ * If the 'index_time_in_millis' has not changed between requests, then proceed.
+ *
+ * This will require a minimum of 2 requests before resolving, if there is no
+ * indexer activity, meaning that 'interval_time' effects every test where
+ * this function is used.
+ *
+ * @param {number} intervalTime time to wait before stats requests
+ * @param {number} maxIterations maximum number of tries before giving up
+ */
+export default async function waitForIndexer(intervalTime = 500, maxIterations = 120) {
+  let end = Ember.RSVP.defer();
+  doRequests(end, intervalTime, maxIterations);
+  return end.promise;
+}

--- a/tests/acceptance/grants/index-test.js
+++ b/tests/acceptance/grants/index-test.js
@@ -3,54 +3,7 @@ import { currentURL, visit, fillIn, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import testScenario from '../../../mirage/scenarios/test';
-import ENV from 'pass-ember/config/environment';
-import $ from 'jquery';
-
-function sleep(ms) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function doRequests(defer, intervalTime, maxIterations) {
-  let iteration = 0;
-  // See the Elasticsearch _stats API
-  // (https://www.elastic.co/guide/en/elasticsearch/reference/6.2/indices-stats.html)
-  // Example: curl 'http://localhost:9200/pass/_stats/indexing?pretty'
-  const url = ENV.fedora.elasticsearch.replace('_search', '_stats/indexing');
-  let indexingTime = -1;
-
-  while (iteration++ < maxIterations) {
-    // console.log(`> Checking index for activity: ${url}`);
-    let newTime = await $.ajax(url, 'GET', { // eslint-disable-line
-      headers: { 'Content-Type': 'application/json; charset=utf-8' }
-    // }).then(result => result.indices.pass.total.indexing.index_time_in_millis);
-    }).then(result => result.indices.pass.total.indexing.index_total);
-    // console.log(`> Found time: ${newTime}`);
-    if (Math.abs(newTime - indexingTime) == 0) {
-      defer.resolve(true);
-      return;
-    }
-    indexingTime = newTime;
-    await sleep(intervalTime); // eslint-disable-line
-  }
-  defer.reject(true);
-}
-
-/**
- * Wait for the Elasticsearch indexer to settle by checking the indexer stats.
- * If the 'index_time_in_millis' has not changed between requests, then proceed.
- *
- * This will require a minimum of 2 requests before resolving, if there is no
- * indexer activity, meaning that 'interval_time' effects every test where
- * this function is used.
- *
- * @param {number} intervalTime time to wait before stats requests
- * @param {number} maxIterations maximum number of tries before giving up
- */
-async function waitForIndexer(intervalTime = 500, maxIterations = 120) {
-  let end = Ember.RSVP.defer();
-  doRequests(end, intervalTime, maxIterations);
-  return end.promise;
-}
+import waitForIndexer from 'pass-ember/tests/acceptance-helpers';
 
 module('Acceptance | grants/index', (hooks) => {
   setupApplicationTest(hooks);

--- a/tests/acceptance/grants/index-test.js
+++ b/tests/acceptance/grants/index-test.js
@@ -1,0 +1,90 @@
+import { module, test } from 'qunit';
+import { currentURL, visit, fillIn, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import testScenario from '../../../mirage/scenarios/test';
+
+module('Acceptance | grants/index', (hooks) => {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async () => {
+    // testScenario(server);
+
+    await visit('/login');
+    await fillIn('input#identification', 'Jane');
+    await fillIn('input#password', 'j4n3s_p4$$w0rd!!');
+    await click('button#submit');
+
+    await visit('/grants');
+  });
+
+  test('Grants table renders correctly', async (assert) => {
+    assert.equal(currentURL(), '/grants');
+
+    assert.ok(document.querySelector('.models-table-wrapper'), 'There is a grants table');
+
+    // Check headers
+    const headers = document.querySelectorAll('.models-table-wrapper table thead th');
+    assert.equal(headers.length, 9, `Should be 9 columns in the table, but found ${headers.length}`);
+
+    // Table has the right number of grants
+    const rows = document.querySelectorAll('.models-table-wrapper table tbody tr');
+    assert.equal(rows.length, 5, 'There should be 5 grants (rows) in the table');
+    // Select grant has required data
+    rows.forEach(row => row.querySelectorAll('td').forEach((td, index) => {
+      // Columns 0, 1, 2, 4, 7 MUST have data
+      switch (index) {
+        case 0:
+        case 1:
+        case 2:
+        case 4:
+        case 7:
+          assert.ok(td.innerText, `Grant table cell (${index}) must have content`);
+          break;
+        default:
+          // Other columns are not required to have data
+      }
+    }));
+  });
+
+  test('Project Name, Award Number, and Submissions # columns are clickable', async (assert) => {
+    assert.equal(currentURL(), '/grants');
+
+    document.querySelectorAll('.models-table-wrapper table tbody tr').forEach((row) => {
+      let href;
+      row.querySelectorAll('td').forEach((td, index) => {
+        switch (index) {
+          case 0:
+          case 2:
+          case 7: {
+            const html = td.querySelector('a');
+            assert.ok(html, 'Cell must contain an Anchor tag');
+            assert.ok(html.href, 'Cell must have an href');
+            if (!href) {
+              href = html.href;
+            } else {
+              // TODO might be too strict of a check?
+              assert.equal(html.href, href, 'Links for a grant must lead to the same place');
+            }
+            break;
+          }
+          default:
+        }
+      });
+    });
+  });
+
+  test('Column sorting works', async (assert) => {
+    
+    async function checkSort(index) {
+      let state = [];
+      await click(`.models-table table thead tr:nth-child(${index})`);
+    }
+
+    const headers = document.querySelector('.models-table table thead tr');
+    for (let i = 0; i < headers.length; i++) {
+      checkSort(i);
+    }
+  });
+});

--- a/tests/acceptance/grants/index-test.js
+++ b/tests/acceptance/grants/index-test.js
@@ -19,14 +19,13 @@ async function doRequests(defer, intervalTime, maxIterations) {
   let indexingTime = -1;
 
   while (iteration++ < maxIterations) {
-    console.log(`> Checking index for activity: ${url}`);
-
+    // console.log(`> Checking index for activity: ${url}`);
     let newTime = await $.ajax(url, 'GET', { // eslint-disable-line
       headers: { 'Content-Type': 'application/json; charset=utf-8' }
     // }).then(result => result.indices.pass.total.indexing.index_time_in_millis);
     }).then(result => result.indices.pass.total.indexing.index_total);
-    console.log(`> Found time: ${newTime}`);
-    if (Math.abs(newTime - indexingTime) < 3) {
+    // console.log(`> Found time: ${newTime}`);
+    if (Math.abs(newTime - indexingTime) == 0) {
       defer.resolve(true);
       return;
     }

--- a/tests/acceptance/submissions/index-test.js
+++ b/tests/acceptance/submissions/index-test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { currentURL, visit, fillIn, click, triggerKeyEvent } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import ENV from 'pass-ember/config/environment';
+import waitForIndexer from 'pass-ember/tests/acceptance-helpers';
+
+module('Acceptance | submissions/index', (hooks) => {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async () => {
+    await visit('/login');
+    await waitForIndexer();
+    await fillIn('input#identification', 'Jane');
+    await fillIn('input#password', 'j4n3s_p4$$w0rd!!');
+    await click('button#submit');
+
+    await visit('/submissions');
+  });
+
+  /*
+   * Submissions table:
+   *  - Article title is a link that goes to submission detail page
+   *  - Grant links go to grant details page
+   *  - Contains links to associated grants
+   *  - Sort/filter work
+   */
+  test('submissions table contains data', async (assert) => {
+    assert.equal(currentURL(), '/submissions');
+
+    assert.ok(document.querySelector('.models-table-wrapper'), 'There is a submissions table');
+
+    // Check # columns
+    const headers = document.querySelectorAll('.models-table-wrapper table thead th');
+    assert.equal(headers.length, 7, 'should be 7 columns in the table');
+
+    const rows = document.querySelectorAll('.models-table-wrapper table tbody tr');
+    assert.equal(rows.length, 2, 'should be 2 submissions in the table');
+  });
+
+  test('submission article title is clickable', async (assert) => {
+    assert.equal(currentURL(), '/submissions');
+
+    const rows = document.querySelectorAll('.models-table-wrapper table tbody tr');
+    rows.forEach(row => row.querySelectorAll('td').forEach((td, index) => {
+      if (index === 0) {
+        const titleEl = td.querySelector('a');
+        assert.ok(titleEl, 'Title should be an Anchor element');
+        assert.ok(titleEl.href.match(/\/submissions\/.+/), 'Title link should lead to submission details page');
+      }
+    }));
+  });
+
+  test('submission award number links go to grant details)', async (assert) => {
+    const rows = document.querySelectorAll('.models-table-wrapper table tbody tr');
+    rows.forEach(row => row.querySelectorAll('td').forEach((td, index) => {
+      if (index === 1) {
+        const funderEls = td.querySelectorAll('a');
+        if (funderEls.length) {
+          funderEls.forEach((link) => {
+            assert.ok(link.href.match(/\/grants\/.+/), 'Award number links should lead to grant details page');
+          });
+        }
+      }
+    }));
+  });
+
+  test('table filter works', async (assert) => {
+    const searchBoxSelector = '.models-table-wrapper .globalSearch input.filterString';
+    await fillIn(searchBoxSelector, 'eval');
+    await triggerKeyEvent(searchBoxSelector, 'keypress', 13); // Enter
+
+    // Ember.run.later(async () => {
+    const rows = document.querySelectorAll('.models-table-wrapper table tbody tr');
+    assert.equal(rows.length, 1, 'should be one visible row after filter');
+    // });
+  });
+});


### PR DESCRIPTION
Work in progress PR to update various views to show only content relevant to the currently logged in user.

- [x] Grants table should show only grants where currently user is the PI #142 
- [x] Submissions table should show only those submissions where the current user is the managing user (`submission.user === current_user`)
- ~~Grant-picker in the submission workflow should contain only grants where the current user is the PI #322~~ Will be rolled into separate PR

Will include an efficiency pass for using the search service (#280)