### PR TITLE
Allow Authorization head to be removed from ember fedora adapter requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The pass-ember application configures the Fedora adapter uses these environment 
 There are also defaults specified in config/environment.js. They tell the adapter where Fedora
 and Elasticsearch are and generally will not need to be modified during development.
 
+In order to prevent an Authorization header being sent to Fedora and Elasticsearch,
+set FEDORA_ADAPTER_USER and FEDORA_ADAPTER_PASSWORD to empty strings.
+
 ### Running Tests
 
 * `ember test`

--- a/config/environment.js
+++ b/config/environment.js
@@ -63,9 +63,7 @@ module.exports = function (environment) {
     base: 'http://localhost:8080/fcrepo/rest/',
     context: 'http://example.org/pass/',
     data: 'http://example.org/pass/',
-    elasticsearch: 'http://localhost:9200/pass/_search',
-    username: 'admin',
-    password: 'moo'
+    elasticsearch: 'http://localhost:9200/pass/_search'
   };
 
   if (process.env.FEDORA_ADAPTER_BASE) {
@@ -84,13 +82,18 @@ module.exports = function (environment) {
     ENV.fedora.elasticsearch = process.env.FEDORA_ADAPTER_ES;
   }
 
-  if (process.env.FEDORA_ADAPTER_USER_NAME) {
+  if ('FEDORA_ADAPTER_USER_NAME' in process.env) {
     ENV.fedora.username = process.env.FEDORA_ADAPTER_USER_NAME;
+  } else {
+    ENV.fedora.username = 'admin';
   }
 
-  if (process.env.FEDORA_ADAPTER_PASSWORD) {
+  if ('FEDORA_ADAPTER_PASSWORD' in process.env) {
     ENV.fedora.password = process.env.FEDORA_ADAPTER_PASSWORD;
+  } else {
+    ENV.fedora.password = 'moo';
   }
+  
 
   return ENV;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-3
+    image: oapass/fcrepo:4.7.5-2.0-SNAPSHOT-5
     container_name: fcrepo
     env_file: .env
     environment:


### PR DESCRIPTION
For production deployment, the ember fedora adapter should not add an Authorization header to requests.

This pr allows the FEDORA_ADAPTER_USER and FEDORA_ADAPTER_PASSWORD environment variables to be set to empty strings in order to disable the Authorization header. 

The fcrepo version also gets bumped. 