### PR TITLE
DOI lookup fixes

### DIFF
--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -64,6 +64,8 @@
   class=validDOI
   value=model.publication.doi
   keyUp=(action "lookupDOI")
+  mouseUp=(action "lookupDOI")
+  mouseLeave=(action "lookupDOI")
   id="doi"
   placeholder="Leave blank if your manuscript or article has not yet been assigned a DOI"
   readonly=model.newSubmission.id


### PR DESCRIPTION
 - Remove toaster doi lookup message on next
- Cleanup doi lookup error handling so console is not noisy
- Do doi lookup on mouse actions to handle pasting a doi with the mouse

To test, create a new submission and try to paste in a valid DOI with the mouse. Verify that this works. Before this change, the UI will get stuck because the doi lookup would not get triggered.

Closes #769 