### PR TITLE
Refine logic for changing users on basics tab

### DIFF
--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -65,7 +65,7 @@ export default Component.extend({
         let result = await swal({
           type: 'warning',
           title: 'Are you sure?',
-          html: 'Picking a new submitter will also <strong>remove all grants</strong> attached to your submission as a security measure. <strong>Any relevant grants will still be able to be re-added.</strong> Are you sure you want to proceed?',
+          html: 'Changing the submitter will also <strong>remove any grants</strong> currently attached to your submission.  Are you sure you want to proceed?',
           showCancelButton: true,
           cancelButtonText: 'Never mind',
           confirmButtonText: 'Yes, I\'m sure'

--- a/app/templates/components/workflow-wrapper.hbs
+++ b/app/templates/components/workflow-wrapper.hbs
@@ -11,7 +11,7 @@
 <div class="row justify-content-center">
   <main class="col-lg-12">
     {{#if (eq step 1)}}
-    {{workflow-basics submitterEmail=submitterEmail submitterName=submitterName hasProxy=hasProxy model=model
+    {{workflow-basics submitterEmail=submitterEmail submitterName=submitterName maxStep=maxStep hasProxy=hasProxy model=model
     doiInfo=doiInfo next=(action "next") back=(action "back")}}
     {{/if}}
     {{#if (eq step 2)}}


### PR DESCRIPTION
Going from grants tab to basics tab was removing the submitter value, but simply stopping it from removing the submitter value caused problems with grant assignment. Therefore, as well as stopping the submitter from being removed, this PR includes refinement to the logic when flipping between proxy/non-proxy users. Grants are now always removed at the moment the proxy option is changed or a different user selected. Previously it was sometimes done on clicking next, sometimes when selecting or removing a user.

This PR also simplifies the text on the warning message when grants are being removed.

To test, start a submission, add some grants, go back to the basics tab and try to change the user. It should remove any attached grants when you switch user or proxy option. Try different workflows, starting with a proxy then switching to non-proxy, changing between proxy users etc.

Closes #774
