### PR TITLE
web-link repos and specifically ERIC should no longer be included in new submissions

### DIFF
--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import ENV from 'pass-ember/config/environment';
+import { debug } from '@ember/debug';
 
 export default Controller.extend({
   currentUser: Ember.inject.service('current-user'),
@@ -21,7 +22,10 @@ export default Controller.extend({
       sub.get('repositories').forEach((repo) => {
         // add each repo to the metadata
       });
-      sub.set('repositories', sub.get('repositories').filter(repo => repo.get('weblinkOnly')));
+      sub.set('repositories', sub.get('repositories').filter((repo) => { // eslint-disable-line
+        return repo.get('integrationType') !== 'web-link' && repo.get('url') !== 'https://eric.ed.gov/';
+      }));
+
       const pub = this.get('model.publication');
       sub.set('aggregatedDepositStatus', 'not-started');
       sub.set('submittedDate', new Date());

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
 import ENV from 'pass-ember/config/environment';
-import { debug } from '@ember/debug';
 
 export default Controller.extend({
   currentUser: Ember.inject.service('current-user'),

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -22,7 +22,11 @@ export default Controller.extend({
         // add each repo to the metadata
       });
       sub.set('repositories', sub.get('repositories').filter((repo) => { // eslint-disable-line
-        return repo.get('integrationType') !== 'web-link' && repo.get('url') !== 'https://eric.ed.gov/';
+        // TODO the specific URL checks should be removed after Repository data is updated to
+        // include 'integrationType' property
+        return repo.get('integrationType') !== 'web-link' &&
+          repo.get('url') !== 'https://eric.ed.gov/' &&
+          repo.get('url') !== 'https://dec.usaid.gov/';
       }));
 
       const pub = this.get('model.publication');


### PR DESCRIPTION
#422 

## Testing
* Start up `.docker/shib` stack as normal
* Login to `ed-user` in order to get some grants that linked to funders with repositories that submissions _must_ be done manually - in this case, US Dept of Education's ERIC
* Start a new submission, pick a grant linked to Dept of Edu such as `Testing the Efficacy of A Developmentally-Informed Coping Power Program in Middle Schools`
* Progress through the rest of the submission workflow, open up the ERIC site, then click Submit to create the new submission.
* After a few seconds (10s max), check in the Submissions table for your new submission. JScholarship should be the only repository shown.