### PR TITLE
Fix display of external submissions in detail page

### DIFF
--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -17,7 +17,7 @@
     overflow: hidden;
   }
 
-  .line-height-35 {
+  .line-heightexter-35 {
     line-height: 35px;
   }
 
@@ -115,7 +115,7 @@
               <td>
                 <ul class="list-unstyled">
                   {{#each externalSubmission as |sub|}}
-                  <li>{{sub}}</li>
+                  <li>{{sub.message}}</li>
                   {{/each}}
                 </ul>
               </td>


### PR DESCRIPTION
See #758 for details.

In order to test, create a submission using ed-user that will require submission to ERIC. Go through the whole submission and view the details page. Verify that external submissions are displayed correctly.

Closes #758 