### PR TITLE
Fix url encoding issue that resulted in deleted user tokens

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -49,7 +49,7 @@ export default CheckSessionRoute.extend({
         q = intent.length;
       }
       const targetId = intent.substring(prefix.length, q);
-      this.replaceWith(`${prefix}${encodeURIComponent(targetId)}`);
+      this.replaceWith(intent.replace(targetId, `${encodeURIComponent(targetId)}`));
     }
   },
 

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -8,12 +8,6 @@
   </p>
 </div>
 {{#if model.newSubmission.hasNewProxy}}
-<style>
-.temp-hide {
-  visibility:hidden;
-  height:0px;
-}
-</style>
 <div class="alert alert-info">
   <p>When a submission is created on someone's behalf, PASS will contact that person to acquire their approval before
     finalizing the submission and sending it to its corresponding repositories.</p>
@@ -30,12 +24,12 @@
        (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)<br>(<a href="#" {{action 'removeCurrentSubmitter'}}>Remove submitter</a>)
     </p>
     {{/if}}
-  <p class="mb-0 temp-hide"><strong>If the person you are submitting for does not have an account with PASS</strong>, please
+  <p class="mb-0"><strong>If the person you are submitting for does not have an account with PASS</strong>, please
     provide their email address and name so we may notify them:
   </p>
-  <div class="form-inline temp-hide">
-  {{input class=(concat "mt-1 mb-3 form-control w-50 temp-hide" validEmail) keyUp=(action "validateEmail") disabled=true value=submitterEmail placeholder="Email address"}}
-  {{input class="mt-1 mb-3 form-control w-50 temp-hide" disabled=true value=submitterName placeholder="Name"}}
+  <div class="form-inline">
+  {{input class=(concat "mt-1 mb-3 form-control w-50 " validEmail) keyUp=(action "validateEmail") disabled=model.newSubmission.submitter.id value=submitterEmail placeholder="Email address"}}
+  {{input class="mt-1 mb-3 form-control w-50" disabled=model.newSubmission.submitter.id value=submitterName placeholder="Name"}}
   </div>
 </div>
 {{/if}}


### PR DESCRIPTION
In the test and demo environments, it [was noticed](https://github.com/OA-PASS/general-issues/issues/85) that e-mail invited users could not see the appropriate submission editing buttons.  This was ultimately traced to Ember not providing the `userToken` to the user service.  The cause of the issue was ember's handling of unencoded URIs.

When Ember encounters an unencoded URI, it needs to encode the embedded fedora resource URI.  A hack was previously in place to do this.  The issue is that this encoding logic ended up erasing any user tokens that were part of the URL.  As a result, the user service was never being sent any tokens.

This PR updates the encoding hack to account for query parameters.  It does this by using a substitution approach, rather than a replacement approach.

## To test

### Step 1: verify
First, verify you can reproduce the bug.  Launch `pass-docker` master, and create a proxy submission for `newSubmitter1`.  When you get the invitation link (via e-mail, or looking at the logs of notification services), decode it, then paste it into a fresh browser window to log in as `newSubmitter1`

For example, suppose you see the following URL:
`https://pass.local/app/submissions/https%3A%2F%2Fpass.local%2Ffcrepo%2Frest%2Fsubmissions%2F21%2Ffd%2F41%2Fc4%2F21fd
41c4-2f82-48ab-ab5f-3bd7a619b415?userToken=BRZNT4EUUVB7GMWFW2T6M77JNH6STRRI2PKPBXUWL42NEOZFVIOJP4BXZF4WLPYKVJLWEFUQEJXCBNQLWDJYLXDD7UC3V4XIUT76UX5DQSVZ2ZBHDASUFTBLBE3YMDHUEFW3CJ2HK6WOS2DHTAYES4L5F4QNL5F47G5W2RBFGDGE6SJZCISJED6YDURNZYQB63F7USHINHYWJSWR5B7DIFKDKJIIEKBLDCV5WYY5UZ4C5PXKMPJS3E4W2CP7FTEKGR6WHVIBPGCCYBSWRDV3NTEF2IJQ`

decode it (perhaps by pasting it in [an online decoder/encoder](https://www.urldecoder.org) to get something that looks like the following, and paste into the browser: 
`https://pass.local/app/submissions/https://pass.local/fcrepo/rest/submissions/21/fd/41/c4/21fd41c4-2f82-48ab-ab5f-3bd7a619b415?userToken=BRZNT4EUUVB7GMWFW2T6M77JNH6STRRI2PKPBXUWL42NEOZFVIOJP4BXZF4WLPYKVJLWEFUQEJXCBNQLWDJYLXDD7UC3V4XIUT76UX5DQSVZ2ZBHDASUFTBLBE3YMDHUEFW3CJ2HK6WOS2DHTAYES4L5F4QNL5F47G5W2RBFGDGE6SJZCISJED6YDURNZYQB63F7USHINHYWJSWR5B7DIFKDKJIIEKBLDCV5WYY5UZ4C5PXKMPJS3E4W2CP7FTEKGR6WHVIBPGCCYBSWRDV3NTEF2IJQ`

Verify that you do _not_ see any edit/submit/cancel buttons.  This is what is happening on demo/test.

### Step 2: try the fix
Checkout the following pull request from pass-docker OA-PASS/pass-docker#182 

Do a docker-compose pull, then up.  Repeat the above procedure from step 1.  The difference should be that when you paste the decoded URL into the browser, it should work now.  That is to say, Ember will send the user token, the user service will assign permissions to `newSubmitter1`, and you _should_ see the edit/submit/cancel buttons now.  If so, the fix worked!

Resolves OA-PASS/general-issues#85