### PR TITLE
Consolidate submission details

### DIFF
--- a/app/components/repocopy-display.js
+++ b/app/components/repocopy-display.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/repocopy-status.js
+++ b/app/components/repocopy-status.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/submission-repo-details.js
+++ b/app/components/submission-repo-details.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+});

--- a/app/components/submission-repo-details.js
+++ b/app/components/submission-repo-details.js
@@ -1,4 +1,46 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  store: Ember.inject.service(),
+
+  status: Ember.computed('deposit', 'repo', 'repoCopy', function () {
+    const deposit = this.get('deposit');
+    const repo = this.get('repo');
+    const repoCopy = this.get('repoCopy');
+
+    if (repoCopy) {
+      const cs = repoCopy.get('copyStatus');
+      if (cs === 'complete') {
+        return 'Complete';
+      } else if (cs === 'stalled') {
+        return 'Stalled';
+      }
+    }
+
+    return 'Submitted';
+  }),
+
+  /**
+   * Return a tooltip based on the current status.
+   */
+  tooltip: Ember.computed('status', function () {
+    switch (this.get('status')) {
+      case 'Complete':
+        return 'Submission was accepted and processed by the repository. ID(s) have been assigned to the submitted manuscript.';
+      case 'Stalled':
+        return 'The repository has found a problem with your submission that has caused progress to stall. This may require direct interaction with the repository to re-initiate the process. Please check the repository website for more details.';
+      case 'Submitted':
+        return 'Your submission has been sent to the repository or is in queue to be sent.';
+      default:
+        return '';
+    }
+  }),
+
+  /**
+   * Is this an external repository - is this not tracked by PASS
+   * (e.g. US Dept of Education submission system ERIC)
+   */
+  isExternalRepo: Ember.computed('repo', function () {
+    return this.get('repo.url') === 'https://eric.ed.gov/';
+  })
 });

--- a/app/components/submission-status-cell.js
+++ b/app/components/submission-status-cell.js
@@ -2,19 +2,28 @@ import Component from '@ember/component';
 
 export default Component.extend({
   store: Ember.inject.service(),
-  repoCopies: Ember.computed('record', function () {
-    return this.get('store').query('submission', {
+  repoCopies: null,
+
+  init() {
+    this._super(...arguments);
+    // Query to get all 'repositoryCopy' objects that are associated with the 'publication'
+    // in this record's 'submission'
+    this.get('store').query('repositoryCopy', {
       size: 500,
       from: 0,
       query: {
         term: { publication: this.get('record.publication.id') }
       }
-    });
-  }),
+    }).then(rc => this.set('repoCopies', rc));
+  },
   // For specs: https://github.com/OA-PASS/pass-ember/issues/568
   status: Ember.computed('record', 'repoCopies', function () {
     const submission = this.get('record');
     const repoCopies = this.get('repoCopies');
+
+    if (!repoCopies) { // this will be NULL/UNDEFINED until search returns
+      return '';
+    }
 
     if (repoCopies.get('length') === 0) {
       const source = submission.get('source');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -13,6 +13,17 @@ export default Controller.extend({
     }
     return false;
   }),
+  /**
+   * Ugly way to generate date for the template to use.
+   * {
+   *    'repository-id': {
+   *      repo: { }, // repository obj
+   *      deposit: {}, // related deposit, if exists
+   *      repositoryCopy: {} // related repoCopy if exists
+   *    }
+   * }
+   * This map is then turned into an array for use in the template
+   */
   repoMap: Ember.computed('model.deposits', 'model.repoCopies', function () {
     let hasStuff = false;
     const repos = this.get('model.repos');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -13,6 +13,54 @@ export default Controller.extend({
     }
     return false;
   }),
+  repoMap: Ember.computed('model.deposits', 'model.repoCopies', function () {
+    let hasStuff = false;
+    const repos = this.get('model.repos');
+    const deps = this.get('model.deposits');
+    const repoCopies = this.get('model.repoCopies');
+
+    let map = {};
+    repos.forEach(r => map[r.get('id')] = { repo: r }); // eslint-disable-line
+
+    if (deps) {
+      deps.forEach((deposit) => {
+        hasStuff = true;
+        const repo = deposit.get('repository');
+        if (!map.hasOwnProperty(repo.get('id'))) {
+          map[repo.get('id')] = {
+            repo,
+            deposit
+          };
+        } else {
+          map[repo.get('id')] = Object.assign(map[repo.get('id')], {
+            deposit,
+            repositoryCopy: deposit.get('repositoryCopy')
+          });
+        }
+      });
+    }
+    if (repoCopies) {
+      hasStuff = true;
+      repoCopies.forEach((rc) => {
+        const repo = rc.get('repository');
+        if (!map.hasOwnProperty(repo.get('id'))) {
+          map[repo.get('id')] = {
+            repo,
+            repositoryCopy: rc
+          };
+        } else {
+          map[repo.get('id')] = Object.assign(map[repo.get('id')], { repositoryCopy: rc });
+        }
+      });
+    }
+    if (hasStuff) {
+      let results = [];
+      Object.keys(map).forEach(k => results.push(map[k]));
+      return results;
+    }
+
+    return null;
+  }),
   metadataBlobNoKeys: Ember.computed('model.sub.metadata', function () { // eslint-disable-line
     let metadataBlobNoKeys = [];
     JSON.parse(this.get('model.sub.metadata')).forEach((ele) => {

--- a/app/index.html
+++ b/app/index.html
@@ -23,7 +23,11 @@
       }
       @font-face {
         font-family: "quadon-black";
-        src:url("{{rootURL}}/Quadon-Medium.ttf");
+        src:url("{{rootURL}}fonts/Quadon-Medium.ttf");
+      }
+      @font-face {
+        font-family: "quadon-regular";
+        src:url("{{rootURL}}fonts/Quadon-Regular.ttf");
       }
     </style>
     {{content-for "head-footer"}}

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -9,7 +9,7 @@ export default Route.extend({
     const deposits = this.get('store').query('deposit', { term: { submission: params.submission_id }, size: querySize });
 
     const repoCopies = sub.then(s =>
-      this.get('store').query('RepositoryCopy', { term: { publication: s.get('publication.id') }, size: querySize }));
+      this.get('store').query('repositoryCopy', { term: { publication: s.get('publication.id') }, size: querySize }));
     const repos = sub.then(s => s.get('repositories'));
 
     return hash({

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -10,12 +10,14 @@ export default Route.extend({
 
     const repoCopies = sub.then(s =>
       this.get('store').query('RepositoryCopy', { term: { publication: s.get('publication.id') }, size: querySize }));
+    const repos = sub.then(s => s.get('repositories'));
 
     return hash({
       sub,
       files,
       deposits,
-      repoCopies
+      repoCopies,
+      repos
     });
   },
 });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -373,7 +373,7 @@ body {
   -o-font-smoothing: antialiased;
 }
 h1, h2, h3, h4, h5 {
-  font-family:  quadon-black,serif!important;
+  font-family:  quadon-regular,serif!important;
 }
 h1 {
   font-size: 1.7rem!important;

--- a/app/templates/components/repocopy-display.hbs
+++ b/app/templates/components/repocopy-display.hbs
@@ -1,0 +1,24 @@
+<style>
+  .inline { display: inline; }
+</style>
+{{#if repoCopy.externalIds}}
+  <ul class="">
+  {{#if repoCopy.accessUrl}}
+    {{#each repoCopy.externalIds as |externalIds|}}
+    <li>
+      <a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a> 
+      {{repocopy-status status=repoCopy.copyStatus class="inline"}}
+    </li>
+    {{/each}}
+  {{else}}
+    <ul class="repoid-cell">
+    {{#each repoCopy.externalIds as |externalIds|}}
+      <li>{{externalIds}} {{repocopy-status status=repoCopy.copyStatus class="inline"}}</li>
+    {{/each}}
+    </ul>
+  {{/if}}
+  </ul>
+{{else}}
+  <strong>{{repoCopy.copyStatus}}</strong> 
+  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span>
+{{/if}}

--- a/app/templates/components/repocopy-display.hbs
+++ b/app/templates/components/repocopy-display.hbs
@@ -1,20 +1,20 @@
-<style>
-  ul { padding-left: 16px; }
-</style>
-{{#if repoCopy.externalIds}}
-  <ul class="">
-  {{#if repoCopy.accessUrl}}
-    {{#each repoCopy.externalIds as |externalIds|}}
-    <li><a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a></li>
-    {{/each}}
-  {{else}}
-    <ul class="">
-    {{#each repoCopy.externalIds as |externalIds|}}
-      <li>{{externalIds}}</li>
-    {{/each}}
+<div class="row">
+  <strong class="col-5 px-0">Manuscript ID(s):</strong>
+  {{#if repoCopy.externalIds}}
+    <ul class="col list-unstyled">
+    {{#if repoCopy.accessUrl}}
+      {{#each repoCopy.externalIds as |externalIds|}}
+      <li><a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a></li>
+      {{/each}}
+    {{else}}
+      <ul class="col list-unstyled">
+      {{#each repoCopy.externalIds as |externalIds|}}
+        <li>{{externalIds}}</li>
+      {{/each}}
+      </ul>
+    {{/if}}
     </ul>
+  {{else}}
+    <span class="col nodata-placeholder">Manuscript ID(s) are not yet assigned by the repository.</span>
   {{/if}}
-  </ul>
-{{else}}
-  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span>
-{{/if}}
+</div>

--- a/app/templates/components/repocopy-display.hbs
+++ b/app/templates/components/repocopy-display.hbs
@@ -11,7 +11,7 @@
     </li>
     {{/each}}
   {{else}}
-    <ul class="repoid-cell">
+    <ul class="">
     {{#each repoCopy.externalIds as |externalIds|}}
       <li>{{externalIds}} {{repocopy-status status=repoCopy.copyStatus class="inline"}}</li>
     {{/each}}
@@ -19,6 +19,6 @@
   {{/if}}
   </ul>
 {{else}}
-  <strong>{{repoCopy.copyStatus}}</strong> 
-  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span>
+  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span> 
+  {{repocopy-status status=repoCopy.copyStatus class="inline"}}
 {{/if}}

--- a/app/templates/components/repocopy-display.hbs
+++ b/app/templates/components/repocopy-display.hbs
@@ -1,24 +1,20 @@
 <style>
-  .inline { display: inline; }
+  ul { padding-left: 16px; }
 </style>
 {{#if repoCopy.externalIds}}
   <ul class="">
   {{#if repoCopy.accessUrl}}
     {{#each repoCopy.externalIds as |externalIds|}}
-    <li>
-      <a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a> 
-      {{repocopy-status status=repoCopy.copyStatus class="inline"}}
-    </li>
+    <li><a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a></li>
     {{/each}}
   {{else}}
     <ul class="">
     {{#each repoCopy.externalIds as |externalIds|}}
-      <li>{{externalIds}} {{repocopy-status status=repoCopy.copyStatus class="inline"}}</li>
+      <li>{{externalIds}}</li>
     {{/each}}
     </ul>
   {{/if}}
   </ul>
 {{else}}
-  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span> 
-  {{repocopy-status status=repoCopy.copyStatus class="inline"}}
+  <span class="nodata-placeholder">Manuscript ID(s) are not yet available</span>
 {{/if}}

--- a/app/templates/components/repocopy-status.hbs
+++ b/app/templates/components/repocopy-status.hbs
@@ -1,0 +1,2 @@
+<strong>({{status}})</strong>
+{{!-- TODO here we can color code RepositoryCopy.copyStatus, add tooltips, etc --}}

--- a/app/templates/components/repocopy-status.hbs
+++ b/app/templates/components/repocopy-status.hbs
@@ -1,2 +1,4 @@
+{{#if status}}
 <strong>({{status}})</strong>
+{{/if}}
 {{!-- TODO here we can color code RepositoryCopy.copyStatus, add tooltips, etc --}}

--- a/app/templates/components/submission-repo-details.hbs
+++ b/app/templates/components/submission-repo-details.hbs
@@ -1,5 +1,6 @@
 <style>
   .sub-status { padding-left:23px; }
+  .sub-status .card-title { font-size: 1.2em; }
   .fas {
     display: inline;
     font-size: 0.8em;
@@ -9,26 +10,37 @@
   .stalled>.fa-circle {color: #f86c6b;}
 </style>
 <li>
-  <p class="card-title">
-    <strong>{{repo.name}} ({{#if repo.url}}<a href={{repo.url}}>{{repo.url}}</a>{{/if}})</strong>
-  </p>
-  <p class="card-text">
-    <div class="sub-status">
-      {{#if isExternalRepo}}
-        <span>Deposit into {{repo.name}} was prompted.</span>
-      {{else}}
-        {{#if tooltip}}
-          <span class="{{status}}" tooltip-position="left" tooltip="{{tooltip}}">
-            <i class="fas fa-info-circle"></i> {{status}}
-          </span>
+  <div class="card float-left col-5 mr-3 mb-0">
+    <div class="card-body sub-status">
+      <div class="row card-title">
+        {{#if repo.url}}
+          <a href={{repo.url}} target="_blank">{{repo.name}}</a>
         {{else}}
-          <span class="{{status}}">
-            <i class="fas fa-circle"></i> {{status}}
-          </span>
+          {{repo.name}}
         {{/if}}
-        
+      </div>
+      <p class="card-text">
+        <div class="row">
+          <strong class="col-5 px-0">Status: </strong>
+          {{#if isExternalRepo}}
+            <span class="col">Deposit into {{repo.name}} was prompted.</span>
+          {{else}}
+            <div class="col">
+              {{#if tooltip}}
+                <span class="{{status}}" tooltip-position="left" tooltip="{{tooltip}}">
+                  <i class="fas fa-info-circle"></i> {{status}}
+                </span>
+              {{else}}
+                <span class="{{status}}">
+                  <i class="fas fa-circle"></i> {{status}}
+                </span>
+              {{/if}}
+            </div>
+          {{/if}}
+        </div>
+        <hr class="my-2">
         {{repocopy-display repoCopy=repoCopy}}
-      {{/if}}
+      </p>
     </div>
-  </p>
+  </div>
 </li>

--- a/app/templates/components/submission-repo-details.hbs
+++ b/app/templates/components/submission-repo-details.hbs
@@ -17,9 +17,16 @@
       {{#if isExternalRepo}}
         <span>Deposit into {{repo.name}} was prompted.</span>
       {{else}}
-        <span class="{{status}}" {{#if tooltip}}tooltip-position="left" tooltip="{{tooltip}}{{/if}}">
-          {{#if tooltip}}<i class="fas fa-info-circle"></i> {{/if}}{{status}}
-        </span>
+        {{#if tooltip}}
+          <span class="{{status}}" tooltip-position="left" tooltip="{{tooltip}}">
+            <i class="fas fa-info-circle"></i> {{status}}
+          </span>
+        {{else}}
+          <span class="{{status}}">
+            <i class="fas fa-circle"></i> {{status}}
+          </span>
+        {{/if}}
+        
         {{repocopy-display repoCopy=repoCopy}}
       {{/if}}
     </div>

--- a/app/templates/components/submission-repo-details.hbs
+++ b/app/templates/components/submission-repo-details.hbs
@@ -1,0 +1,41 @@
+<style>
+  .sub-status { padding-left:23px; }
+  .fas {
+    display: inline;
+    font-size: 0.8em;
+    opacity: 0.9;
+  }
+  .Complete>.fa-circle, .Complete .fa-info-circle {color: #4dbd74;}
+  .stalled>.fa-circle {color: #f86c6b;}
+</style>
+<li>
+  <p class="card-title">
+    <strong>{{repo.name}} ({{#if repo.url}}<a href={{repo.url}}>{{repo.url}}</a>{{/if}})</strong>
+  </p>
+  <p class="card-text">
+    <div class="sub-status">
+      {{#if repoCopy}}
+        {{#if (eq repoCopy.copyStatus "complete")}}
+          <span class="Complete" tooltip-position="left" tooltip="Submission to this repository was accepted and processed that the repository. ID(s) have been assigned to the submitted manuscript">
+            <i class="fas fa-info-circle"></i> Complete
+          </span>
+          {{repocopy-display repoCopy=repoCopy}}
+        {{/if}}
+        {{#if (eq repoCopy.copyStatus "stalled")}}
+          <span class="stalled" tooltip-position="left" tooltip="">
+            <i class="fas fa-info-circle"></i> Stalled
+          </span>
+        {{/if}}
+      {{else}}
+        {{#if (eq repo.url "https://eric.ed.gov/")}}
+          <span>Deposit into {{repo.name}} was prompted.</span>
+        {{else}}
+          <span class="" tooltip-position="left" tooltip="PASS has received your submission. Your submission has been sent to the target repositories or is in queue to be sent">
+            <i class="fas fa-info-circle"></i> Submitted
+          </span>
+          {{repocopy-display repoCopy=repoCopy}}
+        {{/if}}
+      {{/if}}
+    </div>
+  </p>
+</li>

--- a/app/templates/components/submission-repo-details.hbs
+++ b/app/templates/components/submission-repo-details.hbs
@@ -14,27 +14,13 @@
   </p>
   <p class="card-text">
     <div class="sub-status">
-      {{#if repoCopy}}
-        {{#if (eq repoCopy.copyStatus "complete")}}
-          <span class="Complete" tooltip-position="left" tooltip="Submission to this repository was accepted and processed that the repository. ID(s) have been assigned to the submitted manuscript">
-            <i class="fas fa-info-circle"></i> Complete
-          </span>
-          {{repocopy-display repoCopy=repoCopy}}
-        {{/if}}
-        {{#if (eq repoCopy.copyStatus "stalled")}}
-          <span class="stalled" tooltip-position="left" tooltip="">
-            <i class="fas fa-info-circle"></i> Stalled
-          </span>
-        {{/if}}
+      {{#if isExternalRepo}}
+        <span>Deposit into {{repo.name}} was prompted.</span>
       {{else}}
-        {{#if (eq repo.url "https://eric.ed.gov/")}}
-          <span>Deposit into {{repo.name}} was prompted.</span>
-        {{else}}
-          <span class="" tooltip-position="left" tooltip="PASS has received your submission. Your submission has been sent to the target repositories or is in queue to be sent">
-            <i class="fas fa-info-circle"></i> Submitted
-          </span>
-          {{repocopy-display repoCopy=repoCopy}}
-        {{/if}}
+        <span class="{{status}}" {{#if tooltip}}tooltip-position="left" tooltip="{{tooltip}}{{/if}}">
+          {{#if tooltip}}<i class="fas fa-info-circle"></i> {{/if}}{{status}}
+        </span>
+        {{repocopy-display repoCopy=repoCopy}}
       {{/if}}
     </div>
   </p>

--- a/app/templates/components/submission-status-cell.hbs
+++ b/app/templates/components/submission-status-cell.hbs
@@ -37,7 +37,7 @@
       </span>
     {{/if}}
     {{#if (eq status "See details")}}
-      {{#link-to "submissions.detal" record.id}}
+      {{#link-to "submissions.detail" record.id}}
         <i class="fas fa-circle"></i> {{status}}
       {{/link-to}}
     {{/if}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -94,7 +94,7 @@
                 </ul>
               </td>
             </tr>
-            <tr>
+            {{!-- <tr>
               <td class="text-nowrap">Repositories</td>
               <td>
                 <ul class="list-unstyled mb-0">
@@ -103,7 +103,7 @@
                   {{/each}}
                 </ul>
               </td>
-            </tr>
+            </tr> --}}
             {{#if externalSubmission}}
               <tr>
                 <td class="text-nowrap">External Submission Repositories</td>
@@ -130,7 +130,7 @@
                 </td>
               </tr>
             {{/if}}
-            <tr>
+            {{!-- <tr>
               <td class="text-nowrap">Manuscript IDs</td>
               <td>
                 {{#if model.repoCopies}}
@@ -163,7 +163,7 @@
                   <span class="nodata-placeholder">Manuscript IDs are not yet available</span>
                 {{/if}}
               </td>
-            </tr>
+            </tr> --}}
             <tr>
               <td class="text-nowrap">Submitter</td>
               <td>
@@ -214,6 +214,27 @@
                 </ul>
               </td>
             </tr>
+            {{!-- Consolidate repository, deposit, repoCopy info --}}
+            {{#if repoMap}}
+            <tr>
+              <td>Repositories</td>
+              <td>
+                {{#each repoMap as |repoInfo|}}
+                <div class="card">
+                  <div class="card-body">
+                    <p class="card-title">
+                      {{repoInfo.repo.name}} 
+                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
+                    </p>
+                    <p class="card-text">
+                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
+                    </p>
+                  </div>
+                </div>
+                {{/each}}
+              </td>
+            </tr>
+            {{/if}}
             <tr>
               <td>Files</td>
               <td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -101,7 +101,6 @@
               <td>
                 <ul class="list-unstyled">
                 {{#each repoMap as |repoInfo index|}}
-                  {{#if (not-eq index 0)}}<hr>{{/if}}
                   {{submission-repo-details repo=repoInfo.repo deposit=repoInfo.deposit repoCopy=repoInfo.repositoryCopy}}
                 {{/each}}
                 </ul>
@@ -109,7 +108,7 @@
             </tr>
             {{/if}}
             <tr>
-              <td class="text-nowrap">Submitter</td>
+              <td class="text-nowrap"><h2>Submitter</h2></td>
               <td>
                 {{#if (eq model.sub.source "other")}}
                   <i>This submission did not originate from PASS</i>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -94,109 +94,20 @@
                 </ul>
               </td>
             </tr>
-            {{!-- <tr>
-              <td class="text-nowrap">Repositories</td>
-              <td>
-                <ul class="list-unstyled mb-0">
-                  {{#each (await model.sub.repositories) as |repository index|}}
-                    <li>{{repository.name}}</li>
-                  {{/each}}
-                </ul>
-              </td>
-            </tr> --}}
-            {{#if externalSubmission}}
-              <tr>
-                <td class="text-nowrap">External Submission Repositories</td>
-                <td>
-                  <ul>
-                    <li>Deposit into Educational Resources Information Center (ERIC) was prompted</li>
-                  </ul>
-                </td>
-              </tr>
-            {{/if}}
-            {{#if (and model.deposits (not-eq model.sub.source  "other"))}}
-              <tr>
-                <td>Deposits</td>
-                <td>
-                  <ul>
-                    {{#each model.deposits as |deposit index|}}
-                      <li>Deposit for {{await deposit.repository.name}} (<a href= {{await deposit.repositoryCopy.accessUrl}}>{{await deposit.repositoryCopy.externalIds}}</a>)
-                        <ul>
-                          <li>Status: {{deposit.depositStatus}}</li>
-                        </ul>
-                      </li>
-                    {{/each}}
-                  </ul>
-                </td>
-              </tr>
-            {{/if}}
             {{!-- Consolidate repository, deposit, repoCopy info --}}
             {{#if repoMap}}
             <tr>
-              <td style="min-width:115px;">Repositories</td>
+              <td>Repositories</td>
               <td>
                 <ul class="list-unstyled">
                 {{#each repoMap as |repoInfo index|}}
                   {{#if (not-eq index 0)}}<hr>{{/if}}
-                  <li>
-                    <p class="card-title">
-                      {{repoInfo.repo.name}} 
-                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
-                    </p>
-                    <p class="card-text">
-                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
-                    </p>
-                  </li>
-                {{!-- <div class="card">
-                  <div class="card-body">
-                    <p class="card-title">
-                      {{repoInfo.repo.name}} 
-                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
-                    </p>
-                    <p class="card-text">
-                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
-                    </p>
-                  </div>
-                </div> --}}
+                  {{submission-repo-details repo=repoInfo.repo deposit=repoInfo.deposit repoCopy=repoInfo.repositoryCopy}}
                 {{/each}}
                 </ul>
               </td>
             </tr>
             {{/if}}
-            {{!-- <tr>
-              <td class="text-nowrap">Manuscript IDs</td>
-              <td>
-                {{#if model.repoCopies}}
-                  <ul class="repoid-cell">
-                    {{#each model.repoCopies as |repoCopy index|}}
-                      {{#if repoCopy.externalIds}}
-                        <li>
-                          <ul class="repoid-cell">
-                            {{#if repoCopy.accessUrl}}
-                              {{#each repoCopy.externalIds as |externalIds|}}
-                                <li>
-                                  <a href="{{repoCopy.accessUrl}}" target="_blank">{{externalIds}}</a> - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})
-                                </li>
-                              {{/each}}
-                            {{else}}
-                              <ul class="repoid-cell">
-                                {{#each repoCopy.externalIds as |externalIds|}}
-                                  <li>{{externalIds}} - {{get repoCopy "repository.name"}} ({{repoCopy.copyStatus}})</li>
-                                {{/each}}
-                              </ul>
-                            {{/if}}
-                          </ul>
-                        </li>
-                      {{else}}
-                        <span class="nodata-placeholder">Manuscript IDs are not yet available</span>
-                      {{/if}}
-                    {{/each}}
-                  </ul>
-                {{else}}
-                  <span class="nodata-placeholder">Manuscript IDs are not yet available</span>
-                {{/if}}
-              </td>
-            </tr> --}}
             <tr>
               <td class="text-nowrap">Submitter</td>
               <td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -69,7 +69,7 @@
         <table class="table table-responsive-sm table-bordered w-100">
           <tbody>
             <tr>
-              <td class="max-width">Status</td>
+              <td class="max-width"><strong>Status</strong></td>
               {{#if (eq model.sub.source "other")}}
                 {{#if (eq model.sub.submitted true)}}
                   <td><i>This submission did not originate from PASS.</i></td>
@@ -81,7 +81,7 @@
               {{/if}}
             </tr>
             <tr>
-              <td>Grants</td>
+              <td><strong>Grants</strong></td>
               <td>
                 <ul class="list-unstyled">
                   {{#each model.sub.grants as |grant|}}
@@ -97,7 +97,7 @@
             {{!-- Consolidate repository, deposit, repoCopy info --}}
             {{#if repoMap}}
             <tr>
-              <td>Repositories</td>
+              <td><strong>Repositories</strong></td>
               <td>
                 <ul class="list-unstyled">
                 {{#each repoMap as |repoInfo index|}}
@@ -108,7 +108,7 @@
             </tr>
             {{/if}}
             <tr>
-              <td class="text-nowrap"><h2>Submitter</h2></td>
+              <td class="text-nowrap"><strong>Submitter</strong></td>
               <td>
                 {{#if (eq model.sub.source "other")}}
                   <i>This submission did not originate from PASS</i>
@@ -121,7 +121,7 @@
               </td>
             </tr>
             <tr>
-              <td>Details</td>
+              <td><strong>Details</strong></td>
               <td>
                 <ul class="list-unstyled">
                   {{#each-in metadataBlobNoKeys as |key data|}}
@@ -158,7 +158,7 @@
               </td>
             </tr>
             <tr>
-              <td>Files</td>
+              <td><strong>Files</strong></td>
               <td>
                 {{#if (eq model.sub.source "other")}}
                   <p class="mb-0">

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -114,7 +114,7 @@
                 </td>
               </tr>
             {{/if}}
-            {{#if (not-eq model.sub.source "other")}}
+            {{#if (and model.deposits (not-eq model.sub.source  "other"))}}
               <tr>
                 <td>Deposits</td>
                 <td>
@@ -129,6 +129,39 @@
                   </ul>
                 </td>
               </tr>
+            {{/if}}
+            {{!-- Consolidate repository, deposit, repoCopy info --}}
+            {{#if repoMap}}
+            <tr>
+              <td style="min-width:115px;">Repositories</td>
+              <td>
+                <ul class="list-unstyled">
+                {{#each repoMap as |repoInfo index|}}
+                  {{#if (not-eq index 0)}}<hr>{{/if}}
+                  <li>
+                    <p class="card-title">
+                      {{repoInfo.repo.name}} 
+                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
+                    </p>
+                    <p class="card-text">
+                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
+                    </p>
+                  </li>
+                {{!-- <div class="card">
+                  <div class="card-body">
+                    <p class="card-title">
+                      {{repoInfo.repo.name}} 
+                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
+                    </p>
+                    <p class="card-text">
+                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
+                    </p>
+                  </div>
+                </div> --}}
+                {{/each}}
+                </ul>
+              </td>
+            </tr>
             {{/if}}
             {{!-- <tr>
               <td class="text-nowrap">Manuscript IDs</td>
@@ -214,27 +247,6 @@
                 </ul>
               </td>
             </tr>
-            {{!-- Consolidate repository, deposit, repoCopy info --}}
-            {{#if repoMap}}
-            <tr>
-              <td>Repositories</td>
-              <td>
-                {{#each repoMap as |repoInfo|}}
-                <div class="card">
-                  <div class="card-body">
-                    <p class="card-title">
-                      {{repoInfo.repo.name}} 
-                      {{#if repoInfo.repo.url}}<a href={{repoInfo.repo.url}}>{{repoInfo.repo.url}}</a>{{/if}}
-                    </p>
-                    <p class="card-text">
-                      {{repocopy-display repoCopy=repoInfo.repositoryCopy}}
-                    </p>
-                  </div>
-                </div>
-                {{/each}}
-              </td>
-            </tr>
-            {{/if}}
             <tr>
               <td>Files</td>
               <td>


### PR DESCRIPTION
#539 
#568 
#582 

Changes are focused in `submission/details`

* Remove old sections: repositories, manuscript IDs, deposits, external repositories
* New display section added intended to consolidate information about repositories, repositoryCopies, and deposits. See ticket for specs

* Update status display in Submissions table
* Revert header fonts