### PR TITLE
Add all error properties to default error msg

### DIFF
--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -53,8 +53,8 @@ export default Service.extend({
   handleUnknownError(error) {
     swal({
       type: 'error',
-      title: 'Something went wrong',
-      text: `${error.message}`
+      title: 'Something went wrong.',
+      text: `${JSON.stringify(error)}`
     });
   }
 });


### PR DESCRIPTION
Previously, the `error.message` would often come back as an unhelpful "undefined". This prints the whole message in the "Something went wrong" box.