### PR TITLE
Remove URI encoding hack

### DIFF
--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -10,30 +10,6 @@ import { hash } from 'rsvp';
  * is done through the search service (through Store.query)
  */
 export default CheckSessionRoute.extend({
-  /**
-   * It is possible for unfortunate things to happen somewhere in the backend stack
-   * that will result in the returned IDs being unencoded. This Route is setup in
-   * the Router to glob match to all '/grants/*'. In the event that unencoded
-   * ID is encountered (it will include slashes), simply encode it and replace the
-   * current history with the encoded version.
-   *
-   * https://pass/grants/https:%2F%2Fpass%2Ffcrepo%2Frest%2Fgrants%2F07%2F4b%2F32%2Fa5%2F074b32a5-f1e2-4938-8b3d-c63449145c65
-   * https://pass/grants/https://pass/fcrepo/rest/grants/07/4b/32/a5/074b32a5-f1e2-4938-8b3d-c63449145c65
-   */
-  beforeModel(transition) {
-    this._super(transition);
-    const intent = transition.intent.url;
-    const prefix = '/grants/';
-
-    if (!intent) {
-      return;
-    }
-
-    const targetId = intent.substring(prefix.length);
-    if (targetId.includes('https://')) {
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
-    }
-  },
   model(params, transition) {
     if (!params || !params.grant_id) {
       this.get('errorHandler').handleError(new Error('didNotLoadData'));

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -2,27 +2,6 @@ import CheckSessionRoute from '../check-session-route';
 import { hash } from 'rsvp';
 
 export default CheckSessionRoute.extend({
-  /**
-   * It is possible for unfortunate things to happen somewhere in the backend stack
-   * that will result in the returned IDs being unencoded. This Route is setup in
-   * the Router to glob match to all '/submissions/*'. In the event that unencoded
-   * ID is encountered (it will include slashes), simply encode it and replace the
-   * current history with the encoded version.
-   */
-  beforeModel(transition) {
-    this._super(transition);
-    const intent = transition.intent.url;
-    const prefix = '/submissions/';
-
-    if (!intent) {
-      return;
-    }
-
-    const targetId = intent.substring(prefix.length);
-    if (targetId.includes('https://')) {
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
-    }
-  },
   model(params) {
     if (!params || !params.submission_id) {
       this.get('errorHandler').handleError(new Error('didNotLoadData'));


### PR DESCRIPTION
This pr removes a hack in the grants and submissions detail page which checked for an unencoded grant or submission URI and encoded it.

The tests fail because of string template issues. But this is fixed in #785 .