### PR TITLE
Added function to scroll to top when navbars are rendered

### DIFF
--- a/app/components/nav-bar.js
+++ b/app/components/nav-bar.js
@@ -17,7 +17,7 @@ export default Component.extend({
   },
   didRender() {
     this._super(...arguments);
-    if (!window.location.hash) {
+    if (window.location.search.indexOf("anchor=") == -1) {
       window.scrollTo(0,0); 
     }
   }

--- a/app/components/nav-bar.js
+++ b/app/components/nav-bar.js
@@ -15,4 +15,10 @@ export default Component.extend({
       // this.get('session').invalidate();
     },
   },
+  didRender() {
+    this._super(...arguments);
+    if (!window.location.hash) {
+      window.scrollTo(0,0); 
+    }
+  }
 });

--- a/app/components/submission-nav.js
+++ b/app/components/submission-nav.js
@@ -14,4 +14,8 @@ export default Component.extend({
       }
     }
   },
+  didRender() {
+    this._super(...arguments);
+    window.scrollTo(0,0);
+  }
 });

--- a/app/controllers/faq.js
+++ b/app/controllers/faq.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['anchor'],
+  anchor: '',
+  showAnchor: function() {
+    var _this = this;
+    Ember.run.schedule('afterRender', function scrollToAnchor(){
+      var elem = Ember.$(_this.anchorLocation);
+      if (elem.get(0)) {
+        elem.get(0).scrollIntoView(true);
+      }
+    });
+  }.observes('anchorLocation')
+});

--- a/app/router.js
+++ b/app/router.js
@@ -23,7 +23,9 @@ Router.map(function () {
   });
   this.route('thanks');
   this.route('404', { path: '/*path' });
-  this.route('faq');
+  this.route('faq', {
+    queryParams: ['anchor']
+  });
 });
 
 export default Router;

--- a/app/routes/faq.js
+++ b/app/routes/faq.js
@@ -1,4 +1,13 @@
 import CheckSessionRoute from './check-session-route';
 
 export default CheckSessionRoute.extend({
+  queryParams: {
+    anchor: {
+      refreshModel: true
+    }
+  },
+  model: function(params) {
+    var faqController = this.controllerFor('faq');
+    faqController.set('anchorLocation', params.anchor);
+  }
 });

--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -13,7 +13,7 @@
         {{/if}}
         <li class="nav-item">{{#link-to 'about' class='nav-link'}}About{{/link-to}}</li>
         <li class="nav-item">{{#link-to 'contact' class='nav-link'}}Contact{{/link-to}}</li>
-        <li class="nav-item">{{#link-to 'faq' class='nav-link'}}FAQ{{/link-to}}</li>
+        <li class="nav-item">{{#link-to 'faq' (query-params anchor='') class='nav-link'}}FAQ{{/link-to}}</li>
 
         {{!-- {{#if session.isAuthenticated}} --}}
           {{!-- <li class="nav-item dropdown ml-auto">

--- a/app/templates/components/workflow-repositories.hbs
+++ b/app/templates/components/workflow-repositories.hbs
@@ -14,7 +14,7 @@
 {{#if optionalRepositories}}
 <h4 class="mt-3 font-weight-light">Institutional repositories</h4>
 <p class="lead text-muted">
-  A Submission to the following will put you in compliance with your <a href="{{rootURL}}faq#institution-policy" target="_blank">institution's open access policy</a>. If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional.
+  A Submission to the following will put you in compliance with your {{#link-to "faq" (query-params anchor='#institution-policy')}}institution's open access policy{{/link-to}}. If you are already making your publication openly available elsewhere (e.g. PubMed Central), this may be optional.
 </p>
 <div id="local-deposit-list">
   <ul class="list-group">

--- a/app/templates/faq.hbs
+++ b/app/templates/faq.hbs
@@ -28,7 +28,7 @@
     <li>{{#link-to "faq" (query-params anchor='#what-to-expect')}}What should I expect after submitting through PASS?{{/link-to}}</li>
     <li>{{#link-to "faq" (query-params anchor='#publisher-submit')}}Will the publisher automatically submit my article to PubMed Central?{{/link-to}}</li>
     <li>{{#link-to "faq" (query-params anchor='#nih-submissions')}}What information about NIH submissions is pre-loaded into PASS?{{/link-to}}</li>
-    <li>{{#link-to "faq" (query-params anchor='#negotiate-copy')}}How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#negotiate-copyright')}}How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?{{/link-to}}</li>
     <li>{{#link-to "faq" (query-params anchor='#who-can-use')}}Who can use PASS?{{/link-to}}</li>
   </ul>
   <section>

--- a/app/templates/faq.hbs
+++ b/app/templates/faq.hbs
@@ -23,13 +23,13 @@
   </header>
   <p>The following questions are answered on this page. If you have other questions, feel free to {{#link-to 'contact'}}contact us{{/link-to}}</p>
   <ul>
-    <li><a href="{{rootURL}}faq#supported-policies">What Open or Public Access policies can PASS support?</a></li>
-    <li><a href="{{rootURL}}faq#institution-policy">What is JHU's open access policy?</a></li>
-    <li><a href="{{rootURL}}faq#what-to-expect">What should I expect after submitting through PASS?</a></li>
-    <li><a href="{{rootURL}}faq#publisher-submit">Will the publisher automatically submit my article to PubMed Central?</a></li>
-    <li><a href="{{rootURL}}faq#nih-submissions">What information about NIH submissions is pre-loaded into PASS?</a></li>
-    <li><a href="{{rootURL}}faq#negotiate-copyright">How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?</a></li>
-    <li><a href="{{rootUrl}}faq#who-can-use">Who can use PASS?</a></li>
+    <li>{{#link-to "faq" (query-params anchor='#supported-policies')}}What Open or Public Access policies can PASS support?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#institution-policy')}}What is JHU's open access policy?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#what-to-expect')}}What should I expect after submitting through PASS?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#publisher-submit')}}Will the publisher automatically submit my article to PubMed Central?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#nih-submissions')}}What information about NIH submissions is pre-loaded into PASS?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#negotiate-copy')}}How do I negotiate a copyright agreement for my publication to comply with Public/Open Access Policies?{{/link-to}}</li>
+    <li>{{#link-to "faq" (query-params anchor='#who-can-use')}}Who can use PASS?{{/link-to}}</li>
   </ul>
   <section>
     <a id="supported-policies" class="faq-anchor"></a>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -92,5 +92,5 @@
   </h2>
   {{carousel-gallery class="row mb-4 padding-lr-100"}}
   <div class="w-100 text-center">
-    <a href="{{rootURL}}faq#supported-policies" class="btn btn-link mt-1 pl-4 pr-4 ember-view">See full list of policies supported by PASS here</a>
+    {{#link-to "faq" (query-params anchor="#supported-policies") class="btn btn-link mt-1 pl-4 pr-4 ember-view"}}See full list of policies supported by PASS here{{/link-to}}
   </div>

--- a/app/templates/submissions/index.hbs
+++ b/app/templates/submissions/index.hbs
@@ -26,7 +26,7 @@
     {{/if}}
   </div>
 </div>
-<p>This list contains all Submissions that you have initiated through PASS. If you have an NIH grant, it may also contain pre-loaded information about incomplete, in-progress, or completed Submissions to PubMed Central that cite a grant for which you are the PI. Find out more about these pre-loaded NIH submissions on the <a href="{{rootURL}}faq#nih-submissions">FAQ page</a></p>
+<p>This list contains all Submissions that you have initiated through PASS. If you have an NIH grant, it may also contain pre-loaded information about incomplete, in-progress, or completed Submissions to PubMed Central that cite a grant for which you are the PI. Find out more about these pre-loaded NIH submissions on the {{#link-to "faq" (query-params anchor="#nih-submissions")}}FAQ page{{/link-to}}</p>
 <div class="row">
   <div class="col-12" style="overflow-x: auto;">
     <div class="submission-table">

--- a/app/templates/thanks.hbs
+++ b/app/templates/thanks.hbs
@@ -7,5 +7,5 @@
   of all submissions associated to your account, please see
   {{#link-to 'submissions.index' class="btn-link"}}here{{/link-to}}.
 </p>
-<p>To learn more about what to expect from each repository after submitting through PASS, <a href="{{rootURL}}faq#what-to-expect">visit the FAQ page.</a></p>
+<p>To learn more about what to expect from each repository after submitting through PASS, {{#link-to "faq" (query-params anchor="#supported-policies")}}visit the FAQ page.{{/link-to}}</p>
 


### PR DESCRIPTION
This fixes #719.  A script now runs when the workflow navigation bar renders or the top navigation bar renders (which should happen on each new page or workflow step) to set the scroll position to the top of the page.  When going through the workflow or scrolling down the submission page then changing page the user is always returned to the top of the page. This does not affect the scroll when there is a hash in the URL (as with FAQ links).

@htpvu 2 things I wanted to mention. This seems to work, but being unfamiliar with ember I don't know if there is a better way code-wise. Also, note that because the navigation bar tends to load first, sometimes there is a lag in the page content changing when flicking between e.g. grants and submissions - let me know if you think this is unacceptable. There may be a way to improve this. 