### PR TITLE
User Store.query for journal picker, get it working with incomplete data

### DIFF
--- a/app/components/find-journal.js
+++ b/app/components/find-journal.js
@@ -13,12 +13,29 @@ export default Component.extend({
      * @param term {string} The search term
      * @returns {array} array of objects
      *                  {
-     *                    suggestion: 'the autocompleted suggestion',
      *                    id: `string ID of the associated Journal model object`
+     *                    ... // properties from the source document in the search index
      *                  }
      */
     searchJournals(term) {
-      return this.get('autocomplete').suggest('journalName', term);
+      // return this.get('autocomplete').suggest('journalName', term);
+      /*
+       * TODO BELOW MUST BE REMOVED WHEN JOURNAL DATA IS UPDATED
+       * > This function should be updated to use autocomplete
+       * > 'workflow-basic.js#validateNext' should be updated by removing the journal.name check
+       * > 'find-journal.hbs' should be updated to remove the journal.name reference
+       */
+      return this.get('store').query('journal', {
+        query: {
+          bool: {
+            should: [
+              { term: { name: term } }, // Shouldn't be necessary, but the 'assets' container looks like it has old data
+              { term: { journalName: term } }
+            ]
+          }
+        },
+        size: 100
+      });
     },
 
     onSelect(selected) {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -49,7 +49,7 @@ export default Component.extend({
       let validTitle = false;
       let validJournal = false;
 
-      if (journal.get('journalName') == null) {
+      if (journal.get('journalName') == null && journal.get('name') == null) {
         toastr.warning('The journal must not be left blank');
         validJournal = false;
         $('.ember-power-select-trigger').css('border-color', '#f86c6b');

--- a/app/models/journal.js
+++ b/app/models/journal.js
@@ -15,5 +15,9 @@ export default DS.Model.extend({
   }),
   isMethodB: Ember.computed('pmcParticipation', function () {
     return this.get('pmcParticipation') ? this.get('pmcParticipation').toLowerCase() === 'b' : false;
-  })
+  }),
+
+  // TODO MUST REMOVE
+  // Artifact of incomplete data - once Journal data is updated this must be removed
+  name: DS.attr('string')
 });

--- a/app/templates/components/find-journal.hbs
+++ b/app/templates/components/find-journal.hbs
@@ -5,5 +5,5 @@
   onchange=(action "onSelect")
   as |journal|
 }}
-  {{journal.journalName}}
+  {{get journal 'journalName'}} {{get journal 'name'}}
 {{/power-select}}


### PR DESCRIPTION
This PR steps back from using autocomplete temporarily in order to work around some incomplete Journal data. `Store.query` is now used, which results in less user friendly behavior in the journal picker widget. This behavior should be OK for initial testing.

### Testing
Testing should be done in the new docker shib environment in this repository. 
* Navigate to `pass-ember/.docker/shib`
* (Optional) make sure images and volumes are cleaned out with `docker-compose down -v` or if you want to be extra paranoid: `docker-compose down && docker system prune -f && docker volume prune -f`
* Make sure you have up-to-date images: `docker-compose pull`
* Run `docker-compose up` to bring the environment up.
* When things settle, you can navigate to `https://pass` in your browser to bring up PASS.
* Use known test user credentials to login (https://github.com/OA-PASS/pass-docker#shibboleth-users)

Now you can test.

These changes only touch the submission workflow. The journal picker appear in the initial step - 
* Start a new Submission in the Ember app
* Assume that no DOI is available, so leave this input blank
* Enter a title in the appropriate input
* Start typing in the Journal input. When words are typed, a dropdown should appear with journal possibilities.
* Select a possibility from the dropdown
* You should now be able to proceed normally through the submission workflow