### PR TITLE
Fix bug in Grants step that happens in Firefox

### DIFF
--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -26,8 +26,14 @@ export default Component.extend({
     back() {
       this.sendAction('back');
     },
-    addGrant(grant) {
-      if (event.target.value) {
+    addGrant(grant, event) {
+      if (grant) {
+        const submission = this.get('model.newSubmission');
+        submission.get('grants').pushObject(grant);
+        this.get('addedGrants').push(grant);
+        this.set('maxStep', 2);
+        submission.set('metadata', '[]');
+      } else if (event && event.target.value) {
         this.get('store').findRecord('grant', event.target.value).then((g) => {
           const submission = this.get('model.newSubmission');
           submission.get('grants').pushObject(g);
@@ -35,12 +41,6 @@ export default Component.extend({
           this.set('maxStep', 2);
           submission.set('metadata', '[]');
         });
-      } else {
-        const submission = this.get('model.newSubmission');
-        submission.get('grants').pushObject(grant);
-        this.get('addedGrants').push(grant);
-        this.set('maxStep', 2);
-        submission.set('metadata', '[]');
       }
     },
     removeGrant(grant) {


### PR DESCRIPTION
#530 

Also fixes an undocumented bug where creating a submission directly from a grant did not pre-populate the submission with the grant in Firefox

## Testing
Follow steps detailed in the related ticket, behavior should be verified in Firefox and Chrome, and whatever other browsers