### PR TITLE
Use 'pass.local' as the hostname for shib testing

### DIFF
--- a/.docker/shib/.env
+++ b/.docker/shib/.env
@@ -3,12 +3,12 @@
 EMBER_ROOT_URL=/app/
 EMBER_PORT=81
 
-FEDORA_ADAPTER_BASE=https://pass/fcrepo/rest/
+FEDORA_ADAPTER_BASE=https://pass.local/fcrepo/rest/
 FEDORA_ADAPTER_CONTEXT=https://oa-pass.github.io/pass-data-model/src/main/resources/context-2.2.jsonld
 FEDORA_ADAPTER_DATA=http://oapass.org/ns/pass#
-FEDORA_ADAPTER_ES=https://pass/es/
+FEDORA_ADAPTER_ES=https://pass.local/es/
 
-USER_SERVICE_URL=https://pass/pass-user-service/whoami
+USER_SERVICE_URL=https://pass.local/pass-user-service/whoami
 
 # Static html server runtime config
 STATIC_HTML_PORT=82

--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - front
   
   proxy:
-    image: oapass/httpd-proxy:20180622@sha256:423b358d177cb903316b1449ed2d25357137e85a9b3f4d270e30e56354c54c0e
+    image: oapass/httpd-proxy:20180815@sha256:f2aeead1df34ddb8d22b8251a7ef2542f7aedb75952c57a8caecf4c74fd79bb7
     container_name: proxy
     networks:
      - front
@@ -64,7 +64,7 @@ services:
      - "443:443"
 
   idp:
-    image: oapass/idp:20180518@sha256:8fc230e81574161626c8cebd9fda35ae2ff0f8a0c8bce085397972ecb09ce7eb
+    image: oapass/idp:20180815@sha256:8cb8e3ac890200bd1611b1b9c82e3cebf7ace1007e5cdfab36eab3118f70be6b
     container_name: idp
     depends_on:
      - ldap
@@ -90,7 +90,7 @@ services:
      - back
 
   sp:
-    image: oapass/sp:20180618@sha256:6999dc7a46c3fd3710bb215d562aca12463e8366eead899ec633b84e1456af3a
+    image: oapass/sp:20180815@sha256:2882114242a7f3160605b3e0f0adfc348f5b74fe625e1eae8db1bb034200c2a8
     container_name: sp
     networks:
      - back

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ available at https://pass/.
 
 
 * In .docker/shib/ run `docker-compose up`
-  * Fedora repository at https://pass/fcrepo/ 
-  * Elasticsearch index search endpoint at https://pass/es/
+  * Fedora repository at https://pass.local/fcrepo/ 
+  * Elasticsearch index search endpoint at https://pass.local/es/
   * Wait for containers to settle.
   * In order to remove persisted data, stop all the containers and `docker system prune -f`
-* Visit your app at https://pass/
-* Visit your tests at https://pass/tests
-* The local code runs in the `ember` container.
+* Visit your app at https://pass.local/app
+* Visit your tests at https://pass.local/app/tests
+* The local code runs in the`ember container.
 
 Note that ember test will not be able to run tests which make requests to services behind
 the Shibboleth proxy. The ember test client would have to go through the process of getting credentials first.


### PR DESCRIPTION
## Overview
Changes the Docker shib configuration such that the public (proxied) address for pass is `https://pass.local`, rather than `https://pass`.  

## To Test
* Edit your hosts file (`/etc/hosts` or `C:\Windows\System32\Drivers\etc\hosts`) to add entry<pre>127.0.0.1               pass.local</pre>
  * It might be a good idea to remove the entry for `pass`, since it is going away.
* Go to `.docker/shib`, do a `docker-compose pull` then `docker-compose up`
* Go to `https://pass.local` and verify that the static pages work
* Click on the login link or go to `https://pass.local/app` and log in as your favorite shib user (e.g. `nih-user`).  Verify that the PASS app still appears to work

## Interested Parties
@karenhanson, @htpvu 