### PR TITLE
Various fixes for metadata display relating to 'authors'

### DIFF
--- a/app/components/metadata-form.js
+++ b/app/components/metadata-form.js
@@ -154,8 +154,7 @@ export default Ember.Component.extend({
       // Validate and check any doi data to make sure its close to the right field
       try {
         this.get('doiInfo')[doiEntry] = this.get('doiInfo')[doiEntry].replace(/(<([^>]+)>)/ig, '');
-        if (doiEntry == 'author' && this.get('doiInfo.author').length > 0) {
-          // Mark 'author' data read-only only if there already is author data.
+        if (doiEntry == 'author') {
           newForm.schema.properties.authors.readonly = true;
           newForm.options.fields.authors.hidden = false;
         } else if (this.get('doiInfo')[doiEntry].length > 0) {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -88,9 +88,9 @@ export default Component.extend({
       if (!this.get('doiInfo.title')) {
         this.set('doiInfo.title', this.get('model.publication.title'));
       }
-      if (!this.get('doiInfo.author')) {
-        this.set('doiInfo.author', []);
-      }
+      // if (!this.get('doiInfo.author')) {
+      //   this.set('doiInfo.author', []);
+      // }
       this.sendAction('next');
     },
     validateDOI() {

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -42,7 +42,7 @@ export default Component.extend({
         },
         authors: {
           title: '<div class="row"><div class="col-6">Author(s)</div><div class="col-6 p-0">ORCID(s)</div></div>',
-          required: true,
+          // required: true,
           type: 'array',
           uniqueItems: true,
           items: {
@@ -123,7 +123,7 @@ export default Component.extend({
           hidden: true
         },
         authors: {
-          // hidden: true,
+          hidden: true,
         },
         'under-embargo': {
           type: 'checkbox',

--- a/app/services/metadata-blob.js
+++ b/app/services/metadata-blob.js
@@ -11,10 +11,12 @@ export default Service.extend({
           strippedData = ele.data[key];
 
           if (key === 'authors') {
-            if (metadataBlobNoKeys['author(s)']) {
-              metadataBlobNoKeys['author(s)'] = _.uniqBy(metadataBlobNoKeys['author(s)'].concat(strippedData), 'author');
-            } else {
-              metadataBlobNoKeys['author(s)'] = strippedData;
+            if (Array.isArray(strippedData) && strippedData.length > 0) {
+              if (metadataBlobNoKeys['author(s)']) {
+                metadataBlobNoKeys['author(s)'] = _.uniqBy(metadataBlobNoKeys['author(s)'].concat(strippedData), 'author');
+              } else {
+                metadataBlobNoKeys['author(s)'] = strippedData;
+              }
             }
           } else if (key === 'container-title') {
             metadataBlobNoKeys['journal-title'] = strippedData;


### PR DESCRIPTION
#660

* Don't let user add authors to submission ever
* Don't display 'author(s)' when none exist

This works around the issues found in the ticket by simply not showing the offending pieces :)

## Testing
* Start a new submission
* DO NOT ENTER A DOI
* Enter an article title and journal
* Progress until the Details step
  * **Author(s)** should not appear
* Progress to the review step
  * **Author(s)** should not appear
* Submit
  * The final metadata blob in the submission _should_ have `authors:[]`
* Check the submission details for the new submission
  * **Author(s)** should not appear