### PR TITLE
Change sort order on submissions table

### DIFF
--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -37,12 +37,11 @@ export default CheckSessionRoute.extend({
 
   _doSubmitter(user) {
     return this.store.query('submission', {
-      sort: [{
-        submittedDate: {
-          missing: '_last',
-          order: 'desc'
-        }
-      }],
+      sort: [
+        { submitted: { missing: '_last', order: 'asc' } },
+        { submissionStatus: { missing: '_last', order: 'asc' } },
+        { submittedDate: { missing: '_last', order: 'desc' } }
+      ],
       query: {
         bool: {
           should: [


### PR DESCRIPTION
Submissions table now sorts by: 
1. submitted asc
2. submissionStatus asc
3. submittedDate desc   
For all fields, if the value is empty they are listed last.

Closes #819 