### PR TITLE
When PMC radio button is toggled, disables tabs must use next

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 install:
 - npm install
 script:
-  - ember test --test-port=4200 && echo "Reporting coveralls" && cat coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage
+  - ember test --test-port=4200
 before_deploy:
   - ember build --environment=surge
 deploy:

--- a/app/components/policy-card.js
+++ b/app/components/policy-card.js
@@ -1,6 +1,9 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  toggleRemoveNIHDeposit: Ember.observer('model.newSubmission.removeNIHDeposit', function () {
+    this.set('maxStep', 3);
+  }),
   // checks if the radio buttons need to be displayed
   usesPmcRepository: Ember.computed('policy.repositories', function () {
     return this.get('policy.repositories') ? (this.get('policy.repositories').filter(repo => repo.get('repositoryKey') === 'pmc').length > 0) : false;
@@ -14,7 +17,7 @@ export default Component.extend({
   didRender() {
     this._super(...arguments);
     if (this.get('methodAJournal') && !this.get('removeNIHDeposit')) {
-      this.sendAction('toggleRemoveNIHDeposit', true);
+      this.sendAction('setRemoveNIHDeposit', true);
     }
   }
 });

--- a/app/components/workflow-policies.js
+++ b/app/components/workflow-policies.js
@@ -27,7 +27,7 @@ export default WorkflowComponent.extend({
     back() {
       this.sendAction('back');
     },
-    toggleRemoveNIHDeposit(bool) {
+    setRemoveNIHDeposit(bool) {
       this.set('model.newSubmission.removeNIHDeposit', bool);
     }
   },

--- a/app/templates/components/workflow-policies.hbs
+++ b/app/templates/components/workflow-policies.hbs
@@ -4,7 +4,7 @@
       policies that are applicable to your work:
     </p>
     {{#each activePolicies as |policy|}}
-      {{policy-card model=model policy=policy journal=model.publication.journal removeNIHDeposit=removeNIHDeposit toggleRemoveNIHDeposit=(action 'toggleRemoveNIHDeposit')}}
+      {{policy-card model=model policy=policy journal=model.publication.journal removeNIHDeposit=removeNIHDeposit maxStep=maxStep setRemoveNIHDeposit=(action 'setRemoveNIHDeposit')}}
     {{/each}}
 </div>
 

--- a/app/templates/components/workflow-wrapper.hbs
+++ b/app/templates/components/workflow-wrapper.hbs
@@ -18,7 +18,7 @@
     {{workflow-grants hasProxy=hasProxy model=model next=(action "next") maxStep=maxStep back=(action "back")}}
     {{/if}}
     {{#if (eq step 3)}}
-    {{workflow-policies hasProxy=hasProxy model=model next=(action "next") back=(action "back")
+    {{workflow-policies hasProxy=hasProxy model=model next=(action "next") maxStep=maxStep back=(action "back")
     toggleNIHDeposit=(action "toggleNIHDeposit")}}
     {{/if}}
     {{#if (eq step 4)}}


### PR DESCRIPTION
This changes the policies pages so that if you go back and change the PMC setting for making arrangements with the publisher, it disables tabs after the policy page in order to ensure that the user must step through the workflow and complete the correct repository metadata.

closes #821 