### PR TITLE
No longer share query params from different places

### DIFF
--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -8,7 +8,7 @@ export default Route.extend({
   resetController(controller, isExiting, transition) {
     // Explicitly clear the 'grant' query parameter when reloading this route
     if (isExiting) {
-      controller.set('grant', undefined);
+      controller.get('queryParams').forEach(param => controller.set(param, null));
       this.get('store').peekAll('submission').forEach(s => s.rollbackAttributes());
     }
   },
@@ -41,11 +41,13 @@ export default Route.extend({
         bool: {
           must: [
             { range: { endDate: { gte: '2011-01-01' } } },
-            { bool: {
-              should: [
-                { term: { pi: this.get('currentUser.user.id') } },
-                { term: { coPis: this.get('currentUser.user.id') } }
-              ]}
+            {
+              bool: {
+                should: [
+                  { term: { pi: this.get('currentUser.user.id') } },
+                  { term: { coPis: this.get('currentUser.user.id') } }
+                ]
+              }
             }
           ]
         }


### PR DESCRIPTION
#630 

Restarting an incomplete submission appended a submission ID as a `submission` URL query parameter in order to pre-populate fields (without needing to know the previous state of the application). If a user were to leave the workflow and start a new submission from the dashboard, the query parameter was kept, so the workflow assumed the other submission was still pre-loaded.

This change clears all query parameters when leaving the submission workflow.

(also fix a code style)