### PR TITLE
Search madness

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -153,15 +153,20 @@ export default Component.extend({
           publication.set('volume', doiInfo.volume);
           publication.set('abstract', doiInfo.abstract);
 
-          // const journal = this.get('model.journals').findBy(
-          //   'journalName',
-          //   doiInfo['container-title'].trim(),
-          // );
           const desiredName = doiInfo['container-title'].trim();
           this.get('store').query('journal', {
             query: { match: { journalName: desiredName } }
           }).then((journals) => {
-            debugger
+            /*
+             * TODO this hack is done because the query returns more matches than expected
+             * We should modify the indexer to index 'journal.journalName' as keyword, instead
+             * of text. Then queries will match on the full journalName ONLY, without the
+             * fuzziness.
+             *
+             * Here, we get the first journal object that has exactly the same journalName
+             * that we were originally looking for.
+             */
+            let journal = journals.findBy('journalName', desiredName);
             if (!journal) {
               const newJournal = this.get('store').createRecord('journal', {
                 journalName: doiInfo['container-title'].trim(),

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -153,19 +153,25 @@ export default Component.extend({
           publication.set('volume', doiInfo.volume);
           publication.set('abstract', doiInfo.abstract);
 
-          const journal = this.get('model.journals').findBy(
-            'journalName',
-            doiInfo['container-title'].trim(),
-          );
-          if (!journal) {
-            const newJournal = this.get('store').createRecord('journal', {
-              journalName: doiInfo['container-title'].trim(),
-              nlmta: 'UNKNOWN',
-            });
-            newJournal.save().then(j => publication.set('journal', j));
-          } else {
-            publication.set('journal', journal);
-          }
+          // const journal = this.get('model.journals').findBy(
+          //   'journalName',
+          //   doiInfo['container-title'].trim(),
+          // );
+          const desiredName = doiInfo['container-title'].trim();
+          this.get('store').query('journal', {
+            query: { match: { journalName: desiredName } }
+          }).then((journals) => {
+            debugger
+            if (!journal) {
+              const newJournal = this.get('store').createRecord('journal', {
+                journalName: doiInfo['container-title'].trim(),
+                nlmta: 'UNKNOWN',
+              });
+              newJournal.save().then(j => publication.set('journal', j));
+            } else {
+              publication.set('journal', journal);
+            }
+          });
         });
       }
     },

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -156,12 +156,16 @@ export default Component.extend({
           const desiredName = doiInfo['container-title'].trim();
           const desiredIssn = Array.isArray(doiInfo['ISSN']) ? doiInfo['ISSN'][0] : // eslint-disable-line
             (doiInfo['ISSN'] ? doiInfo['ISSN'] : ''); // eslint-disable-line
+
           let query = {
             bool: {
               should: [{ match: { journalName: desiredName } }],
-              must: { term: { issns: desiredIssn } }
+              // must: { term: { issns: desiredIssn } }
             }
           };
+          if (desiredIssn) {
+            query.bool.must = { term: { issns: desiredIssn } };
+          }
           // Must match ISSN, optionally match journalName
           this.get('store').query('journal', { query }).then((journals) => {
             let journal = journals.get('length') > 0 ? journals.objectAt(0) : false;
@@ -169,6 +173,7 @@ export default Component.extend({
               console.log(` >>> Journal not found [${desiredIssn}] ${desiredName}`);
               const newJournal = this.get('store').createRecord('journal', {
                 journalName: doiInfo['container-title'].trim(),
+                issns: doiInfo.ISSN,
                 nlmta: 'UNKNOWN',
               });
               newJournal.save().then(j => publication.set('journal', j));

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -42,7 +42,7 @@ export default Route.extend({
     });
 
     const policies = this.loadObjects('policy', 0, 500);
-    const journals = this.loadObjects('journal', 0, 500);
+    // const journals = this.loadObjects('journal', 0, 500);
 
     // let publication = null;
     if (params.submission) {
@@ -55,7 +55,7 @@ export default Route.extend({
           publication,
           grants,
           policies,
-          journals,
+          // journals,
           funders,
           preLoadedGrant
         });
@@ -69,7 +69,7 @@ export default Route.extend({
       publication,
       grants,
       policies,
-      journals,
+      // journals,
       funders,
       preLoadedGrant
     });

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -42,9 +42,7 @@ export default Route.extend({
     });
 
     const policies = this.loadObjects('policy', 0, 500);
-    // const journals = this.loadObjects('journal', 0, 500);
 
-    // let publication = null;
     if (params.submission) {
       return this.get('store').findRecord('submission', params.submission).then((sub) => {
         newSubmission = this.get('store').findRecord('submission', params.submission);
@@ -55,12 +53,10 @@ export default Route.extend({
           publication,
           grants,
           policies,
-          // journals,
           funders,
           preLoadedGrant
         });
       });
-      // publication = newSubmission.get('publication');
     }
     newSubmission = this.get('store').createRecord('submission');
     const h = Ember.RSVP.hash({

--- a/app/services/autocomplete.js
+++ b/app/services/autocomplete.js
@@ -11,7 +11,7 @@ import ENV from 'pass-ember/config/environment';
  * TODO do we need to pass authentication headers?
  */
 export default Service.extend({
-  suggestSize: 10,
+  suggestSize: 100,
   ajax: Ember.inject.service(),
   base: Ember.computed(() => ENV.fedora.elasticsearch),
   es_field_suffix: '_suggest',

--- a/app/services/autocomplete.js
+++ b/app/services/autocomplete.js
@@ -75,7 +75,8 @@ export default Service.extend({
 
     return this.get('ajax').post(this.get('base'), {
       data,
-      headers: this._headers()
+      headers: this._headers(),
+      xhrFields: { withCredentials: true }
     }).then(res => this._adaptResults(res, type));
   },
 


### PR DESCRIPTION
#521 
* Autocomplete now shows up to 100 suggestions as user types in the journal picker.
* When valid DOI is input, the journal search uses `Store.query` by requiring ISSN match and optional match on journal name. This prevents the ember app from creating placeholder Journal objects in Fedora when it is not supposed to.
* Data loading for `submissions/new` cleaned up a bit, now that we don't have to pre-load journals.