### PR TITLE
Modify text on Repositories step, adds FAQ on open access policy 

### DIFF
--- a/app/templates/components/workflow-repositories.hbs
+++ b/app/templates/components/workflow-repositories.hbs
@@ -1,8 +1,7 @@
 {{#if requiredRepositories}}
   <h4 class="mt-3 font-weight-light">Funders' repositories</h4>
   <p>
-    Based on the information about the funders and journal you have provided,
-    you are required to deposit your manuscript/article into:
+    Based on the grant and journal information provided, you are required to submit your manuscript to the repositories below. PASS will help you to create submissions for these in the following steps:
   </p>
   <ul class="list-group">
     {{#each requiredRepositories as |repoInfo|}}

--- a/app/templates/components/workflow-repositories.hbs
+++ b/app/templates/components/workflow-repositories.hbs
@@ -14,8 +14,7 @@
 {{#if optionalRepositories}}
 <h4 class="mt-3 font-weight-light">Institutional repositories</h4>
 <p>
-  Submission to local repositories is optional but encouraged.
-  To opt out of submitting to a local repository, uncheck its checkbox.
+  A Submission to the following will put you in compliance with your <a href="/faq#institution-policy">institution's open access policy</a>. If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional.
 </p>
 <div id="local-deposit-list">
   <ul class="list-group">

--- a/app/templates/faq.hbs
+++ b/app/templates/faq.hbs
@@ -44,6 +44,10 @@
     </ul>
   </section>
   <section>
+    <h3 id="institution-policy">What is my institution's open access policy?</h3>
+    <p>As of July 1, 2018, Johns Hopkins University have put in effect a university wide open access policy that requires all scholarly articles produced by full-time faculty members be made openly available. To learn more about this policy visit the <a href="https://provost.jhu.edu/about/open-access/" target="_blank">Office of the Provost's webpages on Open Access at Johns Hopkins</a>.</p>
+  </section>
+  <section>
     <h3 id="processing">What is an article processing charge?</h3>
     <p>Article process charge, also known as publication fee, is a fee often charged to authors, by publisher, to fund the publication of open access journal articles. This fee is typically paid for by the author’s institution or research funder and range from $100 to $5000.</p>
   </section>


### PR DESCRIPTION
#552 - change wording under "Institutional Repositories" heading a link to FAQ on open access policy. Add FAQ on open access policy.
#556 - change wording on `4. Repositories` to indicate that PASS will help you do a submission to those repositories.