### PR TITLE
Enable the spinner in more situations

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -251,7 +251,7 @@ export default WorkflowComponent.extend({
     validateEmail() {
       const email = this.get('submitterEmail');
       let emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
-      if (email && emailPattern.test(email)) { 
+      if (email && emailPattern.test(email)) {
         this.set('validEmail', 'is-valid');
       } else if (email) {
         this.set('validEmail', 'is-invalid');

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -236,6 +236,7 @@ export default Controller.extend({
           eventType: 'changes-requested',
           link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
         });
+        $('.block-user-input').css('display', 'block');
         se.save().then(() => {
           let sub = this.get('model.sub');
           sub.set('submissionStatus', 'changes-requested');
@@ -414,6 +415,7 @@ export default Controller.extend({
             eventType: 'cancelled',
             link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
           });
+          $('.block-user-input').css('display', 'block');
           se.save().then(() => {
             let sub = this.get('model.sub');
             sub.set('submissionStatus', 'cancelled');


### PR DESCRIPTION
Enables the spinner (which disables user input) when requesting changes, cancelling, or submitting

Known issues:  #798 prevents certain kinds of testing of this PR.  However, if you submit to _just_ jscholarship, you can successfully make the submission, and see the spinner in that case 

Resolves #800 
