### PR TITLE
Grants table sorts by awardStatus by default

### DIFF
--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -26,7 +26,10 @@ export default Route.extend({
     let promise = defer();
     const querySize = 500;
     const grantQuery = {
-      // sort: [{ awardNumber: { order: 'asc' } }], // TODO
+      sort: [
+        'awardStatus',
+        // 'projectName'
+      ],
       query: {
         bool: {
           should: [
@@ -35,7 +38,6 @@ export default Route.extend({
           ]
         }
       },
-
       size: querySize
     };
 


### PR DESCRIPTION
#497 
## Testing
* Start up dev environment as normal
  * _Note that this requires the updated `ember-fedora-adapter`, so if you have not recently rebuilt your `ember` container, you must do so in order for this dependency to be picked up_
* Login to `nih-user`
* Navigate to Grants page
  * **The two _active_ grants should be at the top of the table, followed by the rest of the grants - all _terminated_**. Table sort behaves like before