### PR TITLE
Make queries for grants of pi/copi cleaner.

### DIFF
--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -31,18 +31,16 @@ export default Route.extend({
         { endDate: 'desc' }
       ],
       query: {
-        constant_score: {
-          filter: {
-            bool: {
+        bool: {
+          must: [
+            { range: { endDate: { gte: '2011-01-01' } } },
+            { bool: {
               should: [
                 { term: { pi: user.get('id') } },
                 { term: { coPis: user.get('id') } }
-              ],
-              must: {
-                range: { endDate: { gte: '2011-01-01' } }
-              }
+              ]}
             }
-          }
+          ]
         }
       },
       size: querySize

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -38,18 +38,16 @@ export default Route.extend({
         { endDate: 'desc' }
       ],
       query: {
-        constant_score: {
-          filter: {
-            bool: {
+        bool: {
+          must: [
+            { range: { endDate: { gte: '2011-01-01' } } },
+            { bool: {
               should: [
                 { term: { pi: this.get('currentUser.user.id') } },
                 { term: { coPis: this.get('currentUser.user.id') } }
-              ],
-              must: {
-                range: { endDate: { gte: '2011-01-01' } }
-              }
+              ]}
             }
-          }
+          ]
         }
       },
       from: 0,


### PR DESCRIPTION
Use nested bool queries instead of filter and constant_score.

I did some manual testing and it seems to be correct. In order to test look at the grants queries when creating a new submission and when viewing the grants table and make sure pi/copi is matched correctly.