### PR TITLE
Adds property to support Ember development in Windows, updates README

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -7,5 +7,7 @@
   */
   "disableAnalytics": false,
 
-  "testPort": 4200
+  "testPort": 4200,
+  "watcher": "polling"
+
 }

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ A docker environement which relies on a Shibboleth proxy is in .docker/shib. All
 be available at https://pass.local/.
 
 * In .docker/shib/ run `docker-compose up`
-  * Fedora repository at https://pass.local/fcrepo/ 
-  * Elasticsearch index search endpoint at https://pass.local/es/
-  * Wait for containers to settle.
-  * In order to remove persisted data, stop all the containers and `docker system prune -f`
+* Wait for the containers to finish coming up, this could take 5-10 minutes. There will be a long pause while the `ember` container builds. When you see the "Build successful" message from `ember` and a small table listing the "Slowest Nodes" that indicates the application is ready to use
+* The local code runs in the `ember` container, and changes in the local code will be reflected there.
 * Visit your app at https://pass.local/app
 * Visit your tests at https://pass.local/app/tests
-* The local code runs in the`ember container.
+* Fedora repository is at https://pass.local/fcrepo/ 
+* Elasticsearch index search endpoint is at https://pass.local/es/
+* In order to remove persisted data, stop all the containers and `docker system prune -f`
 
 Note that ember test will not be able to run tests which make requests to services behind
 the Shibboleth proxy. The ember test client would have to go through the process of getting credentials first.


### PR DESCRIPTION
Adds `"watcher":"polling"` property to `.ember-cli` to support reloading in Windows.

### Testing
This should be tested in Windows, but also *nix to ensure it does not break things for other users.
* Follow modified README instructions for starting up `docker`. 
* Once the containers are up, confirm you can load the Ember app and log in
* Change something that you can easily validate through the GUI in the Ember `/app/` folder, observe that the docker ember log reports a change to a file and reloads.
* Hard refresh the page in the browser, you should be able to see your change.