### PR TITLE
Style user search modal

### DIFF
--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -7,22 +7,23 @@ export default Component.extend({
   searchInput: '',
   users: [],
   page: 0,
-  pageSize: 50,
+  pageSize: 40,
   totalResults: 0,
   totalPages: Ember.computed('totalResults', 'pageSize', function () {
     return Math.ceil(this.get('totalResults') / this.get('pageSize'));
   }),
   pages: Ember.computed('page', 'pageSize', 'totalResults', 'totalPages', function () {
     let arr = [];
-    for (let i = 1; i <= this.get('totalPages') + 1; i += 1) {
+    for (let i = 1; i <= this.get('totalPages'); i += 1) {
       arr.push(i);
     }
+    // return arr;
   }),
   filteredUsers: Ember.computed('users', function () {
     return this.get('users').filter(u => u.id !== this.get('currentUser.user.id'));
   }),
   previousDisabled: Ember.computed('page', function () {
-    return this.get('page') <= 0;
+    return this.get('page') <= 1;
   }),
   nextDisabled: Ember.computed('page', function () {
     return this.get('page') >= this.get('totalPages');
@@ -32,7 +33,7 @@ export default Component.extend({
       this.toggleProperty('isShowingModal');
     },
     searchForUsers(page) {
-      if (page === null || page === undefined || !page) {
+      if (page === 0 || page === null || page === undefined || !page) {
         page = 1;
       }
       this.set('page', page);
@@ -66,7 +67,7 @@ export default Component.extend({
           title: 'Are you sure?',
           html: 'Picking a new submitter will also <strong>remove all grants</strong> attached to your submission as a security measure. <strong>Any relevant grants will still be able to be re-added.</strong> Are you sure you want to proceed?',
           showCancelButton: true,
-          cancelButtonText: 'Nevermind',
+          cancelButtonText: 'Never mind',
           confirmButtonText: 'Yes, I\'m sure'
         });
         if (result.value) {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -36,7 +36,7 @@ export default WorkflowComponent.extend({
   currentUser: service('current-user'),
   // modal fields
   isShowingModal: false,
-  modalPageSize: 50,
+  modalPageSize: 40,
   modalTotalResults: 0,
   modalUsers: null,
   modalSearchInput: '',

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -805,3 +805,16 @@ footer {
 .complete>.fa-circle, .complete .fa-info-circle {
   color: #00AB8E;
 }
+
+.ember-modal-wrapper.emd-static.emd-wrapper-target-attachment-center .user-search-modal {
+  top: 5rem;
+  left: 50%;
+  transform: translate(-50%);
+  width: 90%;
+  min-width: 20rem;
+  max-width: 60rem;
+}
+
+.user-search-results .col-6 {
+  max-width:100%
+}

--- a/app/templates/components/workflow-basics-user-search.hbs
+++ b/app/templates/components/workflow-basics-user-search.hbs
@@ -1,4 +1,4 @@
-<div style="min-width:600px;min-height:300px;" class="p-4">
+<div style="min-height:300px;" class="p-4">
   <button style="position:absolute;right:15px;top:15px;border:none;" class="btn btn-outline-primary" {{action 'toggleModal'}}>X</button>
   <div class="container">
     <h2>Search Users</h2>
@@ -11,7 +11,7 @@
     </div>
     <h3 class="my-4">Results</h3>
     {{#if filteredUsers}}
-      <div class="row">
+      <div class="row user-search-results">
         {{#each filteredUsers as |user|}}
           <div class="col-6">
             <a href="#" {{action 'pickSubmitter' user}}>

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -96,7 +96,7 @@
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
 <button class="btn btn-primary pull-right next" {{action "validateNext"}}>Next</button>
 {{#if isShowingModal}}
-{{#modal-dialog translucentOverlay=true onClose="toggleModal" close="toggleModal"}}
+{{#modal-dialog translucentOverlay=true onClose="toggleModal" close="toggleModal" containerClass="user-search-modal"}}
   {{workflow-basics-user-search
     model=model
     isShowingModal=isShowingModal


### PR DESCRIPTION
Resolves #757:
1. Overrides default modal styling to prevent the top part of the modal going off the top of the page when it does not fit
2. Reduces the number of results displayed from 50 to 40 to help with display issues
3. Changes the wrapping behavior to work for narrower displays.
4. Fixes a typo in a warning box "Nevermind" -> "Never mind"

What is does not address:
1. There is pagination code that does not work. I made some minor changes to it to see if I could get it to work, but there are more issues that will be addressed in a separate issue #761 
2. There is deeper issue with scrolling when a modal is visible. This PR makes it "good enough" to function but ideally the modal would scroll correctly.