### PR TITLE
Bump Docker images to match pass-docker

### DIFF
--- a/.docker/shib/.env
+++ b/.docker/shib/.env
@@ -9,22 +9,37 @@ FEDORA_ADAPTER_ES=https://pass/es/
 
 USER_SERVICE_URL=https://pass/pass-user-service/whoami
 
+# Static html server runtime config
+STATIC_HTML_PORT=82
+
 # Fedora config
 
 FCREPO_HOST=fcrepo
 FCREPO_PORT=8080
 FCREPO_JMS_BASEURL=http://fcrepo:8080/fcrepo/rest
 FCREPO_DEBUG_PORT=5006
-FCREPO_JMS_PORT=61616
-FCREPO_JMS_CONFIGURATION=classpath:/pass-jms.xml
-FCREPO_STOMP_PORT=61613
+FCREPO_JMS_CONFIGURATION=classpath:/pass-jms-external.xml
+FCREPO_JMS_DESTINATION=VirtualTopic.pass.docker
 FCREPO_LOG_LEVEL=INFO
 FCREPO_LOG_JMS=INFO
 FCREPO_HOME=/data
-FCREPO_ACTIVEMQ_CONFIGURATION=classpath:/activemq-queue.xml
+FCREPO_LOGBACK_LOCATION=webapps/fcrepo/WEB-INF/classes/logback.xml
 
+# ActiveMQ Server Config
+ACTIVEMQ_JMS_PORT=61616
+ACTIVEMQ_STOMP_PORT=61613
+ACTIVEMQ_WEBCONSOLE_PORT=8161
+
+#ActiveMQ client config
+SPRING_ACTIVEMQ_BROKER_URL=failover:(tcp://activemq:61616)?trackMessages=true&maxCacheSize=100000000
+SPRING_ACTIVEMQ_USER=messaging
+SPRING_ACTIVEMQ_PASSWORD=moo
+
+# Backend PASS client config
 PASS_FEDORA_BASEURL=http://fcrepo:8080/fcrepo/rest/
 PASS_ELASTICSEARCH_URL=http://elasticsearch:9200
+PASS_FEDORA_USER=fedoraAdmin
+PASS_FEDORA_PASSWORD=moo
 
 # Elasticsearch config
 
@@ -37,7 +52,10 @@ PI_FEDORA_PASS=moo
 PI_FEDORA_INTERNAL_BASE=http://fcrepo:8080/fcrepo/rest/
 PI_ES_BASE=http://elasticsearch:9200/
 PI_ES_INDEX=http://elasticsearch:9200/pass/
-PI_FEDORA_JMS_BROKER=tcp://fcrepo:61616
-PI_FEDORA_JMS_QUEUE=fedora
+PI_FEDORA_JMS_QUEUE=Consumer.indexer.VirtualTopic.pass.docker
 PI_TYPE_PREFIX=http://oapass.org/ns/pass#
 PI_LOG_LEVEL=debug
+
+# Authorization Listener
+PASS_AUTHZ_QUEUE=Consumer.authz.VirtualTopic.pass.docker
+

--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -16,13 +16,11 @@ services:
       - back
 
   fcrepo:
-    image: oapass/fcrepo:4.7.5-2.2-SNAPSHOT-4@sha256:5af64e29c4e0ecc0887c94ab5ea2fe6eea959e0dd30995985d4226b65de951a9
+    image:  oapass/fcrepo:4.7.5-2.2-SNAPSHOT-11@sha256:48e4aa7c6cb5ab384815e1e88e8421f5b6978b52764bcc050781882f188aa3e5
     container_name: fcrepo
     env_file: .env
     ports:
       - "${FCREPO_PORT}:${FCREPO_PORT}"
-      - "${FCREPO_JMS_PORT}:${FCREPO_JMS_PORT}"
-      - "${FCREPO_STOMP_PORT}:${FCREPO_STOMP_PORT}"
       - "${FCREPO_DEBUG_PORT}:${FCREPO_DEBUG_PORT}"
     networks:
       - front
@@ -32,8 +30,30 @@ services:
     depends_on: 
       - assets
 
+  activemq:
+    image: oapass/activemq:20180618@sha256:e3cd47a1bc4c21899fc34e5ac7198f6c069f4148296bad0ce619cc2bdda5f435
+    container_name: activemq
+    env_file: .env
+    ports:
+      - "${ACTIVEMQ_JMS_PORT}:${ACTIVEMQ_JMS_PORT}"
+      - "${ACTIVEMQ_STOMP_PORT}:${ACTIVEMQ_STOMP_PORT}"
+      - "${ACTIVEMQ_WEBCONSOLE_PORT}:${ACTIVEMQ_WEBCONSOLE_PORT}"
+    networks:
+      - front
+      - back
+
+  static-html:
+    image: oapass/static-html:20180629-7a50084@sha256:30805d485830d08161a1d4b4fb73c6c070174cfd529deb6edbcd4ef3dd286022
+    container_name: static-html
+    env_file: .env
+    ports:
+      - "${STATIC_HTML_PORT}:${STATIC_HTML_PORT}"
+    networks:
+      - back
+      - front
+  
   proxy:
-    image: oapass/httpd-proxy:20180609@sha256:d73e25407c5eb20fa2271734cdb0d24db2b4efde941d8706e116bec1198c5d95
+    image: oapass/httpd-proxy:20180622@sha256:423b358d177cb903316b1449ed2d25357137e85a9b3f4d270e30e56354c54c0e
     container_name: proxy
     networks:
      - front
@@ -63,13 +83,13 @@ services:
      - source: idp_sealer
 
   ldap:
-    image: oapass/ldap:20180609@sha256:a90044c91d70735f8a0b10cf63151d109fbb87fd775d48f5bc02a91c04fbd882
+    image: oapass/ldap:201808706@sha256:89cdbc3e91917675d9e3da94447f05b74a8fa0b018965c8d97ff278273ab7971
     container_name: ldap
     networks:
      - back
 
   sp:
-    image: oapass/sp:20180609@sha256:7f2066338cf300d88eb8545b35261f64e1749086a7bed28536f0417f2582056e
+    image: oapass/sp:20180618@sha256:6999dc7a46c3fd3710bb215d562aca12463e8366eead899ec633b84e1456af3a
     container_name: sp
     networks:
      - back
@@ -106,9 +126,17 @@ services:
       - assets
 
   assets:
-    image: birkland/assets:2018-06-19@sha256:5639825b668e982f248d35bb23a5d942a9353ca37c55cba06221e568e8445d88
+    image: birkland/assets:2018-07-06@sha256:2af6f8394e337e31abcf7594c66d03547824a49538aafa6ee688bb4011e8aab5
     volumes:
       - passdata:/data
+
+  authz:
+    image: oapass/authz:0.1.0-2.2-SNAPSHOT@sha256:7b82b6a348794f5aff4b91a90dcfcbeb1a8fbffee6a7e1bd337f12909480a86f
+    container_name: authz
+    env_file: .env
+    networks:
+      - back
+
   
 volumes:
   passdata:


### PR DESCRIPTION
Most notably, this adds the `admin`, and `admin-submitter` users to shibboleth so they can log and have admin and admin+submitter privileges.

Also uses external activemq, and pass authz service, to match `pass-docker`.