### PR TITLE
Add manuscript IDs to submission details page

### DIFF
--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -4,10 +4,17 @@ import { hash } from 'rsvp';
 export default Route.extend({
   model(params) {
     const sub = this.get('store').findRecord('submission', params.submission_id);
-    const files = this.get('store').query('file', { match: { submission: params.submission_id } });
+    const files = this.get('store').query('file', { term: { submission: params.submission_id } });
+    const deposits = this.get('store').query('deposit', { term: { submission: params.submission_id } });
+
+    const repoCopies = sub.then(s =>
+      this.get('store').query('RepositoryCopy', { term: { publication: s.get('publication.id') } }));
+
     return hash({
       sub,
-      files
+      files,
+      deposits,
+      repoCopies
     });
   },
 });

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,12 +1,12 @@
-{{#each (search-associated 'deposit' 'submission' record.id) as |deposit index|}}
+{{#each (search-associated 'repositoryCopy' 'publication' (get record 'publication.id')) as |repositoryCopy index|}}
   {{if index ', '}}
-  {{#if (get deposit "repositoryCopy.accessUrl")}}
-    <a href="{{get deposit "repositoryCopy.accessUrl"}}" target="_blank">
-      {{get deposit "repositoryCopy.externalIds"}}
+  {{#if repositoryCopy.accessUrl}}
+    <a href="{{repositoryCopy.accessUrl}}" target="_blank">
+      {{repositoryCopy.externalIds}}
     </a>
   {{else}}
-    {{#if (get deposit "repositoryCopy.externalIds")}}
-      {{get deposit "repositoryCopy.externalIds"}}
+    {{#if repositoryCopy.externalIds}}
+      {{repositoryCopy.externalIds}}
     {{else}}
     {{/if}}
   {{/if}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -114,7 +114,7 @@ table td {
                 <td>Deposits</td>
                 <td>
                   <ul>
-                    {{#each (search-associated 'deposit' 'submission' model.sub.id) as |deposit index|}}
+                    {{#each model.deposits as |deposit index|}}
                       <li>Deposit for {{await deposit.repository.name}} (<a href={{await deposit.repositoryCopy.accessUrl}}>{{await deposit.repositoryCopy.externalIds}}</a>)
                         <ul>
                           <li>Status: {{deposit.depositStatus}}</li>
@@ -125,17 +125,32 @@ table td {
                 </td>
               </tr>
             {{/if}}
-            <td class="text-nowrap">Submitter</td>
-            <td>
-              {{#if (eq model.sub.source  "other")}}
-                <i>This submission did not originate from PASS</i>
-              {{else}}
-                {{get (await model.sub.user) 'displayName'}}
-                {{#if (get (await model.sub.user) 'institutionalId')}}
-                  ({{get (await model.sub.user) 'institutionalId'}})
+            <tr>
+              <td class="text-nowrap">Manuscript IDs</td>
+              {{!-- Must display all repositoryCopy.externalIds --}}
+              <td>
+                <ul>
+                  {{#each model.repoCopies as |repoCopy index|}}
+                    {{#each repoCopy.externalIds as |externalId|}}
+                      <li>{{externalId}} - {{get repoCopy "repository.name"}}</li>
+                    {{/each}}
+                  {{/each}}
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td class="text-nowrap">Submitter</td>
+              <td>
+                {{#if (eq model.sub.source  "other")}}
+                  <i>This submission did not originate from PASS</i>
+                {{else}}
+                  {{get (await model.sub.user) 'displayName'}}
+                  {{#if (get (await model.sub.user) 'institutionalId')}}
+                    ({{get (await model.sub.user) 'institutionalId'}})
+                  {{/if}}
                 {{/if}}
-              {{/if}}
-            </td>
+              </td>
+            </tr>
             <tr>
               <td>Details</td>
               <td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -127,13 +127,18 @@ table td {
             {{/if}}
             <tr>
               <td class="text-nowrap">Manuscript IDs</td>
-              {{!-- Must display all repositoryCopy.externalIds --}}
               <td>
                 <ul>
                   {{#each model.repoCopies as |repoCopy index|}}
-                    {{#each repoCopy.externalIds as |externalId|}}
-                      <li>{{externalId}} - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})</li>
-                    {{/each}}
+                    {{#if repoCopy.externalIds}}
+                      <li>
+                        {{#if repoCopy.accessUrl}}
+                          <a href="{{repoCopy.accessUrl}}" target="_blank">{{repoCopy.externalIds}}</a> - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})
+                        {{else}}
+                          {{repoCopy.externalIds}} - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})
+                        {{/if}}
+                      </li>
+                    {{/if}}
                   {{/each}}
                 </ul>
               </td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -132,7 +132,7 @@ table td {
                 <ul>
                   {{#each model.repoCopies as |repoCopy index|}}
                     {{#each repoCopy.externalIds as |externalId|}}
-                      <li>{{externalId}} - {{get repoCopy "repository.name"}}</li>
+                      <li>{{externalId}} - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})</li>
                     {{/each}}
                   {{/each}}
                 </ul>


### PR DESCRIPTION
Resolves #471 
Resolves #489 

## Testing
* Do the normal Docker setup
* Login as `nih-user`
* Navigate to Submissions page to see table of all submissions for this user
* **One submission should show data in the Manuscript ID column**
* Click on the article title of that submission to see its details page
* **There should be a Manuscript ID row with a clickable link to the manuscript**