### PR TITLE
File validation and fixes

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -27,6 +27,17 @@ export default WorkflowComponent.extend({
   actions: {
     next() {
       if (!this.get('nextDisabled')) {
+
+        // Update any *existing* files that have had their details modified
+        let files = this.get('model.files')
+        if (files) {
+          files.forEach( file => {
+            if (file.get('hasDirtyAttributes')) {
+              // Asynchronously save the updated file metadata.
+              file.save();
+            }
+          });
+        }
         this.set('filesTemp', this.get('files'));
         this.sendAction('next');
       } else {

--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -19,6 +19,19 @@ export default WorkflowComponent.extend({
     let mFiles = this.get('model.files');
     let files = this.get('files');
     let tFiles = this.get('filesTemp');
+
+    if (mFiles) {
+      console.log("Model files: " + mFiles.length);
+    }
+
+    if (files) {
+      console.log("Files: " + files.length);
+    }
+
+    if (tFiles) {
+      console.log("Temp files: " + files.length);
+    }
+
     return (
       (!files || (files && files.length === 0)) &&
       (!mFiles || (mFiles && mFiles.length === 0)) &&
@@ -59,6 +72,24 @@ export default WorkflowComponent.extend({
         cancelButtonText: 'Nevermind'
       }).then((result) => {
         if (result.value) {
+          let mFiles = this.get('model.files');
+          let files = this.get('files');
+          let tFiles = this.get('filesTemp');
+
+          // Remove the file from whatever array it's in
+          
+          if (mFiles) {
+            mFiles.removeObject(file);
+          }
+          
+          if (files) {
+            files.removeObject(file);
+          }
+
+          if (tFiles) {
+            tFiles.removeObject(file);
+          }
+          
           file.destroyRecord();
         }
       });

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -281,6 +281,26 @@ export default Controller.extend({
         return;
       }
 
+      // Validate manuscript files
+      let manuscriptFiles = [].concat(this.get('filesTemp'), this.get('model.files') && this.get('model.files').toArray())
+        .filter(file => file && file.get('fileRole') === 'manuscript');
+
+      if (manuscriptFiles.length == 0) {
+        swal(
+          'Manuscript is missing',
+          'At least one manuscript file is required.  Please Edit the submission to add one',
+          'warning'
+        );
+        return;
+      } else if (manuscriptFiles.length > 1) {
+        swal(
+          'Incorrect manuscript count',
+          `Only one file may be designated as the manuscript.  Instead, found ${manuscriptFiles.length}.  Please edit the file list`,
+          'warning'
+        );
+        return;
+      }
+
       let reposWithAgreementText = this.get('model.repos')
         .filter(repo => (repo.get('integrationType') !== 'web-link') && repo.get('agreementText'))
         .map(repo => ({

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -18,13 +18,6 @@
   {{/if}}
 {{/each}}
 
-<p class="lead text-muted mb-2">Attach manuscript/article files to this submission.</p>
-<p class="lead text-muted">Each individual file must be smaller than 100MB.</p>
-<div class="form-group row">
-  <div class="col-md-12">
-    <input type="file" id="file-multiple-input" multiple size="50" onchange= {{action "getFiles"}} class="text-gray-300" style="border-width:2px; cursor:pointer; border-style: dashed; padding:30px; width:100%">
-  </div>
-</div>
 <div class="row">
   <div class="col-lg-12">
     <table class="table table-responsive-sm table-sm">
@@ -89,6 +82,13 @@
   <!--/.col-->
 </div>
 <!--/.row-->
+<p class="lead text-muted mb-2">Attach manuscript/article files to this submission.</p>
+<p class="lead text-muted">Each individual file must be smaller than 100MB.</p>
+<div class="form-group row">
+  <div class="col-md-12">
+    <input type="file" id="file-multiple-input" multiple size="50" onchange= {{action "getFiles"}} class="text-gray-300" style="border-width:2px; cursor:pointer; border-style: dashed; padding:30px; width:100%">
+  </div>
+</div>
 <p><strong>Tip:</strong> Use the Control or the Shift key to select multiple files.</p>
 <button class="btn btn-outline-primary" {{action "back"}}>Back</button>
 <button class="btn btn-primary pull-right next" {{action "next"}}>Next</button>

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -69,7 +69,7 @@
             </td>
             <td class="text-center vertical-align-middle">
               <select onchange= {{action (mut file.fileRole) value="target.value"}}>
-                <option value="supplement" selected={{eq file.fileRole "supplement"}}>Supplement</option>
+                <option value="supplemental" selected={{eq file.fileRole "supplemental"}}>Supplement</option>
                 <option value="manuscript" selected={{eq file.fileRole "manuscript"}}>Manuscript</option>
                 <option value="table" selected={{eq file.fileRole "table"}}>Table</option>
                 <option value="figure" selected={{eq file.fileRole "figure"}}>Figure</option>

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -17,20 +17,6 @@
     </p>
   {{/if}}
 {{/each}}
-<div class="container">
-  {{#if model.files}}
-    <p class="mt-3 mb-0 lead">Existing Files</p>
-  {{/if}}
-  <div class="row mb-4">
-    {{#each model.files as |file|}}
-        <div class="col-12">
-          {{file.name}}
-          (<a href={{file.uri}}>Download</a>)
-          (<a href="#" {{action 'deleteExistingFile' file}}>Delete</a>)
-        </div>
-    {{/each}}
-  </div>
-</div>
 
 <p class="lead text-muted mb-2">Attach manuscript/article files to this submission.</p>
 <p class="lead text-muted">Each individual file must be smaller than 100MB.</p>
@@ -55,6 +41,27 @@
         </tr>
       </thead>
       <tbody>
+        {{#each model.files as |file|}}
+          <tr>
+            <td class="vertical-align-middle">
+              <a href="{{file.uri}}">{{file.name}}</a>
+            </td>
+            <td class="text-center vertical-align-middle">
+              <select onchange= {{action (mut file.fileRole) value="target.value"}}>
+                <option value="supplement" selected={{eq file.fileRole "supplement"}}>Supplement</option>
+                <option value="manuscript" selected={{eq file.fileRole "manuscript"}}>Manuscript</option>
+                <option value="table" selected={{eq file.fileRole "table"}}>Table</option>
+                <option value="figure" selected={{eq file.fileRole "figure"}}>Figure</option>
+              </select>
+            </td>
+            <td class="vertical-align-middle">
+              {{input class="form-control file-description-width" value=file.description}}
+            </td>
+            <td class="text-center vertical-align-middle">
+              <button type="button" class="btn btn-outline-danger" {{action 'deleteExistingFile' file}}>Remove</button>
+            </td>
+          </tr>
+        {{/each}}
         {{#each files as |file|}}
           <tr>
             <td class="vertical-align-middle">


### PR DESCRIPTION
* Adds validation that requires _exactly one manuscript_ to proceed to 'next' from the file upload page
* Allows file details (role, descriptions) of already-upload files to be editable
* Consolidates all files (pending, and existing) into a unified table
* Places the file upload box at the bottom of the page, as it seemed a more logical location with the above consolidation, except in the case of a proxy submitter intentionally preparing a submission without a manuscript
* Fixes pre-existing bugs and logic errors, including:
  * Improper counting of the list of files, which allowed the existing file count check to be bypassed by navigating back and forward
  * Wrong constant for supplemental files, resulting in Deposit services failing to deposit any submissions that contained supplemental files
* Adds a file validation step on final submission, requesting the user to go back and edit the files if the manuscript count is incorrect.

To test:
* As a proxy submitter, try adding and deleting files, setting their role, description, etc.  Verify that the only way to proceed to the "request approval" stage is to have exactly one manuscript, with any number of additional files
* As an approver/submitter, edit the files created by the proxy submitter.  Change their role and description, or delete them.  Verify that those changes persist, and the only way to proceed to the "submit" stage is to have exactly one manuscript, with any number of additional files.
* As a proxy, create a submission that does _not_ have any manuscripts attached.  Verify that a popup asks you to confirm (and warns that the submitter will have to add one), and submit for approval.  As the submitter, try immediately submitting that submission.  It should warn that a manuscript is necessary.  Either request changes, or fix it yourself.  Verified that the fixed submission is accepted.

Resolves #789 