### PR TITLE
Add min-widths to prevent date and repo name wrapping, truncate long manuscript IDs

### DIFF
--- a/app/components/submissions-repoid-cell.js
+++ b/app/components/submissions-repoid-cell.js
@@ -1,10 +1,64 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  store: Ember.inject.service(),
+  repoCopies: null,
+  jscholarshipCheckString: '/handle/',
+
+  init() {
+    this._super(...arguments);
+
+    const publicationId = this.get('record.publication.id');
+    this.get('store').query('repositoryCopy', {
+      query: {
+        term: { publication: publicationId }
+      },
+      from: 0,
+      size: 100
+    }).then(rc => this.set('repoCopies', rc));
+  },
   didReceiveAttrs() {
     this._super(...arguments);
     if ($('#manuscriptIdTooltip').length == 0) {
       ($('.table-header:nth-child(6)')).append('<span id="manuscriptIdTooltip" tooltip-position="bottom" tooltip="ID are assigned to manuscript by target repositories."><i class="fas fa-info-circle d-inline"></i></span>');
     }
-  }
+  },
+
+  /**
+   * Formatted:
+   *  [
+   *    {
+   *      url: '',
+   *      ids: [
+   *        {
+   *          title: 'href-worthy-id',
+   *          display: 'somewhat-more-human-readable'
+   *        }
+   *      ]
+   *    }
+   *  ]
+   */
+  displayIds: Ember.computed('repoCopies', function () {
+    const rc = this.get('repoCopies');
+    if (!rc) {
+      return [];
+    }
+
+    return rc.filter(repoCopy => !!repoCopy.get('externalIds')).map((repoCopy) => {
+      const check = this.get('jscholarshipCheckString');
+
+      // If an ID has the 'check' string, only display the sub-string after the 'check' string
+      let ids = repoCopy.get('externalIds').map((id) => { // eslint-disable-line
+        return {
+          title: id,
+          display: id.includes(check) ? id.slice(id.indexOf(check) + check.length) : id
+        };
+      });
+      return {
+        url: repoCopy.get('accessUrl'),
+        ids
+      };
+      // Note the 'ids' notation in the above object gets translated to: ids: ids
+    });
+  })
 });

--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -22,11 +22,13 @@ export default Controller.extend({
       propertyName: 'repositoryNames',
       title: 'Repositories',
       component: 'submissions-repo-cell',
+      className: 'repositories-column',
       disableSorting: true
     },
     {
       propertyName: 'submittedDate',
       title: 'Submitted Date',
+      className: 'date-column',
       component: 'date-cell'
     },
     {

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -55,12 +55,14 @@ export default Controller.extend({
       propertyName: 'grant.startDate',
       title: 'Start',
       disableFiltering: true,
+      className: 'date-column',
       component: 'date-cell'
     },
     {
       propertyName: 'grant.endDate',
       title: 'End',
       disableFiltering: true,
+      className: 'date-column',
       component: 'date-cell'
     },
     {
@@ -107,6 +109,7 @@ export default Controller.extend({
       propertyName: 'grant.endDate',
       title: 'End Date',
       disableFiltering: true,
+      className: 'date-column',
       component: 'date-cell'
     },
     {

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -42,11 +42,13 @@ export default Controller.extend({
     propertyName: 'repositoryNames',
     title: 'Repositories',
     component: 'submissions-repo-cell',
+    className: 'repositories-column',
     disableSorting: true
   },
   {
     propertyName: 'submittedDate',
     title: 'Submitted Date',
+    className: 'date-column',
     component: 'date-cell'
   },
   {
@@ -83,11 +85,13 @@ export default Controller.extend({
   {
     propertyName: 'repositories',
     title: 'Repositories',
+    className: 'repositories-column',
     component: 'submissions-repo-cell'
   },
   {
     propertyName: 'submittedDate',
     title: 'Submitted Date',
+    className: 'date-column',
     component: 'date-cell'
   },
   {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -689,6 +689,8 @@ footer {
 .actions-column { min-width: 8rem; }
 .awardnum-column { min-width: 8rem; }
 .awardnum-funder-column { min-width: 9.5rem; }
+.date-column { min-width: 7rem; }
+.repositories-column { min-width: 7.5rem; }
 #journal div {
   width: 100%;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -682,7 +682,11 @@ footer {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+.repoid-cell li {
   word-break: initial;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .title-column { min-width: 24rem; }
 .msid-column { min-width: 10rem; }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -684,11 +684,11 @@ footer {
   padding: 0;
   word-break: initial;
 }
-.title-column { min-width: 400px; }
-.msid-column { min-width: 145px; }
-.actions-column { min-width: 125px; }
-.awardnum-column { min-width: 125px; }
-.awardnum-funder-column { min-width: 150px; }
+.title-column { min-width: 24rem; }
+.msid-column { min-width: 10rem; }
+.actions-column { min-width: 8rem; }
+.awardnum-column { min-width: 8rem; }
+.awardnum-funder-column { min-width: 9.5rem; }
 #journal div {
   width: 100%;
 }

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -13,9 +13,7 @@
     {{else}}
       <ul class="repoid-cell">
         {{#each repositoryCopy.externalIds as |externalIds|}}
-          <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-            <li title="{{externalIds}}">{{externalIds}}</li>
-          </a>
+          <li title="{{externalIds}}">{{externalIds}}</li>
         {{/each}}
       </ul>
     {{/if}}

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -6,7 +6,7 @@
     <ul class="repoid-cell">
       {{#each repositoryCopy.externalIds as |externalIds|}}
         <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-          <li>{{externalIds}}</li>
+          <li title="{{externalIds}}">{{externalIds}}</li>
         </a>
       {{/each}}
     </ul>
@@ -14,7 +14,7 @@
       <ul class="repoid-cell">
         {{#each repositoryCopy.externalIds as |externalIds|}}
           <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-            <li>{{externalIds}}</li>
+            <li title="{{externalIds}}">{{externalIds}}</li>
           </a>
         {{/each}}
       </ul>

--- a/app/templates/components/submissions-repoid-cell.hbs
+++ b/app/templates/components/submissions-repoid-cell.hbs
@@ -1,26 +1,17 @@
-<div style="min-width:150px">
-{{#each (search-associated 'repositoryCopy' 'publication' (get record 'publication.id')) as |repositoryCopy index|}}
-  {{#if repositoryCopy.externalIds}}
-    {{if index ', '}}
-    {{#if repositoryCopy.accessUrl}}
-    <ul class="repoid-cell">
-      {{#each repositoryCopy.externalIds as |externalIds|}}
-        <a href="{{repositoryCopy.accessUrl}}" target="_blank">
-          <li title="{{externalIds}}">{{externalIds}}</li>
+{{#each displayIds as |idInfo index|}}
+  <ul class="repoid-cell">
+    {{#if idInfo.url}}
+      {{#each idInfo.ids as |id|}}
+        <a href="{{idInfo.url}}" target="_blank">
+          <li title="{{id.title}}">{{id.display}}</li>
         </a>
       {{/each}}
-    </ul>
     {{else}}
-      <ul class="repoid-cell">
-        {{#each repositoryCopy.externalIds as |externalIds|}}
-          <li title="{{externalIds}}">{{externalIds}}</li>
-        {{/each}}
-      </ul>
+      {{#each idInfo.ids as |id|}}
+        <li title="{{id.title}}">{{id.display}}</li>
+      {{/each}}
     {{/if}}
-  {{else}}
-    <span class="nodata-placeholder">Not available</span>
-  {{/if}}
+  </ul>
 {{else}}
   <span class="nodata-placeholder">Not available</span>
 {{/each}}
-</div>


### PR DESCRIPTION
* Change the minimum widths on columns from px to rem so it scales better with font size
* Add min-width to Repositories column on Submissions table
* Add min-width to Date columns on Grants and Submissions table (#604)
* Truncate long manuscript IDs so they don't spill into next column, show full text as title tag (#631)
* Remove anchor tag when there is no URL for accessUrl (something I noticed while doing these other changes)

Manuscript ID before this PR: 
![image](https://user-images.githubusercontent.com/4070836/41742744-f244c29e-756c-11e8-9000-a8ea64324bbb.png)

After this PR, a long ID will be truncated like this:
![image](https://user-images.githubusercontent.com/4070836/41742418-de55d9ea-756b-11e8-9810-48ead8e98b3d.png)

JScholarship IDs will be displayed like this with a popup ID on hoverover (note that this record will have a link in the final system):
![image](https://user-images.githubusercontent.com/4070836/41751594-20ec2a7e-7590-11e8-8a0a-02f2c1d98c7b.png)

To test long manuscript ID: I used latest `pass-docker` with deposit service, DSpace etc. running. I created a new Submission for JScholarship and it created a long manuscript ID. You can see the change in the Submissions list.