### PR TITLE
Add usaid support

### DIFF
--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -202,7 +202,7 @@ export default Component.extend({
               showCancelButton: true,
               confirmButtonText: 'Return to deposit agreement',
               cancelButtonText: 'Proceed anyway'
-            }).then(result => {
+            }).then((result) => {
               if (result.value) {
                 console.log('agree to deposit');
                 return;
@@ -238,17 +238,17 @@ export default Component.extend({
           },
         });
 
-
-        JSON.parse(this.get('model.newSubmission.metadata')).map((m) => {
-          if (m.id.includes('eric')) {
-            metadata.push({
-              id: 'external-submissions',
-              data: {
-                submission: 'Prompted to deposit into Educational Resources Information Center (ERIC).'
-              },
-            });
-          }
-        });
+        // Add metadata for external submissions
+        const externalRepos = this.get('model.newSubmission.repositories').filter(repo =>
+          repo.get('integrationType') === 'web-link' ||
+          repo.get('url') === 'https://eric.ed.gov/' ||
+          repo.get('url') === 'https://dec.usaid.gov/');
+        if (externalRepos.get('length') > 0) {
+          let md = { id: 'external-submissions', data: { submission: [] } };
+          externalRepos.forEach(repo => md.data.submission.push(`Deposit into ${repo.get('name')} was prompted`));
+          // Push this new thing to the overall 'metadata' obj
+          metadata.push(md);
+        }
         this.set('model.newSubmission.metadata', JSON.stringify(metadata));
         this.sendAction('next');
       }

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -7,11 +7,8 @@ export default Controller.extend({
       $('[data-toggle="tooltip"]').tooltip();
     });
   }.on('init'),
-  externalSubmission: Ember.computed('metadataBlobNoKeys', function () { // eslint-disable-line
-    if (this.get('metadataBlobNoKeys').Submission) {
-      return true;
-    }
-    return false;
+  externalSubmission: Ember.computed('metadataBlobNoKeys', function () {
+    return this.get('metadataBlobNoKeys').Submission;
   }),
   /**
    * Ugly way to generate date for the template to use.
@@ -72,7 +69,7 @@ export default Controller.extend({
 
     return null;
   }),
-  metadataBlobNoKeys: Ember.computed('model.sub.metadata', function () { // eslint-disable-line
+  metadataBlobNoKeys: Ember.computed('model.sub.metadata', function () {
     let metadataBlobNoKeys = [];
     JSON.parse(this.get('model.sub.metadata')).forEach((ele) => {
       for (var key in ele.data) {

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -93,28 +93,31 @@
                 </ul>
               </td>
             </tr>
-            {{#if mustVisitEric}}
-              <tr>
-                <td class="text-nowrap text-center" id="externalSubmission">External Submission Required
-                  <br>
-                  {{#if disableSubmit}}
-                    <i class="fa fa-exclamation-triangle fa-2x mt-3 notice-triangle"></i>
-                  {{/if}}
-                </td>
-                <td>
-                  <label class="">
-                    Please visit the following web portal to submit your manuscript directly. Metadata displayed above
-                    could be used to aid in your submission progress.
-                  </label>
-                  <ul class="m-0">
-                    <li>
-                      <button type="button" class="btn btn-link" {{action "openEricAlert"}}>
-                        https://eric.ed.gov/submit/
-                      </button>
-                    </li>
-                  </ul>
-                </td>
-              </tr>
+            {{#if mustVisitWeblink}}
+              
+                <tr>
+                  <td class="text-nowrap text-center" id="externalSubmission">External Submission Required
+                    <br>
+                    {{#if disableSubmit}}
+                      <i class="fa fa-exclamation-triangle fa-2x mt-3 notice-triangle"></i>
+                    {{/if}}
+                  </td>
+                  <td>
+                    <label class="">
+                      Please visit the following web portal to submit your manuscript directly. Metadata displayed above
+                      could be used to aid in your submission progress.
+                    </label>
+                    <ul class="m-0">
+                      {{#each weblinkRepos as |repo|}}
+                        <li>
+                          <button type="button" class="btn btn-link" {{action "openWeblinkAlert" repo}}>
+                            {{get repo 'url'}}
+                          </button>
+                        </li>
+                      {{/each}}
+                    </ul>
+                  </td>
+                </tr>
             {{/if}}
             <tr>
               <td>Grants</td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -115,6 +115,16 @@
               </td>
             </tr>
             {{/if}}
+            {{#if externalSubmission}}
+              <tr>
+                <td class="text-nowrap"><strong>External Submission Repositories</strong></td>
+                <td>
+                  <ul>
+                    <li>Deposit into Educational Resources Information Center (ERIC) was prompted</li>
+                  </ul>
+                </td>
+              </tr>
+            {{/if}}
             <tr>
               <td class="text-nowrap"><strong>Submitter</strong></td>
               <td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -50,6 +50,7 @@
 
   .max-width {
     max-width: 300px !important;
+    min-width: 150px;
   }
 
   .fa-30 {
@@ -119,7 +120,7 @@
               <tr>
                 <td class="text-nowrap"><strong>External Submission Repositories</strong></td>
                 <td>
-                  <ul>
+                  <ul class="list-unstyled">
                     {{#each externalSubmission as |sub|}}
                       <li>{{sub}}</li>
                     {{/each}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -120,7 +120,9 @@
                 <td class="text-nowrap"><strong>External Submission Repositories</strong></td>
                 <td>
                   <ul>
-                    <li>Deposit into Educational Resources Information Center (ERIC) was prompted</li>
+                    {{#each externalSubmission as |sub|}}
+                      <li>{{sub}}</li>
+                    {{/each}}
                   </ul>
                 </td>
               </tr>


### PR DESCRIPTION
#614 will hopefully be addressed 

Add support for USAID grants in a submission. Previously, these grants were basically ignored in the submission workflow, thus in the submission details page as well. This update will make USAID and other web-link grants behave similarly to Dept of Edu grants: submission will be halted at the review step. Final submission will only be possible after the user clicks a link to the open the web-linked repository (with the goal of having the user manually add a submission).

### Testing
* Start docker stack as normal
* Login as `ed-user`
* Create a submission with a US Department of Education funded grant
* In the final review step, the Submit button will prompt a user to click the link to the ERIC site, if they have not already done so. Once this link is clicked, the user can click Submit.
* After the submission is done, wait about 10 seconds (for the indexer to catch up [this is in the process of being addressed]) and check the details page for your new submission
* A section for External Submission Repositories should be displayed, mentioning something about ERIC.

-----

* Close your browser to clear cookies and stuffs
* Login to PASS as `usaid-user` 
* Start a new submission with the grant `411228_GR410977: Passages`
* Behavior throughout and after the submission workflow should mirror those above, but instead of ERIC being mentioned, things will mention DEC