### PR TITLE
[do not merge] Add superuser stuff

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -2,7 +2,5 @@ import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
-  isSubmitter: Ember.computed('currentUser', () =>
-    this.get('currentUser.user.roles').includes('submitter'))
+  currentUser: Ember.inject.service('current-user')
 });

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -67,21 +67,21 @@ export default Controller.extend({
       propertyName: 'grant.oapCompliance',
       title: 'Policy Compliance',
       component: 'oap-compliance-cell',
-    },
+    }
   ],
 
-  adminColumns() {
+  adminColumns: computed('commonColumns', function () {
     return this.get('commonColumns');
-  },
+  }),
 
-  submitterColumns() {
+  submitterColumns: computed('commonColumns', function () {
     let cols = this.get('commonColumns');
     cols.push({
       title: 'Actions',
       component: 'grant-action-cell'
     });
     return cols;
-  },
+  }),
 
   themeInstance: Bootstrap4Theme.create(),
 });

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -16,77 +16,17 @@ export default Controller.extend({
   // Columns displayed depend on the user role
   columns: computed('currentUser', {
     get() {
-      const userRoles = this.get('currentUser.user.roles');
-      if (userRoles.includes('admin')) {
+      const user = this.get('currentUser.user');
+      if (user.get('isSubmitter')) {
+        return this.get('submitterColumns');
+      } else if (user.get('isAdmin')) {
         return this.get('adminColumns');
-      } else if (userRoles.includes('submitter')) {
-        return this.get('piColumns');
       }
       return [];
     },
   }),
 
-  // TODO Reduce duplication in column definitions
-  adminColumns: [
-    {
-      propertyName: 'grant.projectName',
-      title: 'Project Name',
-      component: 'grant-link-cell'
-    },
-    {
-      propertyName: 'grant.primaryFunder.name',
-      title: 'Funder',
-      filterWithSelect: true,
-      predefinedFilterOptions: ['NIH', 'DOE', 'NSF'],
-    },
-    {
-      propertyName: 'grant.awardNumber',
-      title: 'Award Number',
-      className: 'awardnum-column',
-      disableFiltering: true,
-      component: 'grant-link-cell'
-    },
-    {
-      title: 'PI',
-      propertyName: 'grant.pi',
-      component: 'pi-list-cell'
-    },
-    {
-      propertyName: 'grant.startDate',
-      title: 'Start',
-      disableFiltering: true,
-      className: 'date-column',
-      component: 'date-cell'
-    },
-    {
-      propertyName: 'grant.endDate',
-      title: 'End',
-      disableFiltering: true,
-      className: 'date-column',
-      component: 'date-cell'
-    },
-    {
-      propertyName: 'grant.awardStatus',
-      title: 'Status',
-      filterWithSelect: true,
-      predefinedFilterOptions: ['Active', 'Ended'],
-    },
-    {
-      propertyName: 'submissions.length',
-      title: 'Submissions count',
-      disableFiltering: true,
-      component: 'grant-link-cell'
-    },
-    {
-      propertyName: 'grant.oapCompliance',
-      title: 'OAP Compliance',
-      component: 'oap-compliance-cell',
-      filterWithSelect: true,
-      predefinedFilterOptions: ['No', 'Yes'],
-    },
-  ],
-
-  piColumns: [
+  commonColumns: [
     {
       propertyName: 'grant.projectName',
       title: 'Project Name',
@@ -128,11 +68,20 @@ export default Controller.extend({
       title: 'Policy Compliance',
       component: 'oap-compliance-cell',
     },
-    {
+  ],
+
+  adminColumns() {
+    return this.get('commonColumns');
+  },
+
+  submitterColumns() {
+    let cols = this.get('commonColumns');
+    cols.push({
       title: 'Actions',
       component: 'grant-action-cell'
-    }
-  ],
+    });
+    return cols;
+  },
 
   themeInstance: Bootstrap4Theme.create(),
 });

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -42,6 +42,7 @@ export default Route.extend({
     let grant = this.get('store').findRecord('grant', params.grant_id);
 
     const query = {
+      sort: ['awardStatus', { endDate: 'desc' }],
       term: {
         grants: params.grant_id
       },

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -68,7 +68,7 @@ export default Route.extend({
   },
 
   getAdminQuery(sort, size) {
-    const grantQuery = {
+    return {
       sort,
       query: {
         range: { endDate: { gte: '2011-01-01' } }
@@ -78,7 +78,7 @@ export default Route.extend({
   },
 
   getSubmitterQuery() {
-    const grantQuery = {
+    return {
       sort,
       query: {
         bool: {

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -30,7 +30,7 @@ export default Route.extend({
     if (user.get('isAdmin')) {
       grantQuery = this.getAdminQuery(defaultSort, querySize);
     } else if (user.get('isSubmitter')) {
-      grantQuery = this.getSubmitterQuery(defaultSort, querySize);
+      grantQuery = this.getSubmitterQuery(defaultSort, querySize, user);
     } else {
       return;
     }
@@ -77,7 +77,7 @@ export default Route.extend({
     };
   },
 
-  getSubmitterQuery() {
+  getSubmitterQuery(sort, size, user) {
     return {
       sort,
       query: {


### PR DESCRIPTION
#681 

* Add checks for `admin` vs `submitter` in various routes
  * `admin` is allowed to see all data (grants and submissions)
  * `submitter` is allowed to see only their data
  * `submitter` is allowed to enter the submission workflow
  * If a user is both `admin` and `submitter` they should be able to see all data AND create submissions

Until paging is implemented, "all" data just means 500 records :(

## Testing
`pass-docker` already has appropriate test data. 

* Edit the `pass-docker` `.env` file
```
  EMBER_GIT_REPO=https://github.com/jabrah/pass-ember
  EMBER_GIT_BRANCH=8537e590d896dcd4a85a2f9c9c69e8eb1e7b0368
```
* Pull appropriate images
* Build the new Ember image: `docker-compose build ember`
* `docker-compose up -d`
* Do testing things
  * Login as `admin-submitter` to test a user with both roles