### PR TITLE
Revert font back to gentona-light

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -365,7 +365,7 @@ $primary-color: #418FDE;
 $danger-color: #f86c6b;
 $navbar-color: #005EB8;
 body {
-  font-family:  gentona-medium,sans-serif!important;
+  font-family:  gentona-light,sans-serif!important;
   font-size: 1em !important;
   color:#2C2C33 !important;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
#516 
Note that this font and the previous font are both compliant with JHU branding guidelines, which doesn't have much to say about font sizes. http://brand.jhu.edu/typography/