### PR TITLE
Add linked list of questions to top of FAQ page, fix incorrect page scroll

### DIFF
--- a/app/templates/components/workflow-repositories.hbs
+++ b/app/templates/components/workflow-repositories.hbs
@@ -14,7 +14,7 @@
 {{#if optionalRepositories}}
 <h4 class="mt-3 font-weight-light">Institutional repositories</h4>
 <p>
-  A Submission to the following will put you in compliance with your <a href="{{rootURL}}faq#institution-policy">institution's open access policy</a>. If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional.
+  A Submission to the following will put you in compliance with your <a href="{{rootURL}}faq#institution-policy" target="_blank">institution's open access policy</a>. If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional.
 </p>
 <div id="local-deposit-list">
   <ul class="list-group">

--- a/app/templates/faq.hbs
+++ b/app/templates/faq.hbs
@@ -10,6 +10,12 @@
   margin-bottom:3px;
   padding-bottom:0;
 }
+.faq-anchor {
+  display: block;
+  position: relative;
+  top: -50px;
+  visibility: hidden;
+}
 </style>
 <div class="ml-auto mr-auto faq-content" style="max-width: 1000px;">
   <header class="mt-5">
@@ -25,7 +31,8 @@
     <li><a href="{{rootURL}}faq#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
   </ul>
   <section>
-    <h3 id="supported-policies">What Open or Public Access policies can PASS support?</h3>
+    <a id="supported-policies" class="faq-anchor"></a>
+    <h3>What Open or Public Access policies can PASS support?</h3>
     <p>PASS supports Johns Hopkins University’s (JHU) Open Access policy by facilitating submission of an author’s accepted manuscripts to JScholarship, JHU’s institutional repository.</p>
     <p id="agencies_supported_by_PASS">Additionally, PASS supports existing workflows for federal funding agencies’ public access policy submission into PubMed Central (PMC) - used by NIH and the other funding agencies listed below:</p>
     <h5>Full integration</h5>
@@ -53,11 +60,13 @@
     </ul>
   </section>
   <section>
-    <h3 id="institution-policy">What is JHU's open access policy?</h3>
+    <a id="institution-policy" class="faq-anchor"></a>
+    <h3>What is JHU's open access policy?</h3>
     <p>As of July 1, 2018, Johns Hopkins University has implemented a university wide open access policy that expects  every scholarly article produced by full-time faculty members of Johns Hopkins University be accessible in an open access repository. To learn more about this policy visit the <a href="https://provost.jhu.edu/about/open-access/" target="_blank">Office of the Provost's webpages on Open Access at Johns Hopkins</a>.</p>
   </section>
   <section>
-    <h3 id="what-to-expect">What should I expect after submitting through PASS?</h3>
+    <a id="what-to-expect" class="faq-anchor"></a>
+    <h3>What should I expect after submitting through PASS?</h3>
     <p>Each submission may go through a different process for each repository. The PASS team will continue to work with funding agencies to improve integration with their repositories, and bring PASS users more convenient features and streamlined workflows. The current processes are described below:</p>
     <h5>PubMed Central (PMC)</h5>
     <p>Within a few hours of submitting your manuscript files to <a href="https://www.ncbi.nlm.nih.gov/pmc/" target="_blank">PubMed Central</a> through PASS, you will be contacted by the National Institutes of Health Manuscript Submission system (NIHMS) to approve the processing of the submission. At that point your submission will be assigned a NIHMSID, which can be used to demonstrate public access policy compliance while your submission is being processed.</p>
@@ -73,7 +82,8 @@
     <p>PASS does not automatically create or track submissions to <a href="https://dec.usaid.gov/" target="_blank">DEC</a>, but it does identify manuscripts that are subject to the USAID public access policy and provides a link to USAID submission portal.</p>
   </section>
   <section>
-    <h3 id="publisher-submit">Will the publisher automatically submit my article to PubMed Central?</h3>
+    <a id="publisher-submit" class="faq-anchor"></a>
+    <h3>Will the publisher automatically submit my article to PubMed Central?</h3>
     <p>Whether articles are automatically submitted to PubMed Central by a publisher varies depending on the journal. Each journal falls into one of the following categories:</p>
     <ol>
       <li>The publisher can automatically submit the manuscript to PubMed Central on your behalf. A list of journals that provide this service can be <a href="https://publicaccess.nih.gov/submit_process_journals.htm" target="_blank">found here</a>. In this instance, nothing needs to be done through PASS.</li>
@@ -83,7 +93,8 @@
     <p>When there is a fee or you must make your own arrangements, PASS can be used to submit the article to PubMed Central directly without fee. For more information on the various submission paths used by journals, visit the <a href="https://publicaccess.nih.gov/" target="_blank">NIH public access website.</a></p>
   </section>
   <section>
-    <h3 id="nih-submissions">What information about NIH submissions is pre-loaded into PASS?</h3>
+    <a id="nih-submissions" class="faq-anchor"></a>
+    <h3>What information about NIH submissions is pre-loaded into PASS?</h3>
     <p>Records of prior NIH submissions displayed in PASS go back to January 2013. Each night, updated Submission information is loaded into PASS from the NIH Manuscript Submission system (NIHMS). This information contains the public access compliance status of articles associated with NIH grants. If you are a PI on an NIH grant and have articles that are associated with those grants in PubMed, you may see the following on {{#link-to 'submissions'}}your Submissions page{{/link-to}}:</p>
        <ul>
          <li>Information about completed or in-progress Submissions, some of which may have been initiated outside of PASS. No action is required for these Submissions.</li>
@@ -92,7 +103,8 @@
     <p>The information for these submissions comes directly from NIH. Please feel free to {{#link-to 'contact'}}contact us{{/link-to}} if there are problems with the information so that we can contact NIH.</p>
   </section>
   <section>
-    <h3 id="negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</h3>
+    <a id="negotiate-copyright" class="faq-anchor"></a>
+    <h3>How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</h3>
     <p>Many journals make allowances for self-archiving and compliance with access policies implemented by a funder or institution. You can look up many publishers’ policies for copyright and self-archiving on the <a href="http://www.sherpa.ac.uk/romeo/index.php" target="_blank">SHERPA/RoMEO website</a>. If a journal does not allow open sharing of your article, you may be able to negotiate with them to make an exception. For help with copyright negotiation, or any other copyright related questions, please {{#link-to 'contact'}}contact Robin Sinn at the Office of Scholarly Communication{{/link-to}}.</p>
   </section>
   

--- a/app/templates/faq.hbs
+++ b/app/templates/faq.hbs
@@ -15,6 +15,15 @@
   <header class="mt-5">
     <h1>Frequently Asked Questions</h1>
   </header>
+  <p>The following questions are answered on this page. If you have other questions, feel free to {{#link-to 'contact'}}contact us{{/link-to}}</p>
+  <ul>
+    <li><a href="{{rootURL}}faq#supported-policies">What Open or Public Access policies can PASS support?</a></li>
+    <li><a href="{{rootURL}}faq#institution-policy">What is JHU's open access policy?</a></li>
+    <li><a href="{{rootURL}}faq#what-to-expect">What should I expect after submitting through PASS?</a></li>
+    <li><a href="{{rootURL}}faq#publisher-submit">Will the publisher automatically submit my article to PubMed Central?</a></li>
+    <li><a href="{{rootURL}}faq#nih-submissions">What information about NIH submissions is pre-loaded into PASS?</a></li>
+    <li><a href="{{rootURL}}faq#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
+  </ul>
   <section>
     <h3 id="supported-policies">What Open or Public Access policies can PASS support?</h3>
     <p>PASS supports Johns Hopkins University’s (JHU) Open Access policy by facilitating submission of an author’s accepted manuscripts to JScholarship, JHU’s institutional repository.</p>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -81,7 +81,7 @@
       <div class="col-md-12 text-center">
         <h1  class="font-weight-light mt-4" >Public Access Submission System</h1>
         <p class="font-weight-light mt-4">
-          Use PASS to submit your manuscripts to funder and institutional publication repositories (e.g. PubMed Central, JScholarship) and comply with access policies. Using the web-based PASS system, you can: avoid paying <a href="{{rootURL}}faq#processing">article processing charges</a> to make your publication open to the public, simultaneously send your manuscript to multiple repositories seamlessly, and populate forms automatically with publication and author information by providing DOIs and ORCID IDs. {{#link-to 'about'}}Learn more about PASS?{{/link-to}}
+          Use PASS to submit your manuscripts to funder and institutional publication repositories (e.g. PubMed Central, JScholarship) and comply with access policies. Using the web-based PASS system, you can: avoid paying article processing charges to make your publication open to the public, simultaneously send your manuscript to multiple repositories seamlessly, and populate forms automatically with publication and author information by providing DOIs and ORCID IDs. {{#link-to 'about'}}Learn more about PASS?{{/link-to}}
         </p>
         {{#link-to "dashboard" class='btn btn-primary mt-1 pl-4 pr-4'}}Get started!{{/link-to}}
       </div>
@@ -92,5 +92,5 @@
   </h2>
   {{carousel-gallery class="row mb-4 padding-lr-100"}}
   <div class="w-100 text-center">
-    <a href="{{rootURL}}faq#agencies_supported_by_PASS" class="btn btn-link mt-1 pl-4 pr-4 ember-view">See full list of agencies and institutions here</a>
+    <a href="{{rootURL}}faq#supported-policies" class="btn btn-link mt-1 pl-4 pr-4 ember-view">See full list of policies supported by PASS here</a>
   </div>


### PR DESCRIPTION
* Adds a list of questions to top of FAQ. 
* Fixes scrolling to `#`. Previously links to the questions were scrolling to the wrong place due to the floating header, so this change also adds anchor tags (rather than using an `id` property in the `<h3>` field) that are styled to adjust their top position so that scrolling to the question works properly.
* Fixes some FAQ links. Specifically:
  * adds `target="_blank"` to institution policy link in workflow to prevent the user from exiting the workflow to read the policy
  * removes link to article processing charges FAQ on welcome page, this FAQ was removed
  * corrects link to supported policies on welcome page