### PR TITLE
Avoid stripping out preparers, better proxy checking

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -172,7 +172,7 @@ export default WorkflowComponent.extend({
       const proxySubmitterExists = submitterExists && currentUserIsNotSubmitter;
 
       if (!proxySubmitterInfoExists && !proxySubmitterExists) {
-        this.set('model.newSubmission.preparers', Ember.A());
+        // this.set('model.newSubmission.preparers', Ember.A());
       }
 
       // A journal and title must be present

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -171,10 +171,6 @@ export default WorkflowComponent.extend({
       const submitterExists = this.get('model.newSubmission.submitter.id');
       const proxySubmitterExists = submitterExists && currentUserIsNotSubmitter;
 
-      if (!proxySubmitterInfoExists && !proxySubmitterExists) {
-        // this.set('model.newSubmission.preparers', Ember.A());
-      }
-
       // A journal and title must be present
       if (!journal.get('id')) {
         toastr.warning('The journal must not be left blank');

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -429,19 +429,22 @@ export default WorkflowComponent.extend({
           });
         }
 
-        // Add metadata for external submissions
+        // Add metadata for external submissions only if the user is the submitter
         const externalRepos = this.get('model.newSubmission.repositories').filter(repo =>
           repo.get('integrationType') === 'web-link');
-        if (!this.get('hasProxy') && externalRepos.get('length') > 0) {
+
+        if (this.get('model.newSubmission.submitter.id') === this.get('currentUser.user.id') &&
+          externalRepos.get('length') > 0) {
           let md = { id: 'external-submissions', data: { submission: [] } };
           externalRepos.forEach(repo => md.data.submission.push({
             message: `Deposit into ${repo.get('name')} was prompted`,
             name: repo.get('name'),
             url: repo.get('url')
           }));
-          // Push this new thing to the overall 'metadata' obj
+
           metadata.push(md);
         }
+
         this.set('model.newSubmission.metadata', JSON.stringify(metadata));
         this.sendAction('next');
       }

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -48,6 +48,11 @@ export default Controller.extend({
         s.set('submitted', true);
         s.set('submissionStatus', 'submitted');
         s.set('submittedDate', new Date());
+        s.set(
+          'repositories',
+          s.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
+        );
+
         subEvent.set('performerRole', 'submitter');
         subEvent.set('eventType', 'submitted');
       } else {
@@ -93,13 +98,6 @@ export default Controller.extend({
       sub.set('source', 'pass');
       sub.set('removeNIHDeposit', false);
       sub.set('aggregatedDepositStatus', 'not-started');
-
-      if (!this.get('hasProxy')) {
-        sub.set(
-          'repositories',
-          sub.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
-        );
-      }
 
       this.set('uploading', true);
       this.set('waitingMessage', 'Saving your submission');


### PR DESCRIPTION
This pr comments out a check that strips preparers. It is triggered when an approver tries to edit a submission. It is unclear to me what the check was trying to do.

Other changes include more precise checking for a proxy in the new submission route when handling external-submissions metadata and stripping out web-link repositories.