### PR TITLE
Remove policy.funder relationship from Ember Policy model

### DIFF
--- a/app/models/policy.js
+++ b/app/models/policy.js
@@ -7,5 +7,5 @@ export default DS.Model.extend({
 
   repositories: DS.hasMany('repository'),
   institution: DS.attr('string'),
-  funder: DS.hasMany('funder'),
+  // funder: DS.hasMany('funder'),
 });


### PR DESCRIPTION
This relationship was adding bad Policy objects to Fedora. Looks like it was leftover from an earlier version of the Ember model.