### PR TITLE
eslint fixes

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -191,7 +191,7 @@ export default Controller.extend({
           comment: this.get('message'),
           performerRole: 'submitter',
           eventType: 'changes-requested',
-          link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
+          link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
         });
         se.save().then(() => {
           let sub = this.get('model.sub');
@@ -287,7 +287,7 @@ export default Controller.extend({
                 comment: this.get('message'),
                 performerRole: 'submitter',
                 eventType: 'submitted',
-                link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
+                link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
               });
               se.save().then(() => {
                 let sub = this.get('model.sub');
@@ -349,7 +349,7 @@ export default Controller.extend({
             comment: this.get('message'),
             performerRole: 'submitter',
             eventType: 'cancelled',
-            link: `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`)
+            link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
           });
           se.save().then(() => {
             let sub = this.get('model.sub');

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -41,7 +41,7 @@ export default Controller.extend({
       subEvent.set('comment', this.get('comment'));
       subEvent.set('performedDate', new Date());
       subEvent.set('submission', s);
-      subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/` + encodeURIComponent(`${s.id}`));
+      subEvent.set('link', `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`);
 
       // If the person clicking submit *is* the submitter, actually submit the submission.
       if (s.get('submitter.id') === this.get('currentUser.user.id')) {


### PR DESCRIPTION
Fixes eslint failures, but does not fix a real unit test failure:
```
not ok 144 Chrome 70.0 - Integration | Component | submission status cell: it renders
    ---
        actual: >
            null
        stack: >
            Error: Compile Error: submission-status-cell is not a helper
                at http://localhost:4200/assets/vendor.js:23574:19
                at Compilers.compile (http://localhost:4200/assets/vendor.js:23186:13)
                at expr (http://localhost:4200/assets/vendor.js:23537:25)
                at http://localhost:4200/assets/vendor.js:23275:17
                at Compilers.compile (http://localhost:4200/assets/vendor.js:23186:13)
                at compileStatement (http://localhost:4200/assets/vendor.js:23944:20)
                at compileStatements (http://localhost:4200/assets/vendor.js:23949:13)
                at CompilableTemplate.compileStatic (http://localhost:4200/assets/vendor.js:23974:31)
                at http://localhost:4200/assets/vendor.js:20073:30
                at AppendOpcodes.evaluate (http://localhost:4200/assets/vendor.js:19298:13)
        message: >
            Died on test #1     at Module.callback (http://localhost:4200/assets/tests.js:1279:24)
                at Module.exports (http://localhost:4200/assets/vendor.js:111:32)
                at requireModule (http://localhost:4200/assets/vendor.js:32:18)
                at TestLoader.<anonymous> (http://localhost:4200/assets/test-support.js:11699:11)
                at TestLoader.require (http://localhost:4200/assets/test-support.js:11689:27)
                at TestLoader.loadModules (http://localhost:4200/assets/test-support.js:11681:16)
                at loadTests (http://localhost:4200/assets/test-support.js:13154:22): Compile Error: submission-status-cell is not a helper
        negative: >
            false
        Log: |
    ...
```