### PR TITLE
Refine action buttons to clearly indicate when user can act on a Submission

### DIFF
--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -6,5 +6,8 @@ export default Component.extend({
     let userId = this.get('currentUser.user.id');
     let preparers = this.get('record.preparers');
     return preparers.map(x => x.id).includes(userId);
+  }),
+  isSubmitter: Ember.computed('currentUser', 'record', function () {
+    return this.get('currentUser.user.id') === this.get('record.submitter.id');
   })
 });

--- a/app/templates/components/submission-action-cell.hbs
+++ b/app/templates/components/submission-action-cell.hbs
@@ -2,12 +2,23 @@
   {{#link-to 'submissions.new' (query-params submission=record.id) class="btn btn-outline-primary"}}
     Finish submission
   {{/link-to}}
+{{else if (and (eq record.submissionStatus 'changes-requested') isSubmitter)}}
+  <span style="min-width: 130px;display: block;"><i>Awaiting changes. No actions available.</i></span>
+{{else if (and (eq record.submissionStatus 'changes-requested') isPreparer)}}
+  {{#link-to 'submissions.new' (query-params submission=record.id) class="btn btn-outline-primary"}}
+    Edit submission
+  {{/link-to}}
+{{else if (and (eq record.submissionStatus 'approval-requested') isSubmitter)}}
+  {{#link-to "submissions.detail" record.id class="btn btn-outline-primary"}}
+    Review submission
+  {{/link-to}}
+{{else if (and (eq record.submissionStatus 'approval-requested') isPreparer)}}
+  <span style="min-width: 130px;display: block;"><i>Awaiting approval. No actions available.</i></span>
+{{else if (and (eq record.submissionStatus 'needs-attention') isSubmitter)}}
+  {{#link-to "submissions.detail" record.id class="btn btn-outline-primary"}}
+    Review submission
+  {{/link-to}}
 {{else}}
-  {{#if (and (eq record.submissionStatus 'changes-requested') isPreparer)}}
-    {{#link-to 'submissions.new' (query-params submission=record.id) class="btn btn-outline-primary"}}
-      Edit submission
-    {{/link-to}}
-  {{else}}
-    <span style="min-width: 130px;display: block;"><i>No actions available.</i></span>
-  {{/if}}
+  <span style="min-width: 130px;display: block;"><i>No actions available.</i></span>
 {{/if}}
+


### PR DESCRIPTION
Resolves #750 
This change ensures an action button in `/submissions/` is available if the user logs in needs to take action on a Submission. Specifically:

Submitter:
*  `approval-requested` -> `Review submission` button
* `changes-requested` -> `Awaiting changes. No action required.` message
* `needs-attention` -> `Review submission` button
* `manuscript-expected` -> `Finish submission` button
* All other statuses  -> `No actions available` message

Preparer:
*  `approval-requested` -> `Awaiting approval. No actions available.` message
* `changes-requested` -> `Edit submission` button
* All other statuses  -> `No actions available` message
