### PR TITLE
Encoded uris

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -251,7 +251,7 @@ export default WorkflowComponent.extend({
     validateEmail() {
       const email = this.get('submitterEmail');
       let emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
-      if (email && emailPattern.test(email)) { 
+      if (email && emailPattern.test(email)) {
         this.set('validEmail', 'is-valid');
       } else if (email) {
         this.set('validEmail', 'is-invalid');

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -58,7 +58,6 @@ export default CheckSessionRoute.extend({
   },
 
   _loadCurrentUser(userToken) {
-    console.log(`userToken: ${userToken}`);
     return this.get('currentUser').load(userToken);
   }
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,6 +18,41 @@ export default CheckSessionRoute.extend({
     },
   },
 
+  /**
+   * It is possible for unfortunate things to happen somewhere in the backend stack
+   * that will result in route ids not being encoded.
+   * Therefore we specially handle the /submissions/id and /grants/id routes. In
+   * the event that unencoded ID is encountered (it will include slashes), replace
+   * the current history with the encoded version.
+   */
+  beforeModel(transition) {
+    const intent = transition.intent.url;
+
+    if (!intent) {
+      return;
+    }
+
+    let prefix = null;
+
+    if (intent.startsWith('/grants/')) {
+      prefix = '/grants/';
+    } else if (intent.startsWith('/submissions/')) {
+      prefix = '/submissions/';
+    } else {
+      return;
+    }
+
+    // Ensure that route parameter is encoded
+    if (intent.includes('https://')) {
+      let q = intent.indexOf('?');
+      if (q == -1) {
+        q = intent.length;
+      }
+      const targetId = intent.substring(prefix.length, q);
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+    }
+  },
+
   afterModel(model, transition) {
     return this._loadCurrentUser(transition.queryParams.userToken);
   },

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -28,16 +28,15 @@ export default CheckSessionRoute.extend({
     if (!intent) {
       return;
     }
-    
+
     //encode decoded url, but preserve get properties
     if (intent.includes('https://')) {
       let q = intent.indexOf('?');
       if (q == -1) {
         q = intent.length;
       }
-      
       const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}${intent.substring(q)}`);
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
     }
   },
   model(params, transition) {

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -29,7 +29,7 @@ export default CheckSessionRoute.extend({
       return;
     }
 
-    //encode decoded url, but preserve get properties
+    // encode decoded url, but remove get properties from qs
     if (intent.includes('https://')) {
       let q = intent.indexOf('?');
       if (q == -1) {

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -28,10 +28,16 @@ export default CheckSessionRoute.extend({
     if (!intent) {
       return;
     }
-
-    const targetId = intent.substring(prefix.length);
-    if (targetId.includes('https://')) {
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+    
+    //encode decoded url, but preserve get properties
+    if (intent.includes('https://')) {
+      let q = intent.indexOf('?');
+      if (q == -1) {
+        q = intent.length;
+      }
+      
+      const targetId = intent.substring(prefix.length, q);
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}${intent.substring(q)}`);
     }
   },
   model(params, transition) {

--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -10,35 +10,6 @@ import { hash } from 'rsvp';
  * is done through the search service (through Store.query)
  */
 export default CheckSessionRoute.extend({
-  /**
-   * It is possible for unfortunate things to happen somewhere in the backend stack
-   * that will result in the returned IDs being unencoded. This Route is setup in
-   * the Router to glob match to all '/grants/*'. In the event that unencoded
-   * ID is encountered (it will include slashes), simply encode it and replace the
-   * current history with the encoded version.
-   *
-   * https://pass/grants/https:%2F%2Fpass%2Ffcrepo%2Frest%2Fgrants%2F07%2F4b%2F32%2Fa5%2F074b32a5-f1e2-4938-8b3d-c63449145c65
-   * https://pass/grants/https://pass/fcrepo/rest/grants/07/4b/32/a5/074b32a5-f1e2-4938-8b3d-c63449145c65
-   */
-  beforeModel(transition) {
-    this._super(transition);
-    const intent = transition.intent.url;
-    const prefix = '/grants/';
-
-    if (!intent) {
-      return;
-    }
-
-    // encode decoded url, but remove get properties from qs
-    if (intent.includes('https://')) {
-      let q = intent.indexOf('?');
-      if (q == -1) {
-        q = intent.length;
-      }
-      const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
-    }
-  },
   model(params, transition) {
     if (!params || !params.grant_id) {
       this.get('errorHandler').handleError(new Error('didNotLoadData'));

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -17,16 +17,15 @@ export default CheckSessionRoute.extend({
     if (!intent) {
       return;
     }
+
     //encode decoded url, but preserve get properties
     if (intent.includes('https://')) {
       let q = intent.indexOf('?');
       if (q == -1) {
         q = intent.length;
       }
-
       const targetId = intent.substring(prefix.length, q);
-      const params = intent.substring(q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`, {queryParams: params});
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
     }
   },
   model(params) {

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -17,16 +17,16 @@ export default CheckSessionRoute.extend({
     if (!intent) {
       return;
     }
-    
     //encode decoded url, but preserve get properties
     if (intent.includes('https://')) {
       let q = intent.indexOf('?');
       if (q == -1) {
         q = intent.length;
       }
-      
+
       const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}${intent.substring(q)}`);
+      const params = intent.substring(q);
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`, {queryParams: params});
     }
   },
   model(params) {

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -2,32 +2,6 @@ import CheckSessionRoute from '../check-session-route';
 import { hash } from 'rsvp';
 
 export default CheckSessionRoute.extend({
-  /**
-   * It is possible for unfortunate things to happen somewhere in the backend stack
-   * that will result in the returned IDs being unencoded. This Route is setup in
-   * the Router to glob match to all '/submissions/*'. In the event that unencoded
-   * ID is encountered (it will include slashes), simply encode it and replace the
-   * current history with the encoded version.
-   */
-  beforeModel(transition) {
-    this._super(transition);
-    const intent = transition.intent.url;
-    const prefix = '/submissions/';
-
-    if (!intent) {
-      return;
-    }
-
-    // encode decoded url, but remove get properties from qs
-    if (intent.includes('https://')) {
-      let q = intent.indexOf('?');
-      if (q == -1) {
-        q = intent.length;
-      }
-      const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
-    }
-  },
   model(params) {
     if (!params || !params.submission_id) {
       this.get('errorHandler').handleError(new Error('didNotLoadData'));

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -17,10 +17,16 @@ export default CheckSessionRoute.extend({
     if (!intent) {
       return;
     }
-
-    const targetId = intent.substring(prefix.length);
-    if (targetId.includes('https://')) {
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+    
+    //encode decoded url, but preserve get properties
+    if (intent.includes('https://')) {
+      let q = intent.indexOf('?');
+      if (q == -1) {
+        q = intent.length;
+      }
+      
+      const targetId = intent.substring(prefix.length, q);
+      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}${intent.substring(q)}`);
     }
   },
   model(params) {

--- a/app/routes/submissions/detail.js
+++ b/app/routes/submissions/detail.js
@@ -18,7 +18,7 @@ export default CheckSessionRoute.extend({
       return;
     }
 
-    //encode decoded url, but preserve get properties
+    // encode decoded url, but remove get properties from qs
     if (intent.includes('https://')) {
       let q = intent.indexOf('?');
       if (q == -1) {


### PR DESCRIPTION
There is an issue with passing params, this lops off params rather than tries to add them again
resolves #787. 

You can test by passing in the unencoded version of the link with parameters after. For example, before the fix, links like this would have caused files not to load:
* https://pass.local/app/submissions/https://pass.local/fcrepo/rest/submissions/cc/f7/55/87/ccf75587-d828-4458-9deb-d1ed108d3896?userToken=BRO7QA373FK4LPNEJN3TRZUTO2B24EPQ6BHUJOOX3ZOWZEYMXFYRHMPK35THFHHTN4BCLRCXRIKEOX3AOPWCDIRLRCA6DK3LJXGQTSUKWAYZP23IWVMWF5IHQECOMNMVLHOKJTG2LZWNH7DCTZJZPOTYKM6HDJX65TE53ZGFNBYHGOMHPJB3XZET5HPOTFBQ52LHFJQJM24VQCVVNBVRXR5B3FDCATSYRVR7A2CXDP233VFOAIBAOW6LKBTIMGS7CHM4E3U7RHD5H4W2QQX5GUU5JQ
* https://pass.local/app/submissions/https://pass.local/fcrepo/rest/submissions/cc/f7/55/87/ccf75587-d828-4458-9deb-d1ed108d3896?foo=bar 

Now, these should load the details page fine, but you will note that the parameters are no longer visible in the URL.