### PR TITLE
Mock store example [Do not merge]

### DIFF
--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -15,7 +15,7 @@
     <div class="input-group pb-3">
       {{input enter='searchForUsers' value=modalSearchInput class="form-control"}}
       <span class="input-group-btn">
-        <button class="btn btn-primary" {{action 'searchForUsers'}} type="button">Search</button>
+        <button id='search-for-users' class="btn btn-primary" {{action 'searchForUsers'}} type="button">Search</button>
       </span>
     </div>
     {{#if model.newSubmission.submitter.id}}
@@ -98,10 +98,10 @@
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
 <button class="btn btn-primary pull-right next" {{action "validateNext"}}>Next</button>
 {{#if isShowingModal}}
-{{#modal-dialog 
-   translucentOverlay=true 
-   onClose="toggleModal" 
-   close="toggleModal" 
+{{#modal-dialog
+   translucentOverlay=true
+   onClose="toggleModal"
+   close="toggleModal"
    tetherTarget='#on-behalf-of-block'
    attachment='top center'
    targetAttachment='top center'

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -1,20 +1,67 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { run } from '@ember/runloop';
 
-moduleForComponent('workflow-basics', 'Integration | Component | workflow basics', {
-  integration: true
-});
+module('Integration | Component | workflow basics', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  let model = {};
+  // Inject mocked store that on query returns a single user
+  hooks.beforeEach(function () {
+    let store = Ember.Service.extend({
+      query: (type, q) => Promise.resolve([Ember.Object.create({ id: 'bob', username: 'bob', email: 'bob@moo.com' })])
+    });
 
-  model = Ember.Object.create({
-    newSubmission: Ember.Object.create({
-    })
+    run(() => {
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', store);
+      this.store = this.owner.lookup('service:store');
+    });
   });
 
-  this.set('model', model);
+  test('publication title renders', async function (assert) {
+    assert.expect(1);
 
-  this.render(hbs`{{workflow-basics model=model}}`);
-  assert.ok(true);
+    let model = Ember.Object.create({
+      newSubmission: Ember.Object.create({}),
+      publication: Ember.Object.create({ title: 'Advanced Bovine Thought' })
+    });
+
+    this.set('model', model);
+
+    await render(hbs`{{workflow-basics model=model}}`);
+
+    assert.equal(this.element.querySelector('#title').value, model.publication.title);
+  });
+
+  test('choose proxy', async function (assert) {
+    assert.expect(6);
+
+    let model = Ember.Object.create({
+      newSubmission: Ember.Object.create({ hasNewProxy: false }),
+      publication: Ember.Object.create({ title: 'Advanced Bovine Thought' })
+    });
+
+    this.set('model', model);
+    this.set('isShowingModal', false);
+    this.set('users', []);
+
+    await render(hbs`{{workflow-basics model=model isShowingModal=isShowingModal users=users}}`);
+
+    // User chooses to do a proxy submission
+    assert.equal(this.get('model.newSubmission.hasNewProxy'), false);
+    await click('#on-behalf-of-block input[type="radio"]:not(:checked)');
+    assert.equal(this.get('model.newSubmission.hasNewProxy'), true);
+
+    // User search calls mocked Store.query when Search for user button clicked
+    await click('#search-for-users');
+    assert.equal(this.get('users.length'), 1);
+    assert.equal(this.get('isShowingModal'), true);
+
+    // User picks submitter
+    await click('.user-search-results div a');
+    assert.equal(this.get('model.newSubmission.submitter.id'), 'bob');
+    assert.equal(this.get('isShowingModal'), false);
+  });
 });


### PR DESCRIPTION
This pr demonstrates how the store service can be mocked to test a component. This means that a great deal of functionality can actually be tested without the shib environment and all those complications.

One takeaway is that code modules which directly make http requests should be rewritten to use services instead. For example workflow-basics directly makes DOI requests. This makes testing code paths which make a DOI request hard if not impossible. Instead there should be a DOI service which understands how to validate DOIs and retrieve metadata about them. Then tests can inject a mocked DOI service.