### PR TITLE
'container-title' should now be 'journal-title' in metadata blobs

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -141,6 +141,10 @@ export default Component.extend({
           if (doiInfo.isDestroyed) {
             return;
           }
+          // // Crappy hack to rename property 'container-title' (received from DOI)
+          // // to 'journal-title' that is expected by the back end services
+          doiInfo['journal-title'] = doiInfo['container-title'];
+
           this.set('doiInfo', doiInfo);
           // useful console.log
           // console.log(doiInfo);

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -14,7 +14,7 @@ export default Component.extend({
           type: 'string',
           required: true
         },
-        'container-title': {
+        'journal-title': {
           type: 'string',
           required: true
         },
@@ -75,7 +75,7 @@ export default Component.extend({
           placeholder: 'Enter the manuscript title',
           hidden: true,
         },
-        'container-title': {
+        'journal-title': {
           type: 'text',
           label: 'Journal Title',
           placeholder: 'Enter the journal title',


### PR DESCRIPTION
`journal-title` property now appears in the blob with `id="common"`. Journal name is pulled from CrossRef, not from our Fedora data (they may be different).

``` javascript
[
  {
    "id": "common",
    "data": {
      ...
      "journal-title": "Some journal name goes here",
      ...
    }
  },
  ...
]
```