### PR TITLE
Manually add metadata to submission when not using a DOI

### DIFF
--- a/app/components/metadata-form.js
+++ b/app/components/metadata-form.js
@@ -154,7 +154,8 @@ export default Ember.Component.extend({
       // Validate and check any doi data to make sure its close to the right field
       try {
         this.get('doiInfo')[doiEntry] = this.get('doiInfo')[doiEntry].replace(/(<([^>]+)>)/ig, '');
-        if (doiEntry == 'author') {
+        if (doiEntry == 'author' && this.get('doiInfo.author').length > 0) {
+          // Mark 'author' data read-only only if there already is author data.
           newForm.schema.properties.authors.readonly = true;
           newForm.options.fields.authors.hidden = false;
         } else if (this.get('doiInfo')[doiEntry].length > 0) {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -88,6 +88,9 @@ export default Component.extend({
       if (!this.get('doiInfo.title')) {
         this.set('doiInfo.title', this.get('model.publication.title'));
       }
+      if (!this.get('doiInfo.author')) {
+        this.set('doiInfo.author', []);
+      }
       this.sendAction('next');
     },
     validateDOI() {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -85,11 +85,8 @@ export default Component.extend({
       }
     },
     next() {
-      if (this.get('doiInfo').length === 0) {
-        this.set('doiInfo', {
-          'container-title': this.get('model.publication.journal.journalName'),
-          title: this.get('model.publication.title')
-        });
+      if (!this.get('doiInfo.title')) {
+        this.set('doiInfo.title', this.get('model.publication.title'));
       }
       this.sendAction('next');
     },
@@ -197,7 +194,21 @@ export default Component.extend({
     /** Sets the selected journal for the current publication.
      * @param journal {DS.Model} The journal
      */
-    selectJournal(journal) {
+    async selectJournal(journal) {
+      let doiInfo = this.get('doiInfo');
+      doiInfo = {
+        'journal-title': this.get('model.publication.journal.journalName'),
+        title: this.get('model.publication.title'),
+        ISSN: journal.get('issns')
+      };
+
+      const nlmtaDump = await this.getNlmtaFromIssn(doiInfo);
+      if (nlmtaDump) {
+        doiInfo.nlmta = nlmtaDump.nlmta;
+        doiInfo['issn-map'] = nlmtaDump.map;
+      }
+      this.set('doiInfo', doiInfo);
+
       const publication = this.get('model.publication');
       publication.set('journal', journal);
       $('.ember-power-select-trigger').css('border-color', '#4dbd74');

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -200,8 +200,7 @@ export default Component.extend({
     async selectJournal(journal) {
       let doiInfo = this.get('doiInfo');
       doiInfo = {
-        'journal-title': this.get('model.publication.journal.journalName'),
-        title: this.get('model.publication.title'),
+        'journal-title': journal.get('journalName'),
         ISSN: journal.get('issns')
       };
 

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -42,6 +42,7 @@ export default Component.extend({
         },
         authors: {
           title: '<div class="row"><div class="col-6">Author(s)</div><div class="col-6 p-0">ORCID(s)</div></div>',
+          required: true,
           type: 'array',
           uniqueItems: true,
           items: {
@@ -122,7 +123,7 @@ export default Component.extend({
           hidden: true
         },
         authors: {
-          hidden: true,
+          // hidden: true,
         },
         'under-embargo': {
           type: 'checkbox',

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -1,13 +1,15 @@
 import Component from '@ember/component';
-import _ from 'lodash';
 
 export default Component.extend({
+  metatadaService: Ember.inject.service('metadata-blob'),
+
   init() {
     this._super(...arguments);
     // // TODO:  add validation step here that checks the model each rerender
     // this.set('isValidated', false)
     $('[data-toggle="tooltip"]').tooltip();
   },
+
   externalRepoMap: {},
   // externalSubmission: Ember.computed('metadataBlobNoKeys', function () { // eslint-disable-line
   //   if (this.get('metadataBlobNoKeys').Submission) {
@@ -21,35 +23,8 @@ export default Component.extend({
   metadata: Ember.computed('model.newSubmission.metadata', function () { // eslint-disable-line
     return JSON.parse(this.get('model.newSubmission.metadata'));
   }),
-  metadataBlobNoKeys: Ember.computed('model.newSubmission.metadata', function () { // eslint-disable-line
-    let metadataBlobNoKeys = [];
-    JSON.parse(this.get('model.newSubmission.metadata')).forEach((ele) => {
-      for (var key in ele.data) {
-        if (ele.data.hasOwnProperty(key)) {
-          let strippedData;
-          strippedData = ele.data[key];
-
-          if (key === 'authors') {
-            if (metadataBlobNoKeys['author(s)']) {
-              metadataBlobNoKeys['author(s)'] = _.uniqBy(metadataBlobNoKeys['author(s)'].concat(strippedData), 'author');
-            } else {
-              metadataBlobNoKeys['author(s)'] = strippedData;
-            }
-          } else if (key === 'container-title') {
-            metadataBlobNoKeys['journal-title'] = strippedData;
-          } else {
-            metadataBlobNoKeys[key] = strippedData;
-          }
-        }
-      }
-    });
-    for (var key in metadataBlobNoKeys) {
-      if (metadataBlobNoKeys.hasOwnProperty(key)) {
-        metadataBlobNoKeys[_.capitalize(key)] = metadataBlobNoKeys[key];
-        delete metadataBlobNoKeys[key];
-      }
-    }
-    return metadataBlobNoKeys;
+  metadataBlobNoKeys: Ember.computed('model.newSubmission.metadata', function () {
+    return this.get('metadataService').getDisplayBlob(this.get('model.newSubmission.metadata'));
   }),
   hasVisitedWeblink: Ember.computed('externalRepoMap', function () {
     return Object.values(this.get('externalRepoMap')).every(val => val === true);

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -1,7 +1,7 @@
 import Component from '@ember/component';
 
 export default Component.extend({
-  metatadaService: Ember.inject.service('metadata-blob'),
+  metadataService: Ember.inject.service('metadata-blob'),
 
   init() {
     this._super(...arguments);

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -1,12 +1,14 @@
 import Controller from '@ember/controller';
-import _ from 'lodash';
 
 export default Controller.extend({
+  metadataService: Ember.inject.service('metadata-blob'),
+
   tooltips: function () {
     $(() => {
       $('[data-toggle="tooltip"]').tooltip();
     });
   }.on('init'),
+
   externalSubmission: Ember.computed('metadataBlobNoKeys', function () {
     return this.get('metadataBlobNoKeys').Submission;
   }),
@@ -70,31 +72,6 @@ export default Controller.extend({
     return null;
   }),
   metadataBlobNoKeys: Ember.computed('model.sub.metadata', function () {
-    let metadataBlobNoKeys = [];
-    JSON.parse(this.get('model.sub.metadata')).forEach((ele) => {
-      for (var key in ele.data) {
-        if (ele.data.hasOwnProperty(key)) {
-          let strippedData;
-          strippedData = ele.data[key];
-          if (key === 'authors') {
-            if (metadataBlobNoKeys['author(s)']) {
-              metadataBlobNoKeys['author(s)'] = _.uniqBy(metadataBlobNoKeys['author(s)'].concat(strippedData), 'author');
-            } else {
-              metadataBlobNoKeys['author(s)'] = strippedData;
-            }
-          } else {
-            metadataBlobNoKeys[key] = strippedData;
-          }
-        }
-      }
-    });
-
-    for (var key in metadataBlobNoKeys) {
-      if (metadataBlobNoKeys.hasOwnProperty(key)) {
-        metadataBlobNoKeys[_.capitalize(key)] = metadataBlobNoKeys[key];
-        delete metadataBlobNoKeys[key];
-      }
-    }
-    return metadataBlobNoKeys;
+    return this.get('metadataService').getDisplayBlob(this.get('model.sub.metadata'));
   }),
 });

--- a/app/services/metadata-blob.js
+++ b/app/services/metadata-blob.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import _ from 'lodash';
+
+export default Service.extend({
+  getDisplayBlob(metadataBlob) {
+    let metadataBlobNoKeys = [];
+    JSON.parse(metadataBlob).forEach((ele) => {
+      for (var key in ele.data) {
+        if (ele.data.hasOwnProperty(key)) {
+          let strippedData;
+          strippedData = ele.data[key];
+
+          if (key === 'authors') {
+            if (metadataBlobNoKeys['author(s)']) {
+              metadataBlobNoKeys['author(s)'] = _.uniqBy(metadataBlobNoKeys['author(s)'].concat(strippedData), 'author');
+            } else {
+              metadataBlobNoKeys['author(s)'] = strippedData;
+            }
+          } else if (key === 'container-title') {
+            metadataBlobNoKeys['journal-title'] = strippedData;
+          } else if (key === 'issn-map') {
+            // Do nothing
+          } else {
+            metadataBlobNoKeys[key] = strippedData;
+          }
+        }
+      }
+    });
+    for (var key in metadataBlobNoKeys) {
+      if (metadataBlobNoKeys.hasOwnProperty(key)) {
+        metadataBlobNoKeys[_.capitalize(key)] = metadataBlobNoKeys[key];
+        delete metadataBlobNoKeys[key];
+      }
+    }
+    return metadataBlobNoKeys;
+  }
+});


### PR DESCRIPTION
#655 

* User can now enter author info in the metadata step
* Manually entered article title and journal data is added to the metadata blob
* Manually entered article title and journal info is prepopulated into the metadata step

Addition:
* `issn-map` should not appear in either the submission review _or_ submission details pages

## Testing
* Load up docker and login as normal
* Start a new submission
* ### **Do not enter a DOI** 
* Enter stuff for _article title_ and select a journal. Click Next
* Progress until you get to the Details step. 
  * Article title, Journal ISSN should appear correctly
  * User should be able to add authors here (hint: add a user)
* Progress with the rest of the submission
  * **Make sure you have your developer tools open for you browser, opened to the Network tab**. This way you can monitor the outbound requests
* Click the final Submit button
  * In the dev tools, you will see a `submissions` request. The response of this will have the new submission ID in Fedora. You can directly navigate to this URL to see the submission object in Fedora
* Bring up the specific submission in Fedora and inspect it's `metadata` property - this will be a stringified JSON blob. 
  * Article title, journal name, issn, and issn-map should all be present
  * If you had added an author, that author should also be present