### PR TITLE
Try glob matching to grab unencoded grant/submission IDs for the details pages

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -13,10 +13,12 @@ Router.map(function () {
   this.route('about');
   this.route('contact');
   this.route('submissions', function () {
+    this.route('detail', { path: '/*path' });
     this.route('detail', { path: '/:submission_id' });
     this.route('new');
   });
   this.route('grants', function () {
+    this.route('detail', { path: '/*path' });
     this.route('detail', { path: '/:grant_id' });
   });
   this.route('thanks');

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -10,6 +10,26 @@ import { hash } from 'rsvp';
  * is done through the search service (through Store.query)
  */
 export default Route.extend({
+  /**
+   * It is possible for unfortunate things to happen somewhere in the backend stack
+   * that will result in the returned IDs being unencoded. This Route is setup in
+   * the Router to glob match to all '/grants/*'. In the event that unencoded
+   * ID is encountered (it will include slashes), simply encode it and replace the
+   * current history with the encoded version.
+   */
+  beforeModel(transition) {
+    const intent = transition.intent.url;
+    const prefix = '/grants/';
+
+    if (!intent) {
+      return;
+    }
+
+    const targetId = intent.substring(prefix.length);
+    if (targetId.includes('//')) {
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+    }
+  },
   model(params) {
     let grant = this.get('store').findRecord('grant', params.grant_id);
 

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -2,6 +2,26 @@ import Route from '@ember/routing/route';
 import { hash } from 'rsvp';
 
 export default Route.extend({
+  /**
+   * It is possible for unfortunate things to happen somewhere in the backend stack
+   * that will result in the returned IDs being unencoded. This Route is setup in
+   * the Router to glob match to all '/submissions/*'. In the event that unencoded
+   * ID is encountered (it will include slashes), simply encode it and replace the
+   * current history with the encoded version.
+   */
+  beforeModel(transition) {
+    const intent = transition.intent.url;
+    const prefix = '/submissions/';
+
+    if (!intent) {
+      return;
+    }
+
+    const targetId = intent.substring(prefix.length);
+    if (targetId.includes('//')) {
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+    }
+  },
   model(params) {
     const querySize = 500;
     const sub = this.get('store').findRecord('submission', params.submission_id);


### PR DESCRIPTION
Crappy way to check the two `details` paths for unencoded resource IDs. If an unencoded resource ID is found, replace the current browser location with the encoded version. 