### PR TITLE
Install ember-lodash to fix dependency problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3033,6 +3033,196 @@
         "@glimmer/syntax": "0.27.0"
       }
     },
+    "ember-basic-dropdown": {
+      "version": "github:cameronblandford/ember-basic-dropdown#f25bb86bea9c73da40be33ce3ffe59c3c1b9d97a",
+      "requires": {
+        "ember-cli-babel": "6.14.1",
+        "ember-cli-htmlbars": "2.0.3",
+        "ember-maybe-in-element": "0.1.3"
+      },
+      "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+          "requires": {
+            "ensure-posix-path": "1.0.2"
+          }
+        },
+        "babel-preset-env": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+          "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "browserslist": "3.2.8",
+            "invariant": "2.2.2",
+            "semver": "5.5.0"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.4.3",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.4.3.tgz",
+          "integrity": "sha1-BuOZKY1BcAzcENZ1sdgIqJ72stA=",
+          "requires": {
+            "babel-core": "6.26.0",
+            "broccoli-funnel": "2.0.1",
+            "broccoli-merge-trees": "2.0.0",
+            "broccoli-persistent-filter": "1.4.3",
+            "clone": "2.1.1",
+            "hash-for-dep": "1.2.3",
+            "heimdalljs-logger": "0.1.9",
+            "json-stable-stringify": "1.0.1",
+            "rsvp": "4.8.2",
+            "workerpool": "2.3.0"
+          }
+        },
+        "broccoli-debug": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
+          "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "fs-tree-diff": "0.5.7",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "symlink-or-copy": "1.2.0",
+            "tree-sync": "1.2.2"
+          },
+          "dependencies": {
+            "symlink-or-copy": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+              "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.9",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.7",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.3",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "merge-trees": "1.0.1"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "requires": {
+            "caniuse-lite": "1.0.30000851",
+            "electron-to-chromium": "1.3.48"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000851",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000851.tgz",
+          "integrity": "sha512-Y1ecA1cL9wg0vni8t33nBw/poX8ypm+2c3fbwAESj8cm4ufK9CBFQ1+nUK8Dp5dtFo5Fc3JzkI5DKmQbuIo6hQ=="
+        },
+        "electron-to-chromium": {
+          "version": "1.3.48",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
+          "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
+        },
+        "ember-cli-babel": {
+          "version": "6.14.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.14.1.tgz",
+          "integrity": "sha512-dnbc3fwwQphjRoQCflS0zpJHjJ54HDzcCv0FFDxUfMSxLFU/ccC/DRRtuB50WUY/n1Y6zgd66ezTXB+G82KBnw==",
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "0.1.11",
+            "babel-plugin-ember-modules-api-polyfill": "2.3.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-polyfill": "6.26.0",
+            "babel-preset-env": "1.7.0",
+            "broccoli-babel-transpiler": "6.4.3",
+            "broccoli-debug": "0.6.4",
+            "broccoli-funnel": "2.0.1",
+            "broccoli-source": "1.1.0",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "2.1.2",
+            "semver": "5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
+          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
+          "requires": {
+            "resolve": "1.5.0",
+            "semver": "5.5.0"
+          }
+        },
+        "hash-for-dep": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+          "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.3.1",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "resolve": "1.5.0"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.2.tgz",
+          "integrity": "sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg=="
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
+      }
+    },
     "ember-cli": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.1.3.tgz",
@@ -4526,7 +4716,7 @@
       }
     },
     "ember-fedora-adapter": {
-      "version": "git+https://github.com/OA-PASS/ember-fedora-adapter.git#c1afd3858e82e8d3b9fc99fb4463cbb48e88d0a7",
+      "version": "git+https://github.com/OA-PASS/ember-fedora-adapter.git#68bfeede523cb779c1546925f397ca341ffcb6a6",
       "requires": {
         "ember-cli-babel": "6.11.0"
       }
@@ -4817,198 +5007,6 @@
         "ember-concurrency": "0.8.19",
         "ember-text-measurer": "0.4.1",
         "ember-truth-helpers": "2.0.0"
-      },
-      "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
-          "requires": {
-            "ensure-posix-path": "1.0.2"
-          }
-        },
-        "babel-preset-env": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-          "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-          "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-async-to-generator": "6.24.1",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-exponentiation-operator": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.26.0",
-            "browserslist": "3.2.8",
-            "invariant": "2.2.2",
-            "semver": "5.5.0"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "6.4.3",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.4.3.tgz",
-          "integrity": "sha1-BuOZKY1BcAzcENZ1sdgIqJ72stA=",
-          "requires": {
-            "babel-core": "6.26.0",
-            "broccoli-funnel": "2.0.1",
-            "broccoli-merge-trees": "2.0.0",
-            "broccoli-persistent-filter": "1.4.3",
-            "clone": "2.1.1",
-            "hash-for-dep": "1.2.3",
-            "heimdalljs-logger": "0.1.9",
-            "json-stable-stringify": "1.0.1",
-            "rsvp": "4.8.2",
-            "workerpool": "2.3.0"
-          }
-        },
-        "broccoli-debug": {
-          "version": "0.6.4",
-          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
-          "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "symlink-or-copy": "1.2.0",
-            "tree-sync": "1.2.2"
-          },
-          "dependencies": {
-            "symlink-or-copy": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
-              "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
-            }
-          }
-        },
-        "broccoli-funnel": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "requires": {
-            "array-equal": "1.0.0",
-            "blank-object": "1.0.2",
-            "broccoli-plugin": "1.3.0",
-            "debug": "2.6.9",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.7",
-            "heimdalljs": "0.2.5",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "path-posix": "1.0.0",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.3",
-            "walk-sync": "0.3.2"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
-          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
-        },
-        "browserslist": {
-          "version": "3.2.8",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-          "requires": {
-            "caniuse-lite": "1.0.30000851",
-            "electron-to-chromium": "1.3.48"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000851",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000851.tgz",
-          "integrity": "sha512-Y1ecA1cL9wg0vni8t33nBw/poX8ypm+2c3fbwAESj8cm4ufK9CBFQ1+nUK8Dp5dtFo5Fc3JzkI5DKmQbuIo6hQ=="
-        },
-        "electron-to-chromium": {
-          "version": "1.3.48",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
-          "integrity": "sha1-07DYWTgUBE4JLs4hCPw6ya6kuQA="
-        },
-        "ember-basic-dropdown": {
-          "version": "github:cameronblandford/ember-basic-dropdown#f25bb86bea9c73da40be33ce3ffe59c3c1b9d97a",
-          "requires": {
-            "ember-cli-babel": "6.14.1",
-            "ember-cli-htmlbars": "2.0.3",
-            "ember-maybe-in-element": "0.1.3"
-          },
-          "dependencies": {
-            "ember-cli-babel": {
-              "version": "6.14.1",
-              "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.14.1.tgz",
-              "integrity": "sha512-dnbc3fwwQphjRoQCflS0zpJHjJ54HDzcCv0FFDxUfMSxLFU/ccC/DRRtuB50WUY/n1Y6zgd66ezTXB+G82KBnw==",
-              "requires": {
-                "amd-name-resolver": "1.2.0",
-                "babel-plugin-debug-macros": "0.1.11",
-                "babel-plugin-ember-modules-api-polyfill": "2.3.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-polyfill": "6.26.0",
-                "babel-preset-env": "1.7.0",
-                "broccoli-babel-transpiler": "6.4.3",
-                "broccoli-debug": "0.6.4",
-                "broccoli-funnel": "2.0.1",
-                "broccoli-source": "1.1.0",
-                "clone": "2.1.1",
-                "ember-cli-version-checker": "2.1.2",
-                "semver": "5.5.0"
-              }
-            }
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
-          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
-          "requires": {
-            "resolve": "1.5.0",
-            "semver": "5.5.0"
-          }
-        },
-        "hash-for-dep": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
-          "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "0.3.1",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "resolve": "1.5.0"
-          }
-        },
-        "rsvp": {
-          "version": "4.8.2",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.2.tgz",
-          "integrity": "sha512-8CU1Wjxvzt6bt8zln+hCjyieneU9s0LRW+lPRsjyVCY8Vm1kTbK7btBIrCGg6yY9U4undLDm/b1hKEEi1tLypg=="
-        },
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        }
       }
     },
     "ember-promise-helpers": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "coveralls": "^3.0.1",
     "ember-cli-code-coverage": "^0.4.2",
+    "ember-lodash": "^4.18.0",
     "qunit-dom": "^0.6.2",
     "toastr": "^2.1.4"
   },


### PR DESCRIPTION
## Overview 
The deployed files created by `ember build --production` throw an error
about missing lodash.  This is an attempt to fix that by doing an `ember install ember-lodash`, and committing the updated dependencies.

## To test:

I tested a static build via `ember build --production`, with files served up by nginx.  The error went away when built using this PR
  * Make sure this did not break anything unintended.

## Note:  
 * `npm` (or whatever package manager is used underneath) was unkind to `package-lock.json`, and re-arranged many lines it didn't need to.  This makes it difficult to reason about what `ember install ember-lodash` did.