### PR TITLE
Make web linked repositories open correctly in demo

### DIFF
--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -96,8 +96,7 @@ export default WorkflowComponent.extend({
         }
         // Go to the weblink repo
 
-        // this.get('externalRepoMap')[repo.get('id')] = true;
-        this.set(`externalRepoMap.${repo.id}`, true);
+        this.get('externalRepoMap')[repo.get('id')] = true;
         const allLinksVisited = Object.values(this.get('externalRepoMap')).every(val => val === true);
         if (allLinksVisited) {
           this.set('hasVisitedWeblink', true);


### PR DESCRIPTION
PR to _hopefully_ fix #714, or at least not break it more!  This issue only appeared in demo and presumably production. It was not replicated in `pass-docker` and will therefore only be fully verified by testing in demo.

The main identifiable and relevant difference between running this on `pass-docker` vs running on demo is that demo URLs have periods in them, while `pass-docker` runs at `https://pass`.  In the Ember code, periods can result in attempts to bind objects as if it is dot-notation. 

The change in this PR alters the current approach to updating the `externalRepoMap`. Curiously, there was already a line commented out that will hopefully fix the problem, so this change switches to use that. I have verified that using this other line of code does not break anything.

### Testing
Using `pass-docker` the branch should be tested to ensure links open as expected when using the `https://pass` URL i.e. the change doesn't break anything. Note that user `usaid-user` has both an education grant and a USAID grant to test adding two web-linked repositories simultaneously.

Once approved, we need to push a new image to the Docker hub, and test the branch in demo to see if the issue when using URLs with periods in them is now resolved.