### PR TITLE
Add message for Manuscript ID fields when none is found

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -654,3 +654,8 @@ table td {
   border-color: #a4b7c1!important;;
   margin: 0px 5px;
   }
+
+.nodata-placeholder {
+  display: block;
+  font-style: italic;
+}

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,13 +1,19 @@
 {{#each (search-associated 'repositoryCopy' 'publication' (get record 'publication.id')) as |repositoryCopy index|}}
-  {{if index ', '}}
-  {{#if repositoryCopy.accessUrl}}
-    <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-      {{repositoryCopy.externalIds}}
-    </a>
-  {{else}}
-    {{#if repositoryCopy.externalIds}}
-      {{repositoryCopy.externalIds}}
+  {{#if repositoryCopy.externalIds}}
+    {{if index ', '}}
+    {{#if repositoryCopy.accessUrl}}
+      <a href="{{repositoryCopy.accessUrl}}" target="_blank">
+        {{repositoryCopy.externalIds}}
+      </a>
     {{else}}
+      {{#if repositoryCopy.externalIds}}
+        {{repositoryCopy.externalIds}}
+      {{else}}
+      {{/if}}
     {{/if}}
+  {{else}}
+    <span class="nodata-placeholder">Not available</span>
   {{/if}}
+{{else}}
+  <span class="nodata-placeholder">Not available</span>
 {{/each}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -128,7 +128,9 @@ table td {
             <tr>
               <td class="text-nowrap">Manuscript IDs</td>
               <td>
-                <ul>
+                
+                {{#if model.repoCopies}}
+                  <ul>
                   {{#each model.repoCopies as |repoCopy index|}}
                     {{#if repoCopy.externalIds}}
                       <li>
@@ -138,9 +140,14 @@ table td {
                           {{repoCopy.externalIds}} - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})
                         {{/if}}
                       </li>
+                    {{else}}
+                      <span class="nodata-placeholder">Manuscript IDs are not yet available</span>
                     {{/if}}
                   {{/each}}
-                </ul>
+                  </ul>
+                {{else}}
+                  <span class="nodata-placeholder">Manuscript IDs are not yet available</span>
+                {{/if}}
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Resolves #498 

## Testing
* Bring up `pass-ember/.docker/shib` env as normal
* Login to `nih-user`
* Navigate to Submissions page
  * **One submission should have no _Manuscript ID_ data, message should say as much**
  * Navigate to that submission's details page
    * **Manuscript ID field should have message saying none found or whatever**