### PR TITLE
Allows you to scroll on the user search popup modal, removes page buttons if one page

### DIFF
--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -19,6 +19,9 @@ export default Component.extend({
     }
     return arr;
   }),
+  moreThanOnePage: Ember.computed('pages', function () {
+    return (this.get('pages') ? (this.get('pages').length > 1) : false);
+  }),
   filteredUsers: Ember.computed('users', function () {
     return this.get('users').filter(u => u.id !== this.get('currentUser.user.id'));
   }),

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -809,16 +809,12 @@ footer {
 .complete>.fa-circle, .complete .fa-info-circle {
   color: #00AB8E;
 }
-
-.ember-modal-wrapper.emd-static.emd-wrapper-target-attachment-center .user-search-modal {
-  top: 5rem;
-  left: 50%;
-  transform: translate(-50%);
+.ember-modal-dialog.user-search-modal {
   width: 90%;
   min-width: 20rem;
   max-width: 60rem;
+  min-height: 25rem; 
 }
-
 .user-search-results .col-6 {
   max-width:100%
 }

--- a/app/templates/components/workflow-basics-user-search.hbs
+++ b/app/templates/components/workflow-basics-user-search.hbs
@@ -23,7 +23,7 @@
       {{else}}
       <p>No results found.</p>
     {{/if}}
-    {{#if pages}}
+    {{#if moreThanOnePage }}
     <ul class="pagination mt-4 mx-auto mb-0 pb-0" style="justify-content:center;">
       {{#each pages as |p|}}
         {{#if (eq p page)}}

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -1,6 +1,6 @@
 {{yield}}
 {{#unless (or model.newSubmission.id model.preLoadedGrant)}}
-<div class="py-0 mt-2 alert alert-secondary">
+<div class="py-0 mt-2 alert alert-secondary" id="on-behalf-of-block">
   <p class="my-2 lead">I'm creating this submission on behalf of:
     {{radio-button class="ml-3 mr-1" value=false name='showProxyWindow' checked=model.newSubmission.hasNewProxy}} Myself
     {{radio-button class="ml-3 mr-1" value=true name='showProxyWindow' checked=model.newSubmission.hasNewProxy}} Someone
@@ -98,7 +98,14 @@
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
 <button class="btn btn-primary pull-right next" {{action "validateNext"}}>Next</button>
 {{#if isShowingModal}}
-{{#modal-dialog translucentOverlay=true onClose="toggleModal" close="toggleModal" containerClass="user-search-modal"}}
+{{#modal-dialog 
+   translucentOverlay=true 
+   onClose="toggleModal" 
+   close="toggleModal" 
+   tetherTarget='#on-behalf-of-block'
+   attachment='top center'
+   targetAttachment='top center'
+   containerClass='user-search-modal'}}
   {{workflow-basics-user-search
     model=model
     isShowingModal=isShowingModal

--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,6 +2320,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -4029,16 +4030,6 @@
         "ember-cli-babel": "6.16.0"
       }
     },
-    "ember-concurrency": {
-      "version": "0.8.19",
-      "resolved": "https://registry.npmjs.org/ember-concurrency/-/ember-concurrency-0.8.19.tgz",
-      "integrity": "sha1-cbnBdboHeGUxACnLS9uIDhfVFV4=",
-      "requires": {
-        "babel-core": "6.26.3",
-        "ember-cli-babel": "6.16.0",
-        "ember-maybe-import-regenerator": "0.1.6"
-      }
-    },
     "ember-cookies": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.3.1.tgz",
@@ -4140,12 +4131,6 @@
       "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
       "requires": {
         "ember-cli-version-checker": "2.1.0"
-      }
-    },
-    "ember-fedora-adapter": {
-      "version": "git+https://github.com/OA-PASS/ember-fedora-adapter.git#fa418b5cf0e5982e316d47ac5850ed87b3598fca",
-      "requires": {
-        "ember-cli-babel": "6.16.0"
       }
     },
     "ember-fetch": {
@@ -4491,32 +4476,6 @@
         }
       }
     },
-    "ember-maybe-import-regenerator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ember-maybe-import-regenerator/-/ember-maybe-import-regenerator-0.1.6.tgz",
-      "integrity": "sha1-NdQYKK+m1qWbwNo85H80xXPXdso=",
-      "requires": {
-        "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
-        "ember-cli-babel": "6.16.0",
-        "regenerator-runtime": "0.9.6"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.9.6",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
-          "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
-        }
-      }
-    },
-    "ember-maybe-in-element": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz",
-      "integrity": "sha512-cAiG6N9HwvoPsMIePgwECilPrKRrIdfKqx9g8qWHKPS4vwrgS2PTeLmOcJvVYbBTXkHaFZmecDRpf6xAj6zk7A==",
-      "requires": {
-        "ember-cli-babel": "6.16.0"
-      }
-    },
     "ember-modal-dialog": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/ember-modal-dialog/-/ember-modal-dialog-2.4.1.tgz",
@@ -4537,27 +4496,6 @@
         "ember-cli-babel": "6.16.0",
         "ember-cli-htmlbars": "2.0.3",
         "ember-composable-helpers": "2.1.0"
-      }
-    },
-    "ember-power-select": {
-      "version": "git+https://github.com/cameronblandford/ember-power-select.git#4f8ae0eab33cda01c0a9aa94b0592d1ce91b7df7",
-      "requires": {
-        "ember-basic-dropdown": "github:cameronblandford/ember-basic-dropdown#f25bb86bea9c73da40be33ce3ffe59c3c1b9d97a",
-        "ember-cli-babel": "6.16.0",
-        "ember-cli-htmlbars": "2.0.3",
-        "ember-concurrency": "0.8.19",
-        "ember-text-measurer": "0.4.1",
-        "ember-truth-helpers": "2.0.0"
-      },
-      "dependencies": {
-        "ember-basic-dropdown": {
-          "version": "github:cameronblandford/ember-basic-dropdown#f25bb86bea9c73da40be33ce3ffe59c3c1b9d97a",
-          "requires": {
-            "ember-cli-babel": "6.16.0",
-            "ember-cli-htmlbars": "2.0.3",
-            "ember-maybe-in-element": "0.1.3"
-          }
-        }
       }
     },
     "ember-promise-helpers": {
@@ -4793,12 +4731,31 @@
         "ember-in-viewport": "3.0.3"
       }
     },
-    "ember-text-measurer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ember-text-measurer/-/ember-text-measurer-0.4.1.tgz",
-      "integrity": "sha512-fwRoaGF0pemMyJ5S/j5FYt7PZva8MyZA33DwkL1LLAR9T5hQyatSbZaLl4D1a5Kv8kDXX0tTFZT9xCPPKahYTg==",
+    "ember-tether": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-tether/-/ember-tether-1.0.0.tgz",
+      "integrity": "sha1-YRfqc1GSeIfLdPpdRgl90wAoDC0=",
+      "dev": true,
       "requires": {
-        "ember-cli-babel": "6.16.0"
+        "ember-cli-babel": "6.16.0",
+        "ember-cli-node-assets": "0.2.2",
+        "tether": "1.4.5"
+      },
+      "dependencies": {
+        "ember-cli-node-assets": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz",
+          "integrity": "sha1-0tVWJufMZhn4gtf+VXUfkmYCJwg=",
+          "dev": true,
+          "requires": {
+            "broccoli-funnel": "1.2.0",
+            "broccoli-merge-trees": "1.2.4",
+            "broccoli-source": "1.1.0",
+            "debug": "2.6.9",
+            "lodash": "4.17.10",
+            "resolve": "1.5.0"
+          }
+        }
       }
     },
     "ember-toastr": {
@@ -6355,6 +6312,468 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -9999,6 +10418,7 @@
         "capture-exit": "1.2.0",
         "exec-sh": "0.2.2",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.2.4",
         "micromatch": "3.1.10",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -10923,6 +11343,12 @@
           }
         }
       }
+    },
+    "tether": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tether/-/tether-1.4.5.tgz",
+      "integrity": "sha512-fysT1Gug2wbRi7a6waeu39yVDwiNtvwj5m9eRD+qZDSHKNghLo6KqP/U3yM2ap6TNUL2skjXGJaJJTJqoC31vw==",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ember-cli-code-coverage": "^0.4.2",
     "ember-load": "0.0.12",
     "ember-lodash": "^4.18.0",
+    "ember-tether": "^1.0.0",
     "qunit-dom": "^0.6.2",
     "toastr": "^2.1.4"
   },


### PR DESCRIPTION
Previously you could not scroll the modal when parts of the user search modal disappeared off the bottom of the page. To fix this, `ember-tether` module was added to support "tethering" the modal to a page element. Minor style changes were applied (added a min-height).

Also in the PR, when there is only one page of results, the page button is no longer shown.

To test, search for a name that returns a few results, see that page button does not appear, play with the width of the browser window. Then search for a common name such as "robert", note that if you make the page narrow enough for a scrollbar to appear, you can scroll the modal.

Closes #770 