### PR TITLE
Fixed submitter repository approval workflow

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -251,7 +251,7 @@ export default WorkflowComponent.extend({
     validateEmail() {
       const email = this.get('submitterEmail');
       let emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
-      if (email && emailPattern.test(email)) { 
+      if (email && emailPattern.test(email)) {
         this.set('validEmail', 'is-valid');
       } else if (email) {
         this.set('validEmail', 'is-invalid');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -263,16 +263,19 @@ export default Controller.extend({
         return;
       }
 
-      let reposWithAgreementText = this.get('model.repos').filter(repo =>
-        repo.get('integrationType') !== 'web-link').map((repo) => {
-        if (repo.get('agreementText')) {
-          return {
-            id: repo.get('name'),
-            title: `Deposit requirements for ${repo.get('name')}`,
-            html: `<textarea rows="16" cols="40" name="embargo" class="alpaca-control form-control disabled" disabled="" autocomplete="off">${repo.get('agreementText')}</textarea>`
-          };
-        }
-      });
+      let reposWithAgreementText = this.get('model.repos')
+        .filter(repo => (repo.get('integrationType') !== 'web-link') && repo.get('agreementText'))
+        .map(repo => ({
+          id: repo.get('name'),
+          title: `Deposit requirements for ${repo.get('name')}`,
+          html: `<textarea rows="16" cols="40" name="embargo" class="alpaca-control form-control disabled" disabled="" autocomplete="off">${repo.get('agreementText')}</textarea>`
+        }));
+
+      let reposWithoutAgreementText = this.get('model.repos')
+        .filter(repo => repo.get('integrationType') !== 'web-link' && !repo.get('agreementText'))
+        .map(repo => ({
+          id: repo.get('name')
+        }));
       // INFO: this is used to testing more then 1 repo.
       // reposWithAgreementText.push({
       //   id: 'some',
@@ -294,10 +297,10 @@ export default Controller.extend({
           }
         });
         // make sure there are repos to submit to.
-        if (reposThatUserAgreedToDeposit.length > 0 && this.get('model.sub.repositories.length') > 0) {
+        if ((reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length > 0) && this.get('model.sub.repositories.length') > 0) {
           swal({
-            title: 'You agree to deposit to the following repositories',
-            html: `Your repositories: <pre><code> ${JSON.stringify(reposThatUserAgreedToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')} </code></pre>`, // eslint-disable-line
+            title: 'You are about to submit to:',
+            html: `<pre><code> ${JSON.stringify(reposThatUserAgreedToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')} ${JSON.stringify(reposWithoutAgreementText.map(repo => repo.id)).replace(/[\[\]']/g, '')} </code></pre>`, // eslint-disable-line
             confirmButtonText: 'Submit',
             showCancelButton: true,
           }).then((result) => {


### PR DESCRIPTION
This changes the popup workflow when a submitter is approving a Submission:
* It no longer shows a blank agreement box and fails when PubMed Central is assigned to the Submission
* The "you are about to Submit.." message now includes all submissions you are submitting to, not just the ones you signed agreementText for.

Closes #798 
Closes #783

![image](https://user-images.githubusercontent.com/4070836/48368967-24f5e880-e683-11e8-9940-6e949f36a6d2.png)

![image](https://user-images.githubusercontent.com/4070836/48369021-553d8700-e683-11e8-9848-e66a3ddb63fe.png)
