### PR TITLE
Proposed workaround for shib timeout

### DIFF
--- a/app/initializers/application.js
+++ b/app/initializers/application.js
@@ -1,0 +1,14 @@
+export function initialize(/* application */) {
+  Ember.onerror = (error) => {
+    console.log(` >> Ember error caught: ${error}`);
+    window.location.reload(true);
+  };
+
+  Ember.RSVP.on('error', (error) => {
+    console.log(` >> RSVP error caught: ${error}`);
+  });
+}
+
+export default {
+  initialize
+};

--- a/app/initializers/application.js
+++ b/app/initializers/application.js
@@ -1,11 +1,16 @@
 export function initialize(/* application */) {
   Ember.onerror = (error) => {
     console.log(` >> Ember error caught: ${error}`);
-    window.location.reload(true);
+    if (error.message === 'shib302') {
+      window.location.reload(true);
+    }
   };
 
   Ember.RSVP.on('error', (error) => {
     console.log(` >> RSVP error caught: ${error}`);
+    if (error.message === 'shib302') {
+      window.location.reload(true);
+    }
   });
 }
 


### PR DESCRIPTION
#345 

`ember-fedora-adapter` has been updated to throw a specific error when Shib responds with a redirect when session times out. This PR adds a global error handler that will force the current page to refresh when this error is encountered.

## Manual testing
_(Kind of optional)_ If you don't do this modification, I think the default session timeout is one hour
* You can modify the `sp` container from `pass-docker` so that the session expires quickly, retag and build the new image.
  * `pass-docker/sp/etc-shibboleth/shibboleth2.xml`: `<Sessions lifetime="5" timeout="5" relayState="ss:mem" checkAddress="false" handlerSSL="false" cookieProps="https">` seems to do OK
  * `pass-docker/sp/etc-httpd/conf/sp.conf`: any references to `app/` redirection must be removed, as in the `pass-ember` environment, the app sits at `pass/` and not `pass/app/`
* Modify `.docker/shib/docker-compose.yml` to point to the `sp` image you just created

-----

* Run `docker-compose up` from `pass-ember/.docker/shib`
* Login as some known user, wait until session times out, then try to navigate to the Grants page
* The page should reload.

