### PR TITLE
Temporarily hide new user section of Basics workflow tab

### DIFF
--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -8,6 +8,12 @@
   </p>
 </div>
 {{#if model.newSubmission.hasNewProxy}}
+<style>
+.temp-hide {
+  visibility:hidden;
+  height:0px;
+}
+</style>
 <div class="alert alert-info">
   <p>When a submission is created on someone's behalf, PASS will contact that person to acquire their approval before
     finalizing the submission and sending it to its corresponding repositories.</p>
@@ -24,12 +30,12 @@
        (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)<br>(<a href="#" {{action 'removeCurrentSubmitter'}}>Remove submitter</a>)
     </p>
     {{/if}}
-  <p class="mb-0"><strong>If the person you are submitting for does not have an account with PASS</strong>, please
+  <p class="mb-0 temp-hide"><strong>If the person you are submitting for does not have an account with PASS</strong>, please
     provide their email address and name so we may notify them:
   </p>
-  <div class="form-inline">
-  {{input class=(concat "mt-1 mb-3 form-control w-50 " validEmail) keyUp=(action "validateEmail") disabled=model.newSubmission.submitter.id value=submitterEmail placeholder="Email address"}}
-  {{input class="mt-1 mb-3 form-control w-50" disabled=model.newSubmission.submitter.id value=submitterName placeholder="Name"}}
+  <div class="form-inline temp-hide">
+  {{input class=(concat "mt-1 mb-3 form-control w-50 temp-hide" validEmail) keyUp=(action "validateEmail") disabled=true value=submitterEmail placeholder="Email address"}}
+  {{input class="mt-1 mb-3 form-control w-50 temp-hide" disabled=true value=submitterName placeholder="Name"}}
   </div>
 </div>
 {{/if}}


### PR DESCRIPTION
This temporarily hides the new user form until we can determine why user tokens are not working in demo

To test create a new submission as preparer and as yourself - note on the basics tab you should no longer have any option to submit on behalf of a user that does not exist yet.