### PR TITLE
Fix workflow for web-linked only repos

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -49,7 +49,7 @@ export default Controller.extend({
    * If the submission is submitted, return external-submissions object from metadata.
    * Otherwise generate what it should be from external repositories.
    */
-  externalSubmissionsMetadata: Ember.computed('model.sub.respositories', 'model.sub.submitted', 'model.sub.metadata', function () {
+  externalSubmissionsMetadata: Ember.computed('model.sub.submitted', 'model.sub.metadata', function () {
     if (this.get('model.sub.submitted')) {
       let values = JSON.parse(this.get('model.sub.metadata')).filter(x => x.id === 'external-submissions');
 
@@ -267,7 +267,6 @@ export default Controller.extend({
     },
     async approveChanges() {
       let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
-
       // First, check if user has visited all required weblinks.
       if (this.get('disableSubmit')) {
         if (!this.get('hasVisitedWeblink')) {
@@ -295,6 +294,13 @@ export default Controller.extend({
         .map(repo => ({
           id: repo.get('name')
         }));
+
+      let reposWithWebLink = this.get('model.repos')
+        .filter(repo => repo.get('integrationType') === 'web-link')
+        .map(repo => ({
+          id: repo.get('name')
+        }));
+
       // INFO: this is used to testing more then 1 repo.
       // reposWithAgreementText.push({
       //   id: 'some',
@@ -316,89 +322,110 @@ export default Controller.extend({
           }
         });
         // make sure there are repos to submit to.
-        if ((reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length > 0) && this.get('model.sub.repositories.length') > 0) {
-          swal({
-            title: 'You are about to submit to:',
-            html: `<pre><code> ${JSON.stringify(reposThatUserAgreedToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')} ${JSON.stringify(reposWithoutAgreementText.map(repo => repo.id)).replace(/[\[\]']/g, '')} </code></pre>`, // eslint-disable-line
-            confirmButtonText: 'Submit',
-            showCancelButton: true,
-          }).then((result) => {
-            console.log(result.value);
-            if (result.value) {
-              const externalSubmissionsMetadata = this.get('externalSubmissionsMetadata');
+        if (this.get('model.sub.repositories.length') > 0) {
+          if (reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length > 0 || reposWithWebLink.length > 0) {
+            let swalMsg = 'Once you click submit you will no longer be able to edit this submission or add repositories.<br/>';
+            if (reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length) {
+              swalMsg = `${swalMsg}You are about to submit your files to: <pre><code>${JSON.stringify(reposThatUserAgreedToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')}${JSON.stringify(reposWithoutAgreementText.map(repo => repo.id)).replace(/[\[\]']/g, '')} </code></pre>`;
+            }
+            if (reposWithWebLink.length > 0) {
+              swalMsg = `${swalMsg}You were prompted to submit to: <code><pre>${JSON.stringify(reposWithWebLink.map(repo => repo.id)).replace(/[\[\]']/g, '')}</code></pre>`;
+            }
 
-              // Update repos to reflect repos that user agreed to deposit
-              this.set('model.sub.repositories', this.get('model.sub.repositories').filter((repo) => {
-                if (repo.get('integrationType') === 'weblink') {
+            swal({
+              title: 'Confirm submission',
+              html: swalMsg, // eslint-disable-line
+              confirmButtonText: 'Submit',
+              showCancelButton: true,
+            }).then((result) => {
+              if (result.value) {
+                const externalSubmissionsMetadata = this.get('externalSubmissionsMetadata');
+                // Update repos to reflect repos that user agreed to deposit
+                this.set('model.sub.repositories', this.get('model.sub.repositories').filter((repo) => {
+                  if (repo.get('integrationType') === 'weblink') {
+                    return false;
+                  }
+                  let temp = reposWithAgreementText.map(x => x.id).includes(repo.get('name'));
+                  if (!temp) {
+                    return true;
+                  } else if (reposThatUserAgreedToDeposit.map(r => r.id).includes(repo.get('name'))) {
+                    return true;
+                  }
                   return false;
-                }
-                let temp = reposWithAgreementText.map(x => x.id).includes(repo.get('name'));
-                if (!temp) {
-                  return true;
-                } else if (reposThatUserAgreedToDeposit.map(r => r.id).includes(repo.get('name'))) {
-                  return true;
-                }
-                return false;
-              }));
-              // update Metadata blob to refelect changes in repos
-              this.set('model.sub.metadata', JSON.stringify(JSON.parse(this.get('model.sub.metadata')).filter((md) => {
-                let whiteListedMetadataKeys = ['common', 'crossref', 'pmc', 'agent_information'];
-                if (whiteListedMetadataKeys.includes(md.id)) {
-                  return md;
-                }
-                return this.get('model.sub.repositories').map(r => r.get('name')).includes(md.id);
-              })));
+                }));
+                // update Metadata blob to refelect changes in repos
+                this.set('model.sub.metadata', JSON.stringify(JSON.parse(this.get('model.sub.metadata')).filter((md) => {
+                  let whiteListedMetadataKeys = ['common', 'crossref', 'pmc', 'agent_information'];
+                  if (whiteListedMetadataKeys.includes(md.id)) {
+                    return md;
+                  }
+                  return this.get('model.sub.repositories').map(r => r.get('name')).includes(md.id);
+                })));
 
-              // Add external submissions metadata
-              if (externalSubmissionsMetadata) {
-                let md = JSON.parse(this.get('model.sub.metadata'));
-                md.push(externalSubmissionsMetadata);
-                this.set('model.sub.metadata', JSON.stringify(md));
-              }
+                // Add external submissions metadata
+                if (externalSubmissionsMetadata) {
+                  let md = JSON.parse(this.get('model.sub.metadata'));
+                  md.push(externalSubmissionsMetadata);
+                  this.set('model.sub.metadata', JSON.stringify(md));
+                }
 
-              // Remove external repositories
-              this.set(
-                'model.sub.repositories',
-                this.get('model.sub.repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
-              );
+                // Remove external repositories
+                this.set(
+                  'model.sub.repositories',
+                  this.get('model.sub.repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
+                );
 
-              $('.block-user-input').css('display', 'block');
-              // save sub and send it
-              let s = this.get('model.sub');
-              let se = this.get('store').createRecord('submissionEvent', {
-                submission: this.get('model.sub'),
-                performedBy: this.get('currentUser.user'),
-                performedDate: new Date(),
-                comment: this.get('message'),
-                performerRole: 'submitter',
-                eventType: 'submitted',
-                link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
-              });
-              se.save().then(() => {
-                let sub = this.get('model.sub');
-                sub.set('submissionStatus', 'submitted');
-                sub.set('submittedDate', new Date());
-                sub.set('submitted', true);
-                sub.save().then(() => {
-                  window.location.reload(true);
+                $('.block-user-input').css('display', 'block');
+                // save sub and send it
+                let s = this.get('model.sub');
+                let se = this.get('store').createRecord('submissionEvent', {
+                  submission: this.get('model.sub'),
+                  performedBy: this.get('currentUser.user'),
+                  performedDate: new Date(),
+                  comment: this.get('message'),
+                  performerRole: 'submitter',
+                  eventType: 'submitted',
+                  link: `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${s.id}`)}`
                 });
-              });
-            }
-          });
+                se.save().then(() => {
+                  let sub = this.get('model.sub');
+                  sub.set('submissionStatus', 'submitted');
+                  sub.set('submittedDate', new Date());
+                  sub.set('submitted', true);
+                  sub.save().then(() => {
+                    window.location.reload(true);
+                  });
+                });
+              }
+            });
+          } else {
+            // there were repositories, but the user didn't sign any of the agreements
+            let reposUserDidNotAgreeToDeposit = reposWithAgreementText.filter((repo) => {
+              if (!reposThatUserAgreedToDeposit.includes(repo)) {
+                return true;
+              }
+            });
+            swal({
+              title: 'Your submission cannot be submitted.',
+              html: `You declined to agree to the deposit agreement(s) for ${JSON.stringify(reposUserDidNotAgreeToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')}. Therefore, this submission cannot be submitted. \n You can either (a) cancel the submission or (b) return to the submission to provide required input and try again.`,
+              confirmButtonText: 'Cancel submission',
+              showCancelButton: true,
+              cancelButtonText: 'Go back to edit information'
+            }).then((result) => {
+              if (result.value) {
+                this.send('cancelSubmission');
+              }
+            });
+          }
         } else {
-          let reposUserDidNotAgreeToDeposit = reposWithAgreementText.filter((repo) => {
-            if (!reposThatUserAgreedToDeposit.includes(repo)) {
-              return true;
-            }
-          });
+          // no repositories associated with the submission
           swal({
             title: 'Your submission cannot be submitted.',
-            html: `You declined to agree to the deposit agreement(s) for ${JSON.stringify(reposUserDidNotAgreeToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')}. Therefore, this submission cannot be submitted. \n You can either (a) cancel the submission or (b) return to the submission to provide required input and try again.`,
+            html: 'No repositories are associated with this submission. \n You can either (a) cancel the submission or (b) return to the submission and edit it to include a repository.',
             confirmButtonText: 'Cancel submission',
             showCancelButton: true,
             cancelButtonText: 'Go back to edit information'
           }).then((result) => {
-            console.log(result.value);
             if (result.value) {
               this.send('cancelSubmission');
             }

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -324,7 +324,7 @@ export default Controller.extend({
         // make sure there are repos to submit to.
         if (this.get('model.sub.repositories.length') > 0) {
           if (reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length > 0 || reposWithWebLink.length > 0) {
-            let swalMsg = 'Once you click submit you will no longer be able to edit this submission or add repositories.<br/>';
+            let swalMsg = 'Once you click confirm you will no longer be able to edit this submission or add repositories.<br/>';
             if (reposWithoutAgreementText.length > 0 || reposThatUserAgreedToDeposit.length) {
               swalMsg = `${swalMsg}You are about to submit your files to: <pre><code>${JSON.stringify(reposThatUserAgreedToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')}${JSON.stringify(reposWithoutAgreementText.map(repo => repo.id)).replace(/[\[\]']/g, '')} </code></pre>`;
             }
@@ -335,7 +335,7 @@ export default Controller.extend({
             swal({
               title: 'Confirm submission',
               html: swalMsg, // eslint-disable-line
-              confirmButtonText: 'Submit',
+              confirmButtonText: 'Confirm',
               showCancelButton: true,
             }).then((result) => {
               if (result.value) {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -816,7 +816,7 @@ footer {
   min-height: 25rem; 
 }
 .user-search-results .col-6 {
-  max-width:100%
+  max-width:100%;
 }
 
 // Row selection in ember-models-table

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -79,7 +79,7 @@
             model.sub.submittedDate}}</small>{{/if}}
         </div>
         <p class="mb-1">DOI: {{#if model.sub.publication.doi}}{{model.sub.publication.doi}}{{else}}<span class="text-muted">None</span>{{/if}}</p>
-        <table class="table table-responsive-sm table-bordered w-100">
+        <table class="table table-responsive-sm table-bordered w-100 d-flex">
           <tbody>
             <tr>
               <td><strong>Submission status</strong></td>
@@ -117,7 +117,7 @@
             {{/if}}
             {{#if externalSubmission}}
             <tr>
-              <td class="text-nowrap"><strong>External Submission Repositories</strong></td>
+              <td><strong>External Submission Repositories</strong></td>
               <td>
                 <ul class="list-unstyled">
                   {{#each externalSubmission as |sub|}}
@@ -141,6 +141,7 @@
               </td>
             </tr>
             {{#if (await model.sub.preparers)}}
+            <tr>
               <td class="text-nowrap"><strong>Preparer(s)</strong></td>
               <td>
                 {{#each (await model.sub.preparers) as |preparer index|}}
@@ -150,13 +151,15 @@
                 {{/if}}
                 {{/each}}
               </td>
+            </tr>
             {{/if}}
             {{#if mustVisitWeblink}}
             <tr>
-              <td class="text-nowrap text-center" id="externalSubmission">External Submission Required
+              <td id="externalSubmission">
+                <strong>External Submission Required</strong>
                 <br>
                 {{#if disableSubmit}}
-                <i class="fa fa-exclamation-triangle fa-2x mt-3 notice-triangle"></i>
+                <i class="fa fa-exclamation-triangle fa-2x mt-3 ml-3 notice-triangle"></i>
                 {{/if}}
               </td>
               <td>


### PR DESCRIPTION
This fixes an issue where if a preparer prepares a proxy submission that contains a web linked repository only, the submitter cannot submit it.  For this change, I did some changes to the message that appears to confirm which repositories you are submitting to. It now has some wording for web-linked, please let me know if you want me to change the text. 

Fixed a few minor style issues.

Ideally testing would involve looking at the behavior of hitting "submit" on a proxy submission under various circumstances and making sure it behaves as expected. For example, having the preparer prepare the following and see what happens when submitter submits:
1. submission with web-link repo only (no agreements or other repositories so no repositories attached)
2. submission with jscholarship + weblink
3. submission with jscholarship + pmc
4. submission with pmc only
