### PR TITLE
Fix if-statement causing incorrect repo assignment

### DIFF
--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -58,7 +58,7 @@ export default WorkflowComponent.extend({
 
       const shouldAddNIH = this.get('includeNIHDeposit');
       let anyInSubmission = grantRepos.any(grantRepo => this.get('model.newSubmission.repositories').includes(grantRepo));
-      if (shouldAddNIH || !funder.get('policy.title').toUpperCase() === 'National Institutes of Health Public Access Policy') {
+      if (shouldAddNIH || funder.get('policy.title').toUpperCase() !== 'NATIONAL INSTITUTES OF HEALTH PUBLIC ACCESS POLICY') {
         grantRepos.forEach((repo) => {
           repos.addObject({
             repo,


### PR DESCRIPTION
Fix for issue #720, which was caused by incorrect use of JS `!condition`.
Also, fixed case of `policy.title` used in same condition.

### Testing
This can be tested using the `usaid-user`, which has both USAID and NIH grants. You also do not need to select a Method A journal specifically - checking to arrange something with the publisher rather than submitting through PASS provides the same effect