### PR TITLE
Add file size validation

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -45,6 +45,10 @@ export default Component.extend({
           for (let i = 0; i < uploads.files.length; i++) {
             const file = uploads.files[i];
             if (file) {
+              if (file.size > (1024 * 1024 * 100)) {
+                toastr.error(`Your file '${file.name}' is bigger than 100MB (${Number.parseFloat(file.size / 1024 / 1024).toPrecision(3)}MB) and was not added to the submission.`);
+                continue;
+              }
               const newFile = this.get('store').createRecord('file', {
                 name: file.name,
                 mimeType: file.type.substring(file.type.indexOf('/') + 1),

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -18,6 +18,7 @@
   {{/if}}
 {{/each}}
 <p>Attach manuscript/article files to this submission.</p>
+<p>Each individual file must be smaller than 100MB.</p>
 <div class="form-group row">
   <div class="col-md-12">
     <input type="file" id="file-multiple-input" multiple size="50" onchange= {{action "getFiles"}} class="text-gray-300" style="border-width:2px; cursor:pointer; border-style: dashed; padding:30px; width:100%">


### PR DESCRIPTION
Add a note that tells users that files must be smaller than 100MB. If a user tries to upload a file larger than 100MB, alert the user that they have done so, in addition to telling them the name of the too-big file and its size.

* #635 