### PR TITLE
Replace example.org in context URL with oapass.org

### DIFF
--- a/.docker/shib/.env
+++ b/.docker/shib/.env
@@ -2,8 +2,8 @@
 EMBER_PORT=81
 
 FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
-FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.0.jsonld
-FEDORA_ADAPTER_DATA=http://example.org/pass/
+FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld
+FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass#
 FEDORA_ADAPTER_ES=https://pass/es/
 
 # Fedora config
@@ -31,5 +31,5 @@ PI_ES_BASE=http://elasticsearch:9200/
 PI_ES_INDEX=http://elasticsearch:9200/pass/
 PI_FEDORA_JMS_BROKER=tcp://fcrepo:61616
 PI_FEDORA_JMS_QUEUE=fedora
-PI_TYPE_PREFIX=http://example.org/pass/
+PI_TYPE_PREFIX=http://oapass.org/ns/pass#
 PI_LOG_LEVEL=debug

--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - back
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-1
     container_name: fcrepo
     env_file: .env
     ports:

--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - back
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.1-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT
     container_name: fcrepo
     env_file: .env
     ports:
@@ -29,7 +29,7 @@ services:
       - back
 
   indexer:
-    image: oapass/indexer:0.0.9-2.1-SNAPSHOT
+    image: oapass/indexer:0.0.10-2.2-SNAPSHOT
     container_name: indexer
     env_file: .env
     networks:

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # Adapter integration test config:
 
 FEDORA_ADAPTER_BASE=http://localhost:8080/fcrepo/rest/
-FEDORA_ADAPTER_CONTEXT=http://example.org/pass/
-FEDORA_ADAPTER_DATA=http://example.org/pass/
+FEDORA_ADAPTER_CONTEXT=http://oapass.org/ns/pass#
+FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass#
 FEDORA_ADAPTER_ES=http://localhost:9200/pass/_search
 FEDORA_ADAPTER_ES_INDEX=http://localhost:9200/pass/
 
@@ -16,9 +16,9 @@ FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
 
-COMPACTION_URI=http://example.org/pass/
-COMPACTION_PRELOAD_URI_PASS_STATIC=http://example.org/pass/
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.0.jsonld
+COMPACTION_URI=http://oapass.org/ns/pass#
+COMPACTION_PRELOAD_URI_PASS_STATIC=http://oapass.org/ns/pass#
+COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.2.jsonld
 
 # Elasticsearch config
 
@@ -33,5 +33,5 @@ PI_ES_BASE=http://elasticsearch:9200/
 PI_ES_INDEX=http://elasticsearch:9200/pass/
 PI_FEDORA_JMS_BROKER=tcp://fcrepo:61616
 PI_FEDORA_JMS_QUEUE=fedora
-PI_TYPE_PREFIX=http://example.org/pass/
+PI_TYPE_PREFIX=http://oapass.org/ns/pass#
 PI_LOG_LEVEL=debug

--- a/.env
+++ b/.env
@@ -16,10 +16,6 @@ FCREPO_STOMP_PORT=61613
 FCREPO_LOG_LEVEL=INFO
 FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
 
-COMPACTION_URI=http://oapass.org/ns/pass#
-COMPACTION_PRELOAD_URI_PASS_STATIC=http://oapass.org/ns/pass#
-COMPACTION_PRELOAD_FILE_PASS_STATIC=/usr/local/tomcat/lib/context-2.2.jsonld
-
 # Elasticsearch config
 
 ES_PORT=9200

--- a/config/environment.js
+++ b/config/environment.js
@@ -64,8 +64,8 @@ module.exports = function (environment) {
 
   ENV.fedora = {
     base: 'http://localhost:8080/fcrepo/rest/',
-    context: 'http://example.org/pass/',
-    data: 'http://example.org/pass/',
+    context: 'http://oapass.org/ns/pass#',
+    data: 'http://oapass.org/ns/pass#',
     elasticsearch: 'http://localhost:9200/pass/_search'
   };
   ENV.userService = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.1-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT
     container_name: fcrepo
     env_file: .env
     environment:
@@ -15,7 +15,7 @@ services:
       - "${FCREPO_DEBUG_PORT}:${FCREPO_DEBUG_PORT}"
 
   indexer:
-    image: oapass/indexer:0.0.8-2.1-SNAPSHOT
+    image: oapass/indexer:0.0.10-2.2-SNAPSHOT
     container_name: indexer
     env_file: .env
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-1
     container_name: fcrepo
     env_file: .env
     environment:


### PR DESCRIPTION
This line may require an update at some point, but not sure what to: https://github.com/OA-PASS/pass-ember/blob/55f43dcd3a400e2548f2cf922d89fcca29c80b2b/app/components/workflow-files.js#L53