### PR TITLE
Make PASS header point to to static ember page

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,14 +1,14 @@
 <div class="site" style="z-index:0;">
   <header class="primary-skin navbar navbar-expand-xs justify-content-center mb-0">
     <div class={{if fullWidth 'container-fluid' 'container'}}>
-        {{#link-to "index" class="navbar-brand custom-color d-none d-sm-block"}}
+        <a href="/" class="navbar-brand custom-color d-none d-sm-block">
           <h3 class="font-weight-light" >
             Public Access Submission System
           </h3>
-        {{/link-to}}
-        {{#link-to "index" class="navbar-brand custom-color d-xs-block d-sm-none"}}
+        </a>
+        <a href="/" class="navbar-brand custom-color d-xs-block d-sm-none">
           <h3 class="font-weight-light">P.A.S.S.</h3>
-        {{/link-to}}
+        </a>
         <a href="https://jhu.edu"><img src='{{rootURL}}fullSizeLogo.png' alt='Logo' class="nav-item d-sm-down-none pull-right jhu-logo pr-0"></a>
   </div>
   </header>


### PR DESCRIPTION
This is part of proposed integration between static and non-static pages. PASS logo link goes to the static welcome page since the logged in version has some issues to do with timing out and image carousel.

Note that I've left in the original index / welcome route and corresponding test in case we decide to put it back at some point. I just hardcoded links directly on the logo.