### PR TITLE
Bump shib env image versions to add new test users

### DIFF
--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - back
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-1
+    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-3
     container_name: fcrepo
     env_file: .env
     ports:
@@ -63,7 +63,7 @@ services:
      - source: idp_sealer
 
   ldap:
-    image: oapass/ldap:20180518
+    image: oapass/ldap:20180608
     container_name: ldap
     networks:
      - back


### PR DESCRIPTION
Adds new test users with appropriate grants:
* `nih-user`
* `ed-user`
* `usaid-user`

Remember to bring down the environment and pull new images. Only `fcrepo` and `ldap` images are updated

Verified locally