### PR TITLE
Change default table page size to 50

### DIFF
--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -10,8 +10,8 @@ export default Controller.extend({
   messageSubject: '',
   messageText: '',
 
-  tablePageSize: 5,
-  tablePageSizeValues: [5, 10, 25],
+  tablePageSize: 50,
+  tablePageSizeValues: [10, 25, 50],
 
   // Columns displayed depend on the user role
   columns: computed('currentUser', {

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -10,6 +10,9 @@ export default Controller.extend({
   messageSubject: '',
   messageText: '',
 
+  tablePageSize: 50,
+  tablePageSizeValues: [10, 25, 50],
+
   // Columns displayed depend on the user role
   columns: computed('currentUser', {
     get() {

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -20,6 +20,8 @@
       filteringIgnoreCase=true
       multipleColumnsSorting=false
       authorSelected='authorclick'
+      pageSize=tablePageSize
+      pageSizeValues=tablePageSizeValues
     }}
     </div>
   </div>


### PR DESCRIPTION
#518 

Grants and Submissions table pages have been changed to show 50 entries by default. Possible options now 10, 25, 50. 