### PR TITLE
Fix user search pagination code

### DIFF
--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -6,18 +6,18 @@ export default Component.extend({
   currentUser: Ember.inject.service('current-user'),
   searchInput: '',
   users: [],
-  page: 0,
-  pageSize: 40,
+  page: 1,
+  pageSize: 30,
   totalResults: 0,
   totalPages: Ember.computed('totalResults', 'pageSize', function () {
     return Math.ceil(this.get('totalResults') / this.get('pageSize'));
   }),
-  pages: Ember.computed('page', 'pageSize', 'totalResults', 'totalPages', function () {
+  pages: Ember.computed('totalPages', function () {
     let arr = [];
     for (let i = 1; i <= this.get('totalPages'); i += 1) {
       arr.push(i);
     }
-    // return arr;
+    return arr;
   }),
   filteredUsers: Ember.computed('users', function () {
     return this.get('users').filter(u => u.id !== this.get('currentUser.user.id'));

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -32,7 +32,7 @@ export default WorkflowComponent.extend({
   currentUser: service('current-user'),
   // modal fields
   isShowingModal: false,
-  modalPageSize: 40,
+  modalPageSize: 30,
   modalTotalResults: 0,
   modalUsers: null,
   modalSearchInput: '',

--- a/app/templates/components/workflow-basics-user-search.hbs
+++ b/app/templates/components/workflow-basics-user-search.hbs
@@ -25,20 +25,13 @@
     {{/if}}
     {{#if pages}}
     <ul class="pagination mt-4 mx-auto mb-0 pb-0" style="justify-content:center;">
-      <li>
-        <a href="#" {{if (eq page 1) "disabled"}} aria-label="Previous">
-          <span aria-hidden="true">&laquo;</span>
-        </a>
-      </li>
       {{#each pages as |p|}}
-      {{!-- TODO: if page === p, disable the button --}}
-        <li {{if (eq p page) 'class="active"'}}><a href="#" {{action 'searchUsers' p}}>{{p}}</a></li>
+        {{#if (eq p page)}}
+          <li class="active"><a>{{p}}</a></li>
+        {{else}}
+          <li><a href="#" {{action 'searchForUsers' p}}>{{p}}</a></li>
+        {{/if}}
       {{/each}}
-      <li>
-        <a href="#" {{if (eq page totalPages) "disabled"}} aria-label="Next">
-          <span aria-hidden="true">&raquo;</span>
-        </a>
-      </li>
     </ul>
     {{/if}}
   </div>


### PR DESCRIPTION
Previously the buttons were not appearing in the search results modal. This fixes the pagination. It also lowers the number of users displayed per page to reduce the impact of the fact the modal will not scroll.

resolves #761 