### PR TITLE
Fixes policy page logic to show radio buttons for policies using PMC

### DIFF
--- a/.docker/shib/docker-compose.yml
+++ b/.docker/shib/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     depends_on:
       - assets
   assets:
-    image: birkland/assets:2018-11-07_3.2@sha256:5043faf1e43505e45c013e8f0542b7494ddd6379bcf3714607a42f48bd1f4f3e
+    image: birkland/assets:2018-11-13_3.2@sha256:60310d68c7ab910096f471bf6636b35487c52ab6db970fc280959f49eec0f465
     volumes:
       - passdata:/data
 

--- a/app/components/policy-card.js
+++ b/app/components/policy-card.js
@@ -1,15 +1,12 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  // checks if the radio buttons need to be displayed
+  usesPmcRepository: Ember.computed('policy.repositories', function () {
+    return this.get('policy.repositories') ? (this.get('policy.repositories').filter(repo => repo.get('repositoryKey') === 'pmc').length > 0) : false;
+  }),
   methodAJournal: Ember.computed('journal', function () {
     return this.get('journal.isMethodA');
-  }),
-  policyIsNIH: Ember.computed('policy', function () {
-    return this.get('policy.title') === 'National Institutes of Health Public Access Policy';
-  }),
-  // checks if the radio buttons need to be displayed
-  nihAndNotMethodAJournal: Ember.computed(function () { // eslint-ignore-line
-    return this.get('policyIsNIH') && !this.get('methodAJournal');
   }),
   policyIsJHU: Ember.computed(function () { // eslint-ignore-line
     return this.get('policy.title') === 'Johns Hopkins University (JHU) Open Access Policy';

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -25,6 +25,9 @@ export default WorkflowComponent.extend({
     }
     return '';
   },
+  usesPmcRepository(policyRepos) {
+    return policyRepos ? (policyRepos.filter(repo => repo.get('repositoryKey') === 'pmc').length > 0) : false;
+  },
   requiredRepositories: Ember.computed('model.repositories', function () {
     const grants = this.get('model.newSubmission.grants');
     let repos = Ember.A();
@@ -42,7 +45,7 @@ export default WorkflowComponent.extend({
 
       const shouldAddNIH = this.get('includeNIHDeposit');
       let anyInSubmission = grantRepos.any(grantRepo => this.get('model.newSubmission.repositories').includes(grantRepo));
-      if (shouldAddNIH || funder.get('policy.title').toUpperCase() !== 'NATIONAL INSTITUTES OF HEALTH PUBLIC ACCESS POLICY') {
+      if (shouldAddNIH || !this.usesPmcRepository(grantRepos)) {
         grantRepos.forEach((repo) => {
           repos.addObject({
             repo,

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -12,7 +12,7 @@ export default DS.Model.extend({
   agreementText: DS.attr('string', {
     defaultValue: false
   }),
-
+  repositoryKey: DS.attr('string')
   // policy: DS.belongsTo('policy'),
   // submissions: DS.hasMany('submission', { async: true }),
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -5,15 +5,15 @@ export default DS.Model.extend({
    * (Required)
    */
   username: DS.attr('string'),
-  displayName: DS.attr('string'),
   firstName: DS.attr('string'),
   middleName: DS.attr('string'),
   lastName: DS.attr('string'),
+  displayName: DS.attr('string'),
   email: DS.attr('string'),
 
-  institutionalId: DS.attr('string'),
-  orcidId: DS.attr('string'),
   affiliation: DS.attr('string'),
+  locatorIds: DS.attr('set'),
+  orcidId: DS.attr('string'),
   /** Possible values: admin, submitter */
   roles: DS.attr('set'),
 

--- a/app/templates/components/policy-card.hbs
+++ b/app/templates/components/policy-card.hbs
@@ -21,8 +21,8 @@
         {{/if}}
 
         <br><br>
-        {{#if (or (eq policy.title 'National Institutes of Health Public Access Policy') (eq policy.title 'NIH'))}}
-          {{#if journal.isMethodA}}
+        {{#if usesPmcRepository}}
+          {{#if methodAJournal}}
             <div class="alert alert-success">
               The journal you published in participates in the PMC Method A program, and will submit the published article to PMC on your behalf.
               <em>You do not need to submit a manuscript to NIH Manuscript Submission System (NIHMS) as a part of this
@@ -33,7 +33,6 @@
               <p>Some journals would submit your article to PMC on your behalf, for a fee. Specific arrangements would be required. Please indicate below whether or not you have made an arrangement with the publisher to have your article deposited by your
                 journal/publisher.
               </p>
-              {{#if nihAndNotMethodAJournal}}
                 {{radio-button value=true name='removeNIHDeposit' checked=model.newSubmission.removeNIHDeposit}}
                 I have made (or intend to make) an arrangement with the publisher to
                 deposit my article directly to PMC. (You will not need to submit your
@@ -43,7 +42,6 @@
                 I will not make an arrangement with the publisher to deposit my article
                 directly to PMC. (You will need to submit your manuscript to NIHMS as
                 part of this process.)
-              {{/if}}
             </div>
           {{/if}}
         {{/if}}


### PR DESCRIPTION
The logic that displays the radio button on the policy page now applies to any policy that uses PMC as its repository. This uses the new `repositoryKey` value, and so an updated `assets` image is referenced with that value populated.

Includes a couple of updates to the model:
* adds `Repository.repositoryKey` - this fix needs the assets container that has these values
* removes `User.institutionalId` (I verified that nothing references this)
* adds `User.locatorIds`

closes #790