### PR TITLE
Fixes date filter on the Grants lists

### DIFF
--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -31,7 +31,7 @@ export default Route.extend({
         // 'projectName'
       ],
       query: {
-        constant_score : {
+        constant_score: {
           filter: {
             bool: {
               should: [
@@ -39,7 +39,7 @@ export default Route.extend({
                 { term: { coPis: user.get('id') } }
               ],
               must : {
-                range: { "endDate": { "gte": "2011-01-01" } }
+                range: { endDate: { gte: '2011-01-01' } }
               }
             }
           }

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -31,13 +31,17 @@ export default Route.extend({
         // 'projectName'
       ],
       query: {
-        bool: {
-          should: [
-            { term: { pi: user.get('id') } },
-            { term: { coPis: user.get('id') } }
-          ],
+        constant_score : {
           filter: {
-            range: { "endDate": { "gte": "2011-01-01" }} 
+            bool: {
+              should: [
+                { term: { pi: user.get('id') } },
+                { term: { coPis: user.get('id') } }
+              ],
+              must : {
+                range: { "endDate": { "gte": "2011-01-01" } }
+              }
+            }
           }
         }
       },

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -35,7 +35,7 @@ export default Route.extend({
     const funders = this.loadObjects('funder', 0, 500);
     const grants = this.get('store').query('grant', {
       query: {
-        constant_score : {
+        constant_score: {
           filter: {
             bool: {
               should: [
@@ -43,7 +43,7 @@ export default Route.extend({
                 { term: { coPis: this.get('currentUser.user.id') } }
               ],
               must : {
-                range: { "endDate": { "gte": "2011-01-01" } }
+                range: { endDate: { gte: '2011-01-01' } }
               }
             }
           }

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -35,13 +35,17 @@ export default Route.extend({
     const funders = this.loadObjects('funder', 0, 500);
     const grants = this.get('store').query('grant', {
       query: {
-        bool: {
-          should: [
-            { term: { pi: this.get('currentUser.user.id') } },
-            { term: { coPis: this.get('currentUser.user.id') } }
-          ],
+        constant_score : {
           filter: {
-            range: { "endDate": { "gte": "2011-01-01" }} 
+            bool: {
+              should: [
+                { term: { pi: this.get('currentUser.user.id') } },
+                { term: { coPis: this.get('currentUser.user.id') } }
+              ],
+              must : {
+                range: { "endDate": { "gte": "2011-01-01" } }
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Date filter was not working for Grants lists. This limits the Grant matches to those that have an endDate of after 1/1/2011.

Relates to comment on #572

This is the tail end of PR #590, which was not quite complete and broke the Grants queries