### PR TITLE
Fix test file name

### DIFF
--- a/tests/integration/components/submissions-status-cell-test.js
+++ b/tests/integration/components/submissions-status-cell-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('submission-status-cell', 'Integration | Component | submission status cell', {
+moduleForComponent('submissions-status-cell', 'Integration | Component | submissions status cell', {
   integration: true
 });
 
@@ -9,9 +9,9 @@ test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{submission-status-cell submissionStatus="submitted"}}`);
+  this.render(hbs`{{submissions-status-cell submissionStatus="submitted"}}`);
   assert.ok(true);
 
   // Template block usage:
-  // this.render(hbs`{{submission-status-cell status=""}}`);
+  // this.render(hbs`{{submissions-status-cell status=""}}`);
 });


### PR DESCRIPTION
When the component name `submission-status-cell.js` was changed to `submissions-status-cell.js` the test name was not updated. This fixed that problem.