### PR TITLE
Add reload on unknown error

### DIFF
--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -62,7 +62,11 @@ export default Service.extend({
     swal({
       type: 'error',
       title: 'Something went wrong.',
-      text: `${JSON.stringify(error)}`
+      text: `When you click OK the page will reload. If the issue persists, please contact us and include a copy of this message. ${JSON.stringify(error)}`
+    }).then((result) => {
+      if (result.value){
+        window.location.reload(true);
+      }
     });
   }
 });


### PR DESCRIPTION
I'm proposing this change for consideration/review. 

Currently, when an unknown error occurs, you click OK and return to the page where the problem originated. This rarely resolves the issue and in fact you often get stuck on the page with the error. I'm proposing this change to reload the app when any unknown error occurs, chances are it will fix the issue.
 
**The risk of implementation?** (1) That you will get stuck in a error message loop if there is an error that is not fixed by a refresh (2) It refreshes a workflow step and you lose your progress - typically an error indicates things are messed up anyway, but that might not be the perception of the user who experiences this.
**The risk of not implementing?** Users are stuck with errors that may be resolved by a simple refresh
**An alternative?** perhaps the popup could give a choice "Do you want to try a reload? this may result in current workflow progress being lost. OK/Cancel"

Let me know what you think