### PR TITLE
Set `link` for all submissionEvents

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -186,7 +186,8 @@ export default Controller.extend({
           performedDate: new Date(),
           comment: this.get('message'),
           performerRole: 'submitter',
-          eventType: 'changes-requested'
+          eventType: 'changes-requested',
+          link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
         });
         se.save().then(() => {
           let sub = this.get('model.sub');
@@ -278,7 +279,8 @@ export default Controller.extend({
                 performedDate: new Date(),
                 comment: this.get('message'),
                 performerRole: 'submitter',
-                eventType: 'submitted'
+                eventType: 'submitted',
+                link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
               });
               se.save().then(() => {
                 let sub = this.get('model.sub');
@@ -335,7 +337,8 @@ export default Controller.extend({
             performedDate: new Date(),
             comment: this.get('message'),
             performerRole: 'submitter',
-            eventType: 'cancelled'
+            eventType: 'cancelled',
+            link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
           });
           se.save().then(() => {
             let sub = this.get('model.sub');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -191,7 +191,7 @@ export default Controller.extend({
           comment: this.get('message'),
           performerRole: 'submitter',
           eventType: 'changes-requested',
-          link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
+          link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
         });
         se.save().then(() => {
           let sub = this.get('model.sub');
@@ -287,7 +287,7 @@ export default Controller.extend({
                 comment: this.get('message'),
                 performerRole: 'submitter',
                 eventType: 'submitted',
-                link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
+                link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
               });
               se.save().then(() => {
                 let sub = this.get('model.sub');
@@ -348,7 +348,7 @@ export default Controller.extend({
             comment: this.get('message'),
             performerRole: 'submitter',
             eventType: 'cancelled',
-            link: `${baseURL}${ENV.rootURL}submissions/${s.id}`
+            link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
           });
           se.save().then(() => {
             let sub = this.get('model.sub');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -174,7 +174,7 @@ export default Controller.extend({
     },
     requestMoreChanges() {
       let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
-      
+
       if (!this.get('message')) {
         swal(
           'Comment field empty',

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -183,6 +183,7 @@ export default Controller.extend({
           'warning'
         );
       } else {
+        let s = this.get('model.sub');
         let se = this.get('store').createRecord('submissionEvent', {
           submission: this.get('model.sub'),
           performedBy: this.get('currentUser.user'),
@@ -278,6 +279,7 @@ export default Controller.extend({
               })));
               $('.block-user-input').css('display', 'block');
               // save sub and send it
+              let s = this.get('model.sub');
               let se = this.get('store').createRecord('submissionEvent', {
                 submission: this.get('model.sub'),
                 performedBy: this.get('currentUser.user'),
@@ -338,6 +340,7 @@ export default Controller.extend({
         showCancelButton: true,
       }).then((result) => {
         if (result.value) {
+          let s = this.get('model.sub');
           let se = this.get('store').createRecord('submissionEvent', {
             submission: this.get('model.sub'),
             performedBy: this.get('currentUser.user'),

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -173,6 +173,8 @@ export default Controller.extend({
       });
     },
     requestMoreChanges() {
+      let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
+      
       if (!this.get('message')) {
         swal(
           'Comment field empty',
@@ -200,6 +202,8 @@ export default Controller.extend({
       }
     },
     async approveChanges() {
+      let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
+
       // First, check if user has visited all required weblinks.
       if (this.get('disableSubmit')) {
         if (!this.get('hasVisitedWeblink')) {
@@ -314,6 +318,8 @@ export default Controller.extend({
       }
     },
     cancelSubmission() {
+      let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
+
       if (!this.get('message')) {
         swal(
           'Comment field empty',

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import ENV from 'pass-ember/config/environment';
 // import swal from 'sweetalert2';
 
 export default Controller.extend({

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -41,7 +41,7 @@ export default Controller.extend({
       subEvent.set('comment', this.get('comment'));
       subEvent.set('performedDate', new Date());
       subEvent.set('submission', s);
-      subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/${s.id}`);
+      subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`));
 
       // If the person clicking submit *is* the submitter, actually submit the submission.
       if (s.get('submitter.id') === this.get('currentUser.user.id')) {

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -35,10 +35,13 @@ export default Controller.extend({
   actions: {
     finishSubmission(s) {
       let subEvent = this.store.createRecord('submissionEvent');
+      let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
+      
       subEvent.set('performedBy', this.get('currentUser.user'));
       subEvent.set('comment', this.get('comment'));
       subEvent.set('performedDate', new Date());
       subEvent.set('submission', s);
+      subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/${s.id}`);
 
       // If the person clicking submit *is* the submitter, actually submit the submission.
       if (s.get('submitter.id') === this.get('currentUser.user.id')) {
@@ -60,8 +63,6 @@ export default Controller.extend({
           subEvent.set('eventType', 'approval-requested-newuser');
           s.set('submitterEmail', `mailto:${this.get('submitterEmail')}`);
           s.set('submitterName', this.get('submitterName'));
-          let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
-          subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/${s.id}`);
         } // end if
       } // end if
 

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -36,7 +36,7 @@ export default Controller.extend({
     finishSubmission(s) {
       let subEvent = this.store.createRecord('submissionEvent');
       let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
-      
+
       subEvent.set('performedBy', this.get('currentUser.user'));
       subEvent.set('comment', this.get('comment'));
       subEvent.set('performedDate', new Date());


### PR DESCRIPTION
Assures that Ember always adds a `link` to SubmissionEvents.

## To test
Notivication services whitelists need tweaking, so the below instructions do not involve looking at any e-mail messages, and can be attempted in `pass-ember`, or `pass-docker`.

***Feel free to test using https://github.com/OA-PASS/pass-docker/pull/163 instead, as it has this PR incorporated into it, and a lot more things work together.  That would be much more pleasant.***

* Start up Ember's docker, or test in pass-docker
* In incognito mode, log in as `staff2`.  Create a proxy submission, search for user `Kirkwood`.
* Close browser, start another incognito session and log in as `nih-user`.  Look at the submissions table, the first one should be the proxy submission.  Look at it, and request changes.
* Close browser, start another incognito session and log in as `staff2`.  Find the proxy submission from the submissions table, and re-submit it for approval
* Close browser..  and log in as `nih-user`.  Either approve or cancel the submission.
* Now go to `http://pass.local:8080/fcrepo/rest/submissionEvents`
  * Foe every submissionEvent, verify that `pass:link` is set.


Resolves #776, #779