### PR TITLE
Revert some code style changes that were breaking model relationships

### DIFF
--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -29,14 +29,20 @@ export default Controller.extend({
           repo.get('url') !== 'https://dec.usaid.gov/';
       }));
 
+      /*
+       * Note for the code below, but also Ember in general::::
+       * Seems that calling `obj.set('prop', obj2)` must be used in the case of:
+       *    obj.prop: belongsTo('obj2')
+       * Where calling `obj.set('prop', obj2.get('id'))` will not set the relationship
+       */
       const pub = this.get('model.publication');
       sub.set('aggregatedDepositStatus', 'not-started');
       sub.set('submittedDate', new Date());
       sub.set('submitted', false);
-      sub.set('user', this.get('currentUser.user.id'));
+      sub.set('user', this.get('currentUser.user')); // this.get('currentUser.user.id') seems to break stuff
       sub.set('source', 'pass');
       pub.save().then((p) => {
-        sub.set('publication', p.get('id'));
+        sub.set('publication', p); // p.get('id') seems to break stuff
         let ctr = 0;
         let len = this.get('filesTemp').length;
         sub.set('removeNIHDeposit', false);
@@ -58,7 +64,7 @@ export default Controller.extend({
                 }
               }
               xhr.onload = (results) => {
-                file.set('submission', s.get('id'));
+                file.set('submission', s); // s.get('id') seems to break stuff
                 file.set('uri', results.target.response);
                 file.save().then((f) => {
                   if (f) {


### PR DESCRIPTION
Ember seems to be very ambiguous about how to handle relationships between objects, sometimes resulting in weird errors. While this has no logged ticket, I noticed that new submissions were not appearing in the Submissions table, no matter how long I waited for any indexer update to finish. Turns out that some changes introduced to normalize some code styling broke the way Ember Data saves relationships between objects. Even though Ember models use URIs to reference other model objects, you can't actually set the URI directly, instead it seems Ember expects the full model object.

## Previous behavior

Bugged behavior created new submission objects with no `user` and no `publication`. File objects were also created for each uploaded file in the submission with no `submission` property.

## Testing
* Login as whoever you want that is able to make a submission
* Start a new submission with whatever data, I like using the DOI `abc` because it's easy to remember
* Progress all the way through the submission workflow and click the Submit button at the end.

### Verification

The most direct way to verify this fix is to have the Dev Tools open to the Network tab as you click Submit. That way you can inspect the outbound requests. The 2nd POST after clicking the button should be to `https://pass/fcrepo/rest/submissions`, which is the creation of a new submission in Fedora. Make sure the data in the request body has a non-null value for both `user` and `publication`. 

Inspect another POST to `https://pass/fcrepo/rest/files` - the creation of a file object in Fedora. There should be one of these for each file you upload as part of the submission. The body of this request must have a non-null `submission` property, and it should be equal to the `id` of the newly created submission object.