### PR TITLE
Update for submission status

### DIFF
--- a/app/components/submission-status-cell.js
+++ b/app/components/submission-status-cell.js
@@ -1,32 +1,14 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  // For specs: https://github.com/OA-PASS/pass-ember/issues/568
+  submissionStatus: service(),
+
   status: Ember.computed('record', function () {
     const submission = this.get('record');
     const repoCopies = this.get('column.repoCopiesMap')[submission.get('id')];
     const deposits = this.get('column.depositsMap')[submission.get('id')];
 
-    if (repoCopies.any(rc => rc.get('copyStatus') == 'stalled')) {
-        return 'Stalled';
-    }
-
-    if (submission.get('source') == 'other' && !submission.get('submitted')) {
-        return 'Manuscript expected';
-    }
-
-    if (repoCopies.get('length') < deposits.get('length')) {
-      if (submission.get('source') == 'pass') {
-        return 'Submitted';
-      }
-    }
-
-    if (repoCopies.get('length') > 0 && repoCopies.get('length') == deposits.get('length')) {
-      if (repoCopies.every(rc => rc.get('copyStatus') == 'complete')) {
-        return 'Complete';
-      }
-    }
-
-    return 'See details';
+    return this.get('submissionStatus').calculateStatus(submission, repoCopies, deposits);
   })
 });

--- a/app/components/submission-status.js
+++ b/app/components/submission-status.js
@@ -1,34 +1,14 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  // For specs: https://github.com/OA-PASS/pass-ember/issues/568
+  submissionStatus: service(),
+
   status: Ember.computed('submission', function () {
     const submission = this.get('submission');
     const repoCopies = this.get('repoCopies');
     const deposits = this.get('deposits');
 
-    // TODO duplicated logic in submission-status-cell
-
-    if (repoCopies.any(rc => rc.get('copyStatus') == 'stalled')) {
-        return 'Stalled';
-    }
-
-    if (submission.get('source') == 'other' && !submission.get('submitted')) {
-        return 'Manuscript expected';
-    }
-
-    if (repoCopies.get('length') < deposits.get('length')) {
-      if (submission.get('source') == 'pass') {
-        return 'Submitted';
-      }
-    }
-
-    if (repoCopies.get('length') > 0 && repoCopies.get('length') == deposits.get('length')) {
-      if (repoCopies.every(rc => rc.get('copyStatus') == 'complete')) {
-        return 'Complete';
-      }
-    }
-
-    return 'See details';
+    return this.get('submissionStatus').calculateStatus(submission, repoCopies, deposits);
   })
 });

--- a/app/components/submission-status.js
+++ b/app/components/submission-status.js
@@ -2,10 +2,12 @@ import Component from '@ember/component';
 
 export default Component.extend({
   // For specs: https://github.com/OA-PASS/pass-ember/issues/568
-  status: Ember.computed('record', function () {
-    const submission = this.get('record');
-    const repoCopies = this.get('column.repoCopiesMap')[submission.get('id')];
-    const deposits = this.get('column.depositsMap')[submission.get('id')];
+  status: Ember.computed('submission', function () {
+    const submission = this.get('submission');
+    const repoCopies = this.get('repoCopies');
+    const deposits = this.get('deposits');
+
+    // TODO duplicated logic in submission-status-cell
 
     if (repoCopies.any(rc => rc.get('copyStatus') == 'stalled')) {
         return 'Stalled';

--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -1,11 +1,15 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
   currentUser: Ember.inject.service('current-user'),
-  columns: [
-    {
+
+  // Columns displayed depend on the user role
+  columns: computed('currentUser', {
+    get() {
+      return [{
       propertyName: 'publicationTitle',
       className: 'title-column',
       title: 'Article',
@@ -34,9 +38,9 @@ export default Controller.extend({
     {
       propertyName: 'aggregatedDepositStatus',
       title: 'Status',
-      filterWithSelect: true,
-      predefinedFilterOptions: ['In Progress', 'Complete'],
-      component: 'submission-status-cell'
+      component: 'submission-status-cell',
+      repoCopiesMap: this.get('model.repoCopiesMap'),
+      depositsMap: this.get('model.depositsMap')
     },
     {
       propertyName: 'repoCopies',
@@ -49,8 +53,8 @@ export default Controller.extend({
       title: 'Actions',
       className: 'actions-column',
       component: 'submission-action-cell'
-    }
-  ],
+    }]
+  }}),
 
   themeInstance: Bootstrap4Theme.create(),
 });

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -17,95 +17,91 @@ export default Controller.extend({
   columns: computed('currentUser', {
     get() {
       if (this.get('currentUser.user.isAdmin')) {
-        return this.get('adminColumns');
+        return [{
+          propertyName: 'publication',
+          title: 'Article',
+          component: 'submissions-article-cell'
+        },
+        {
+          title: 'Award Number (Funder)',
+          className: 'awardnum-funder-column',
+          component: 'submissions-award-cell'
+        },
+        {
+          propertyName: 'repositories',
+          title: 'Repositories',
+          className: 'repositories-column',
+          component: 'submissions-repo-cell'
+        },
+        {
+          propertyName: 'submittedDate',
+          title: 'Submitted Date',
+          className: 'date-column',
+          component: 'date-cell'
+        },
+        {
+          propertyName: 'aggregatedDepositStatus',
+          title: 'Status',
+          repoCopiesMap: this.get('model.repoCopiesMap'),
+          depositsMap: this.get('model.depositsMap')
+        },
+        {
+          // propertyName: 'repoCopies',
+          title: 'Manuscript IDs',
+          component: 'submissions-repoid-cell'
+        }
+      ];
       } else if (this.get('currentUser.user.isSubmitter')) {
-        return this.get('piColumns');
-      }
+        return [{
+          propertyName: 'publicationTitle',
+          className: 'title-column',
+          title: 'Article',
+          component: 'submissions-article-cell'
+        },
+        {
+          title: 'Award Number (Funder)',
+          propertyName: 'grantInfo',
+          className: 'awardnum-funder-column',
+          component: 'submissions-award-cell',
+          disableSorting: true
+        },
+        {
+          propertyName: 'repositoryNames',
+          title: 'Repositories',
+          component: 'submissions-repo-cell',
+          className: 'repositories-column',
+          disableSorting: true
+        },
+        {
+          propertyName: 'submittedDate',
+          title: 'Submitted Date',
+          className: 'date-column',
+          component: 'date-cell'
+        },
+        {
+          propertyName: 'aggregatedDepositStatus',
+          title: 'Status',
+          component: 'submission-status-cell',
+          repoCopiesMap: this.get('model.repoCopiesMap'),
+          depositsMap: this.get('model.depositsMap')
+        },
+        {
+          propertyName: 'repoCopies',
+          className: 'msid-column',
+          title: 'Manuscript IDs',
+          component: 'submissions-repoid-cell',
+          disableSorting: true
+        },
+        {
+          title: 'Actions',
+          className: 'actions-column',
+          component: 'submission-action-cell'
+        }
+      ];
+    } else {
       return [];
-    },
-  }),
-
-  piColumns: [{
-    propertyName: 'publicationTitle',
-    className: 'title-column',
-    title: 'Article',
-    component: 'submissions-article-cell'
-  },
-  {
-    title: 'Award Number (Funder)',
-    propertyName: 'grantInfo',
-    className: 'awardnum-funder-column',
-    component: 'submissions-award-cell',
-    disableSorting: true
-  },
-  {
-    propertyName: 'repositoryNames',
-    title: 'Repositories',
-    component: 'submissions-repo-cell',
-    className: 'repositories-column',
-    disableSorting: true
-  },
-  {
-    propertyName: 'submittedDate',
-    title: 'Submitted Date',
-    className: 'date-column',
-    component: 'date-cell'
-  },
-  {
-    propertyName: 'aggregatedDepositStatus',
-    title: 'Status',
-    filterWithSelect: true,
-    predefinedFilterOptions: ['In Progress', 'Complete'],
-    component: 'submission-status-cell'
-  },
-  {
-    propertyName: 'repoCopies',
-    className: 'msid-column',
-    title: 'Manuscript IDs',
-    component: 'submissions-repoid-cell',
-    disableSorting: true
-  },
-  {
-    title: 'Actions',
-    className: 'actions-column',
-    component: 'submission-action-cell'
-  }
-  ],
-
-  adminColumns: [{
-    propertyName: 'publication',
-    title: 'Article',
-    component: 'submissions-article-cell'
-  },
-  {
-    title: 'Award Number (Funder)',
-    className: 'awardnum-funder-column',
-    component: 'submissions-award-cell'
-  },
-  {
-    propertyName: 'repositories',
-    title: 'Repositories',
-    className: 'repositories-column',
-    component: 'submissions-repo-cell'
-  },
-  {
-    propertyName: 'submittedDate',
-    title: 'Submitted Date',
-    className: 'date-column',
-    component: 'date-cell'
-  },
-  {
-    propertyName: 'aggregatedDepositStatus',
-    title: 'Status',
-    filterWithSelect: true,
-    predefinedFilterOptions: ['In Progress', 'Complete'],
-  },
-  {
-    // propertyName: 'repoCopies',
-    title: 'Manuscript IDs',
-    component: 'submissions-repoid-cell'
-  },
-  ],
+    }
+  }}),
 
   themeInstance: Bootstrap4Theme.create(),
 });

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -21,9 +21,67 @@ export default Route.extend({
     };
     let submissions = this.get('store').query('submission', query);
 
+    // This mapping code is duplicted in submissions/index route.
+
+    // Submission id to array of repoCopy
+    let repoCopiesMap = {};
+
+    // Submission id to array of deposit
+    let depositsMap = {};
+
+    depositsMap = submissions.then(result => {
+      return this.get('store').query('deposit', {
+        from: 0,
+        size: 500,
+        query: {
+          terms : { submission : result.map(s => s.get('id')) }
+        }
+      });
+    }).then(deposits => {
+      let map = {};
+
+      submissions.forEach(s => {
+        map[s.get('id')] = [];
+      });
+
+      deposits.forEach(d => {
+        map[d.get('submission.id')].push(d);
+      });
+
+      return map;
+    });
+
+    repoCopiesMap = submissions.then(result => {
+      return this.get('store').query('repositoryCopy', {
+        from: 0,
+        size: 500,
+        query: {
+          terms: { publication: result.map(s => s.get('publication.id')) }
+        }
+      });
+    }).then(repoCopies => {
+      let map = {};
+
+      submissions.forEach(s => {
+        map[s.get('id')] = [];
+      });
+
+      repoCopies.forEach(rc => {
+        let sub = submissions.find(s => s.get('publication.id') == rc.get('publication.id'));
+
+        if (sub) {
+          map[sub.get('id')].push(rc);
+        }
+      });
+
+      return map;
+    });
+
     return hash({
       grant,
-      submissions
+      submissions,
+      repoCopiesMap,
+      depositsMap
     });
   },
 });

--- a/app/services/submission-status.js
+++ b/app/services/submission-status.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+
+export default Service.extend({
+
+  // Determine the status of a submission given associated repoCopies and deposits.
+  // TODO Document the status semantics and unit test.
+  // Some (out of date?) information https://github.com/OA-PASS/pass-ember/issues/568
+  calculateStatus(submission, repoCopies, deposits) {
+    if (repoCopies.any(rc => rc.get('copyStatus') == 'stalled')) {
+        return 'Stalled';
+    }
+
+    if (submission.get('source') == 'other' && !submission.get('submitted')) {
+        return 'Manuscript expected';
+    }
+
+    if (repoCopies.get('length') == 0) {
+      if (submission.get('source') == 'pass' && submission.get('submitted') ) {
+        return 'Submitted';
+      }
+    }
+
+    if (repoCopies.get('length') > 0 && repoCopies.get('length') == deposits.get('length')) {
+      if (repoCopies.every(rc => rc.get('copyStatus') == 'complete')) {
+        return 'Complete';
+      }
+    }
+
+    if (repoCopies.get('length') > deposits.get('length')) {
+      if (submission.get('source') == 'other' && submission.get('submitted')) {
+        return 'Complete';
+      }
+    }
+
+    return 'See details';
+  }
+});

--- a/app/templates/components/submission-status.hbs
+++ b/app/templates/components/submission-status.hbs
@@ -19,7 +19,6 @@
   }
 </style>
 
-<div class="text-left">
   <span class="status {{status}} pr-1">
     {{#if (eq status "Complete")}}
       <span tooltip-position="left" tooltip="All target repositories have received a copy of the Submission and verified that it is approved for publication">
@@ -42,9 +41,6 @@
       </span>
     {{/if}}
     {{#if (eq status "See details")}}
-      {{#link-to "submissions.detail" record.id}}
-        <i class="fas fa-circle"></i> {{status}}
-      {{/link-to}}
+      <i class="fas fa-circle"></i> See details below
     {{/if}}
   </span>
-</div>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -79,15 +79,7 @@
           <tbody>
             <tr>
               <td class="max-width"><strong>Status</strong></td>
-              {{#if (eq model.sub.source "other")}}
-                {{#if (eq model.sub.submitted true)}}
-                  <td><i>This submission did not originate from PASS.</i></td>
-                {{else}}
-                  <td><i>Your funder is aware of this publication and is expecting the deposit of your manuscript.</i></td>
-                {{/if}}
-              {{else}}
-                <td>{{model.sub.aggregatedDepositStatus}}</td>
-              {{/if}}
+              {{submission-status deposits=model.deposits repoCopies=model.repoCopies submission=model.sub}}
             </tr>
             <tr>
               <td><strong>Grants</strong></td>

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -13,7 +13,7 @@
   <div class="col-12" style="overflow-x: auto;">
     <div class="submission-table">
     {{models-table
-      data=model
+      data=model.submissions
       columns=columns
       themeInstance=themeInstance
       showColumnsDropdown=false

--- a/tests/integration/components/submission-status-test.js
+++ b/tests/integration/components/submission-status-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('submission-status', 'Integration | Component | submission status', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{submission-status}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#submission-status}}
+      template block text
+    {{/submission-status}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/services/submission-status-test.js
+++ b/tests/unit/services/submission-status-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:submission-status', 'Unit | Service | submission status', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
The submissions table, submissions detail page, and grants detail page have their logic for calculating submission status updated. In addition the submissions table will make a constant number of queries instead of being linear to the number of rows.

Due to limited time, there is code duplication in submissions/index and grants/detail routes as well as in the
submissions-status and submissions-status-cell components.

In order to test. Fire up the app login as various users and look at the submission status.

Note that I am not sure the logic is correct!