### PR TITLE
Show 401 error if payload is "Unauthorized"

### DIFF
--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -13,13 +13,10 @@ export default Service.extend({
     } else if (error.message === 'shib302') {
       // Sent from the Fedora adapter to indicate the session has timed out.
       this.handleSessionTimeout(error);
-    } else if (error.status == 401 || error.payload == 401) {
+    } else if (error.status == 401 || error.payload == 401 || error.payload == 'Unauthorized') {
       // Login failure.
       this.handleLoginFailure(error);
     } else if (error.status == 403 || error.payload == 403) {
-      // Some authorization issue
-      this.handleAuthorizationProblem(error);
-    } else if (error.payload == 'Unauthorized') {
       // Some authorization issue
       this.handleAuthorizationProblem(error);
     } else if (error.status == 404) {


### PR DESCRIPTION
This corresponds to a change to add "Unauthorized" to the body of a 401 from the `pass-user-service`.

It has been tested successfully in demo.
