### PR TITLE
Displays new user submitter name on Submission details page

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -31,7 +31,7 @@ export default Controller.extend({
     }
   ),
   /**
-   * Ugly way to generate date for the template to use.
+   * Ugly way to generate data for the template to use.
    * {
    *    'repository-id': {
    *      repo: { }, // repository obj
@@ -190,6 +190,24 @@ export default Controller.extend({
       );
     }
   ),
+  displaySubmitterName: Ember.computed('model.sub', function () {
+    if (this.get('model.sub.submitter.displayName')) {
+      return this.get('model.sub.submitter.displayName');
+    } else if (this.get('model.sub.submitter.firstName')) {
+      return `${this.get('model.sub.submitter.firstName')} ${this.get('model.sub.submitter.lastName')}`;
+    } else if (this.get('model.sub.submitterName')) {
+      return this.get('model.sub.submitterName');
+    }
+    return '';
+  }),
+  displaySubmitterEmail: Ember.computed('model.sub', function () {
+    if (this.get('model.sub.submitter.email')) {
+      return this.get('model.sub.submitter.email');
+    } else if (this.get('model.sub.submitterEmail')) {
+      return this.get('model.sub.submitterEmail').replace('mailto:', '');
+    }
+    return '';
+  }),
   actions: {
     openWeblinkAlert(repo) {
       swal({

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -132,13 +132,11 @@
               <td>
                 {{#if (eq model.sub.source "other")}}
                 <i>This submission did not originate from PASS</i>
-                {{else if (await model.sub.submitter)}}
-                {{get (await model.sub.submitter) 'displayName'}}
-                {{#if (get (await model.sub.submitter) 'institutionalId')}}
-                ({{get (await model.sub.submitter) 'institutionalId'}})
+                {{else if displaySubmitterName}}
+                {{displaySubmitterName}}
                 {{/if}}
-                {{else}}
-                {{model.sub.submitterName}}
+                {{#if displaySubmitterEmail}}
+                &nbsp;(<a href="mailto:{{displaySubmitterEmail}}">{{displaySubmitterEmail}}</a>)
                 {{/if}}
               </td>
             </tr>
@@ -147,6 +145,9 @@
               <td>
                 {{#each (await model.sub.preparers) as |preparer index|}}
                 {{#if index}}, {{/if}} {{get (await preparer) 'displayName'}}
+                {{#if (get (await preparer) 'email')}}
+                &nbsp;(<a href="mailto:{{get (await preparer) 'email'}}">{{get (await preparer) 'email'}}</a>)
+                {{/if}}
                 {{/each}}
               </td>
             {{/if}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -132,11 +132,13 @@
               <td>
                 {{#if (eq model.sub.source "other")}}
                 <i>This submission did not originate from PASS</i>
-                {{else}}
+                {{else if (await model.sub.submitter)}}
                 {{get (await model.sub.submitter) 'displayName'}}
                 {{#if (get (await model.sub.submitter) 'institutionalId')}}
                 ({{get (await model.sub.submitter) 'institutionalId'}})
                 {{/if}}
+                {{else}}
+                {{model.sub.submitterName}}
                 {{/if}}
               </td>
             </tr>


### PR DESCRIPTION
When a submission does not yet have a submitter uri, the Submission details page was showing "submitter" as blank. This does two things:

1. Displays the `submitterName` and `submitterEmail` when there is no `submitter`. 
2. Removes `institutionalId` as it is no longer available on the User record, and instead displays the `User.email` of the submitter

At minimum, submission details pages for the following 3 scenarios should be looked at:
1. Submission with existing submitter and preparer
2. Submission with new submitter and preparer
3. Submission with manuscript expected status

Close #792 