### PR TITLE
Removes example.org url and link from files review

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -54,7 +54,6 @@ export default Component.extend({
                 mimeType: file.type.substring(file.type.indexOf('/') + 1),
                 description: file.description,
                 fileRole: 'supplemental',
-                uri: 'http://example.com',
                 _file: file
               });
               if (this.get('files').length === 0) {

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -197,7 +197,7 @@
                           {{/if}}
                         </td>
                         <td data-label="name" style="min-width:200px;">
-                          <a href= {{file.uri}}>{{file.name}}</a>
+                          {{file.name}}
                         </td>
                         <td data-label="type" class="text-nowrap">
                           {{file.fileRole}}


### PR DESCRIPTION
This is a hatchet approach for #639. Linking to the files would be more elegant if it's possible, but for now, this prevents the disruption caused by clicking out to example.com mid-workflow and pressing the back button only to have to start over.