### PR TITLE
Minor /submissions/ changes

### DIFF
--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -39,8 +39,8 @@ export default CheckSessionRoute.extend({
     return this.store.query('submission', {
       sort: [
         { submitted: { missing: '_last', order: 'asc' } },
-        { submissionStatus: { missing: '_last', order: 'asc' } },
-        { submittedDate: { missing: '_last', order: 'desc' } }
+        { submittedDate: { missing: '_last', order: 'desc' } },
+        { submissionStatus: { missing: '_last', order: 'asc' } }
       ],
       query: {
         bool: {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -526,7 +526,7 @@ table td {
 .awardnum-funder-column {
   min-width: 9.5rem;
 }
-.status-column {min-width: 7rem;}
+.status-column {min-width: 7.6rem;}
 .funder-column {
   min-width: 9.5rem;
   max-width: 12.5rem;


### PR DESCRIPTION
* refined sort order on `/submissions/` so that it sorts on `submittedDate desc` before `submissionStatus`. Previously it put submissions with status `submitted` at end of list even if they were most recently submitted. This maintains the sort on unsubmitted since their date is always null.
* widened status column to avoid wrapping