### PR TITLE
Clean up submitterEmail, submitterName, hasProxy, didAgree, and didNotAgree properties

### DIFF
--- a/app/authorizers/_drf-token-authorizer.js
+++ b/app/authorizers/_drf-token-authorizer.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import Base from 'ember-simple-auth/authorizers/base';
+import { inject as service } from '@ember/service';
 
 export default Base.extend({
-  session: Ember.inject.service('session'),
+  session: service('session'),
 
   authorize(sessionData, block) {
     if (this.get('session.isAuthenticated') && !Ember.isEmpty(sessionData.token)) {

--- a/app/components/commenting-block.js
+++ b/app/components/commenting-block.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import EmberObject, { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 function getDate() {
   // Create a date object with the current time
@@ -24,5 +25,5 @@ function getDate() {
 }
 
 export default Component.extend({
-  currentUser: Ember.inject.service('current-user')
+  currentUser: service('current-user')
 });

--- a/app/components/nav-bar.js
+++ b/app/components/nav-bar.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
 
   /**
    * Do we have a valid user loaded into the user service?

--- a/app/components/policy-card.js
+++ b/app/components/policy-card.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  workflow: Ember.inject.service('workflow'),
+  workflow: service('workflow'),
   pmcPublisherDeposit: Ember.computed('workflow.pmcPublisherDeposit', {
     get(key) {
       return this.get('workflow').getPmcPublisherDeposit();

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
   isPreparer: Ember.computed('currentUser', 'record', function () {
     let userId = this.get('currentUser.user.id');
     let preparers = this.get('record.preparers');

--- a/app/components/submission-nav.js
+++ b/app/components/submission-nav.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  workflow: Ember.inject.service('workflow'),
+  workflow: service('workflow'),
   step: Ember.computed('workflow.currentStep', function () {
     return this.get('workflow').getCurrentStep();
   }),

--- a/app/components/submission-repo-details.js
+++ b/app/components/submission-repo-details.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  store: Ember.inject.service(),
+  store: service('store'),
 
   status: Ember.computed('deposit', 'repoCopy', function () {
     const deposit = this.get('deposit');

--- a/app/components/submissions-repoid-cell.js
+++ b/app/components/submissions-repoid-cell.js
@@ -1,7 +1,8 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  store: Ember.inject.service(),
+  store: service('store'),
   repoCopies: null,
   jscholarshipCheckString: '/handle/',
 

--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -79,8 +79,8 @@ export default Component.extend({
         }
       }
       this.set('searchInput', '');
-      this.set('submitterEmail', '');
-      this.set('submitterName', '');
+      this.set('model.newSubmission.submitterEmail', '');
+      this.set('model.newSubmission.submitterName', '');
       this.set('model.newSubmission.submitter', submitter);
       this.set('isShowingModal', false);
     }

--- a/app/components/workflow-basics-user-search.js
+++ b/app/components/workflow-basics-user-search.js
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
 import ENV from '../config/environment';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  store: Ember.inject.service('store'),
-  currentUser: Ember.inject.service('current-user'),
+  store: service('store'),
+  currentUser: service('current-user'),
   searchInput: '',
   users: [],
   page: 1,

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -20,17 +20,17 @@ function resolve(publication) {
 }
 
 export default Component.extend({
-  store: service(),
-  workflow: service(),
+  store: service('store'),
+  workflow: service('workflow'),
+  errorHandler: service('error-handler'),
+  currentUser: service('current-user'),
+  toast: service('toast'),
   base: Ember.computed(() => ENV.fedora.elasticsearch),
-  ajax: service(),
+  ajax: service('ajax'),
   validDOI: 'form-control',
   isValidDOI: false,
   validTitle: 'form-control',
   validEmail: '',
-  toast: service('toast'),
-  errorHandler: service('error-handler'),
-  currentUser: service('current-user'),
   // modal fields
   isShowingModal: false,
   modalPageSize: 30,
@@ -38,14 +38,14 @@ export default Component.extend({
   modalUsers: null,
   modalSearchInput: '',
   isProxySubmission: Ember.computed('model.newSubmission.isProxySubmission', function () {
-      return this.get('model.newSubmission.isProxySubmission');
+    return this.get('model.newSubmission.isProxySubmission');
   }),
   inputSubmitterEmail: Ember.computed('model.newSubmission.submitterEmail', {
     get(key) {
       return this.get('model.newSubmission.submitterEmail').replace('mailto:', '');
     },
     set(key, value) {
-      this.set('model.newSubmission.submitterEmail', "mailto:" + value);
+      this.set('model.newSubmission.submitterEmail', `mailto:${value}`);
       return value;
     }
   }),

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -37,6 +37,15 @@ export default Component.extend({
   modalTotalResults: 0,
   modalUsers: null,
   modalSearchInput: '',
+  inputSubmitterEmail: Ember.computed('model.newSubmission.submitterEmail', {
+    get(key) {
+      return this.get('model.newSubmission.submitterEmail').replace('mailto:', '');
+    },
+    set(key, value) {
+      this.set('model.newSubmission.submitterEmail', "mailto:" + value);
+      return value;
+    }
+  }),
   doiInfo: Ember.computed('workflow.doiInfo', {
     get(key) {
       return this.get('workflow').getDoiInfo();
@@ -60,7 +69,7 @@ export default Component.extend({
     'model.publication.journal', 'model.publication.title', 'model.newSubmission.hasNewProxy',
     function () {
       const submitterExists = !!(this.get('model.newSubmission.submitter.id'));
-      const submitterInfoExists = this.get('submitterName') && this.get('submitterEmail');
+      const submitterInfoExists = this.get('model.newSubmission.submitterName') && this.get('model.newSubmission.submitterEmail');
       const proxyAndSubmitter = this.get('model.newSubmission.hasNewProxy') && (submitterExists || submitterInfoExists);
       const ifProxyThenSubmitter = !this.get('model.newSubmission.hasNewProxy') || proxyAndSubmitter;
       const journalAndTitle = this.get('model.publication.journal') && this.get('model.publication.title');
@@ -73,8 +82,8 @@ export default Component.extend({
 
     // if there's no proxy, reset all proxy-popup-related fields
     if (!this.get('model.newSubmission.hasNewProxy') && !this.get('hasProxy')) {
-      this.set('submitterEmail', '');
-      this.set('submitterName', '');
+      this.set('model.newSubmission.submitterEmail', '');
+      this.set('model.newSubmission.submitterName', '');
       this.set('model.newSubmission.preparers', Ember.A());
     }
   },
@@ -116,8 +125,8 @@ export default Component.extend({
         this.set('maxStep', 1);
         this.set('model.newSubmission.preparers', Ember.A());
         if (onBehalfOfSomeoneElse) {
-          this.set('submitterEmail', '');
-          this.set('submitterName', '');
+          this.set('model.newSubmission.submitterEmail', '');
+          this.set('model.newSubmission.submitterName', '');
           this.set('model.newSubmission.submitter', null);
         } else {
           this.set('model.newSubmission.submitter', this.get('currentUser.user'));
@@ -183,8 +192,7 @@ export default Component.extend({
       // booleans
       const newProxy = this.get('model.newSubmission.hasNewProxy');
       const currentUserIsNotSubmitter = this.get('model.newSubmission.submitter.id') !== this.get('currentUser.user.id');
-      const submitterEmail = this.get('submitterEmail');
-      const proxySubmitterInfoExists = this.get('submitterEmail') && this.get('submitterName');
+      const proxySubmitterInfoExists = this.get('model.newSubmission.submitterEmail') && this.get('model.newSubmission.submitterName');
       const userIsNotPreparer = !this.get('model.newSubmission.preparers').map(x => x.get('id')).includes(this.get('currentUser.user.id'));
       const submitterExists = this.get('model.newSubmission.submitter.id');
       const proxySubmitterExists = submitterExists && currentUserIsNotSubmitter;
@@ -263,7 +271,7 @@ export default Component.extend({
       }
     },
     validateEmail() {
-      const email = this.get('submitterEmail');
+      const email = this.get('inputSubmitterEmail');
       let emailPattern = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
       if (email && emailPattern.test(email)) {
         this.set('validEmail', 'is-valid');

--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -4,8 +4,8 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),
-  files: Ember.A(),
   currentUser: service('current-user'),
+  files: Ember.A(),
   filesTemp: Ember.computed('workflow.filesTemp', {
     get(key) {
       return this.get('workflow').getFilesTemp();

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -252,7 +252,7 @@ export default Component.extend({
           value = $('[name="agreement-to-deposit"]')[1].checked;
         }
         // if proxy sub then set value of deposit agreement = true to let it pass.
-        if (this.get('hasProxy')) {
+        if (this.get('model.newSubmission.isProxySubmission')) {
           value = true;
         }
         let jhuRepo = this.get('model.repositories').filter(repo => repo.get('name') === 'JScholarship');

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -27,7 +27,6 @@ function getBrowserInfo() {
 
 
 export default Component.extend({
-  didAgree: false,
   router: service(),
   currentUser: service('current-user'),
   workflow: service(),

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -27,9 +27,9 @@ function getBrowserInfo() {
 
 
 export default Component.extend({
-  router: service(),
+  router: service('router'),
   currentUser: service('current-user'),
-  workflow: service(),
+  workflow: service('workflow'),
   common: {
     id: 'common',
     data: {},

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -3,9 +3,9 @@ import { inject as service, } from '@ember/service';
 
 export default Component.extend({
   addedRepositories: [],
-  router: service(),
-  store: service(),
-  workflow: service(),
+  router: service('router'),
+  store: service('store'),
+  workflow: service('workflow'),
   pmcPublisherDeposit: Ember.computed('workflow.pmcPublisherDeposit', function () {
     return this.get('workflow').getPmcPublisherDeposit();
   }),

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -57,7 +57,7 @@ export default Component.extend({
   ),
   userIsPreparer: Ember.computed('model.newSubmission', 'currentUser.user', function () {
     const isNotSubmitter = this.get('model.newSubmission.submitter.id') !== this.get('currentUser.user.id');
-    return (this.get('hasProxy') && isNotSubmitter);
+    return (this.get('model.newSubmission.isProxySubmission') && isNotSubmitter);
   }),
   submitButtonText: Ember.computed('userIsPreparer', function () {
     return this.get('userIsPreparer') ? 'Request approval' : 'Submit';

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -62,6 +62,9 @@ export default Component.extend({
   submitButtonText: Ember.computed('userIsPreparer', function () {
     return this.get('userIsPreparer') ? 'Request approval' : 'Submit';
   }),
+  displaySubmitterEmail: Ember.computed('model.newSubmission.submitterEmail', function() {
+    return this.get('model.newSubmission.submitterEmail').replace('mailto:', '');
+  }),
   actions: {
     submit() {
       $('.block-user-input').css('display', 'block');

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -1,9 +1,10 @@
 import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  workflow: Ember.inject.service('workflow'),
-  metadataService: Ember.inject.service('metadata-blob'),
-  currentUser: Ember.inject.service('currentUser'),
+  workflow: service('workflow'),
+  metadataService: service('metadata-blob'),
+  currentUser: service('current-user'),
   isValidated: Ember.A(),
   init() {
     this._super(...arguments);
@@ -62,7 +63,7 @@ export default Component.extend({
   submitButtonText: Ember.computed('userIsPreparer', function () {
     return this.get('userIsPreparer') ? 'Request approval' : 'Submit';
   }),
-  displaySubmitterEmail: Ember.computed('model.newSubmission.submitterEmail', function() {
+  displaySubmitterEmail: Ember.computed('model.newSubmission.submitterEmail', function () {
     return this.get('model.newSubmission.submitterEmail').replace('mailto:', '');
   }),
   actions: {

--- a/app/controllers/_login.js
+++ b/app/controllers/_login.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  session: Ember.inject.service('session'),
+  session: service('session'),
   actions: {
     authenticate() {
       const { username, password } = this.getProperties('username', 'password');

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,13 +1,13 @@
 import Controller from '@ember/controller';
 import config from '../config/environment';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  // session: Ember.inject.service('session'),
+  currentUser: service('current-user'),
+  notifications: service('toast'),
   params: ['userToken'],
   userToken: null,
   rootURL: config.rootURL,
-  currentUser: Ember.inject.service('current-user'),
-  notifications: Ember.inject.service('toast'),
   institution: '',
   wideRoutes: ['grants.index', 'grants.detail', 'submissions.index'],
   fullWidth: Ember.computed('currentRouteName', function () {

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
 import ENV from 'pass-ember/config/environment';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
   isSubmitter: Ember.computed('currentUser', function () {
     return this.get('currentUser.user.roles').includes('submitter');
   }),

--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -4,7 +4,7 @@ import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 import { computed } from '@ember/object';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
 
   // Columns displayed depend on the user role
   columns: computed('currentUser', {

--- a/app/controllers/grants/index.js
+++ b/app/controllers/grants/index.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
   // Bound to message dialog.
   messageShow: false,
   messageTo: '',

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -1,16 +1,17 @@
 import Controller from '@ember/controller';
 import ENV from 'pass-ember/config/environment';
+import { inject as service } from '@ember/service';
 // import swal from 'sweetalert2';
 
 export default Controller.extend({
-  metadataService: Ember.inject.service('metadata-blob'),
+  metadataService: service('metadata-blob'),
+  currentUser: service('current-user'),
+  store: service('store'),
   tooltips: function () {
     $(() => {
       $('[data-toggle="tooltip"]').tooltip();
     });
   }.on('init'),
-  currentUser: Ember.inject.service('current-user'),
-  store: Ember.inject.service('store'),
   externalSubmission: Ember.computed('externalSubmissionsMetadata', 'model.sub.submitted', function () {
     if (!this.get('model.sub.submitted')) {
       return [];

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -24,12 +24,6 @@ export default Controller.extend({
 
     return [];
   }),
-  hasProxy: Ember.computed(
-    'model.sub.preparers',
-    function () {
-      return this.get('model.sub.preparers.length') > 0;
-    }
-  ),
   /**
    * Ugly way to generate data for the template to use.
    * {
@@ -89,12 +83,12 @@ export default Controller.extend({
 
     return [];
   }),
-  mustVisitWeblink: Ember.computed('weblinkRepos', 'model', 'hasProxy', function () {
+  mustVisitWeblink: Ember.computed('weblinkRepos', 'model', function () {
     const weblinkExists = this.get('weblinkRepos').length > 0;
     const isSubmitter = this.get('currentUser.user.id') === this.get('model.sub.submitter.id');
-    const hasProxy = this.get('hasProxy');
+    const isProxySubmission = this.get('model.sub.isProxySubmission');
     const isSubmitted = this.get('model.sub.submitted');
-    return weblinkExists && isSubmitter && hasProxy && !isSubmitted;
+    return weblinkExists && isSubmitter && isProxySubmission && !isSubmitted;
   }),
   disableSubmit: Ember.computed(
     'mustVisitWeblink',

--- a/app/controllers/submissions/index.js
+++ b/app/controllers/submissions/index.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
   // Bound to message dialog.
   messageShow: false,
   messageTo: '',

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -5,7 +5,6 @@ export default Controller.extend({
   currentUser: Ember.inject.service('current-user'),
   workflow: Ember.inject.service('workflow'),
   queryParams: ['grant', 'submission'],
-  didNotAgree: false, // JHU was included as a repository but will be removed before review because the deposit agreement wasn't accepted
   comment: '', // Holds the comment that will be added to submissionEvent in the review step.
   uploading: false,
   waitingMessage: '',
@@ -82,15 +81,6 @@ export default Controller.extend({
         .filter(file => file && file.get('fileRole') === 'manuscript');
 
       let doSubmission = () => {
-        // Remove JHU as a repository if its deposit agreement is not signed.
-        if (this.get('didNotAgree')) {
-          let jhuRepo = this.get('model.newSubmission.repositories').filter(repo => repo.get('name') === 'JScholarship');
-          if (jhuRepo.length > 0) {
-            jhuRepo = jhuRepo[0];
-            this.get('model.newSubmission.repositories').removeObject(jhuRepo);
-          }
-        }
-
         // start setting variables on the new submission object.
         const sub = this.get('model.newSubmission');
         sub.set('submitted', false);

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -6,17 +6,15 @@ export default Controller.extend({
   workflow: Ember.inject.service('workflow'),
   queryParams: ['grant', 'submission'],
   didNotAgree: false, // JHU was included as a repository but will be removed before review because the deposit agreement wasn't accepted
-  submitterEmail: '', // holds the email of a submitter not yet in the system.
-  submitterName: '', // Holds the name of a submitter not yet in the system.
   comment: '', // Holds the comment that will be added to submissionEvent in the review step.
   hasProxy: Ember.computed( // Definite check for if the submission is in fact a proxy submission.
-    'submitterEmail',
-    'submitterName',
+    'model.newSubmission.submitterEmail',
+    'model.newSubmission.submitterName',
     'model.newSubmission.preparers',
     'model.newSubmission.hasNewProxy',
     function () {
       return (
-        (this.get('submitterEmail') && this.get('submitterName')) ||
+        (this.get('model.newSubmission.submitterEmail') && this.get('model.newSubmission.submitterName')) ||
         this.get('model.newSubmission.preparers.length') > 0 ||
         this.get('model.newSubmission.hasNewProxy')
       );
@@ -75,12 +73,10 @@ export default Controller.extend({
         // If a submitter is specified, it's a normal "approval-requested" scenario.
         if (s.get('submitter.id')) {
           subEvent.set('eventType', 'approval-requested');
-        } else if (this.get('submitterName') && this.get('submitterEmail')) {
+        } else if (this.get('model.newSubmission.submitterName') && this.get('model.newSubmission.submitterEmail')) {
           // debugger; // eslint-disable-line
           // If not specified but a name and email are present, create a mailto link.
           subEvent.set('eventType', 'approval-requested-newuser');
-          s.set('submitterEmail', `mailto:${this.get('submitterEmail')}`);
-          s.set('submitterName', this.get('submitterName'));
         } // end if
       } // end if
 

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -7,19 +7,6 @@ export default Controller.extend({
   queryParams: ['grant', 'submission'],
   didNotAgree: false, // JHU was included as a repository but will be removed before review because the deposit agreement wasn't accepted
   comment: '', // Holds the comment that will be added to submissionEvent in the review step.
-  hasProxy: Ember.computed( // Definite check for if the submission is in fact a proxy submission.
-    'model.newSubmission.submitterEmail',
-    'model.newSubmission.submitterName',
-    'model.newSubmission.preparers',
-    'model.newSubmission.hasNewProxy',
-    function () {
-      return (
-        (this.get('model.newSubmission.submitterEmail') && this.get('model.newSubmission.submitterName')) ||
-        this.get('model.newSubmission.preparers.length') > 0 ||
-        this.get('model.newSubmission.hasNewProxy')
-      );
-    }
-  ),
   uploading: false,
   waitingMessage: '',
 

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -1,9 +1,10 @@
 import Controller from '@ember/controller';
 import ENV from 'pass-ember/config/environment';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
-  currentUser: Ember.inject.service('current-user'),
-  workflow: Ember.inject.service('workflow'),
+  currentUser: service('current-user'),
+  workflow: service('workflow'),
   queryParams: ['grant', 'submission'],
   comment: '', // Holds the comment that will be added to submissionEvent in the review step.
   uploading: false,

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -2,24 +2,6 @@ import Controller from '@ember/controller';
 
 export default Controller.extend({
   parent: Ember.inject.controller('submissions.new'),
-  submitterName: Ember.computed('parent.submitterName', {
-    get(key) {
-      return this.get('parent').get('submitterName');
-    },
-    set(key, value) {
-      this.get('parent').set('submitterName', value);
-      return value;
-    }
-  }),
-  submitterEmail: Ember.computed('parent.submitterEmail', {
-    get(key) {
-      return this.get('parent').get('submitterEmail');
-    },
-    set(key, value) {
-      this.get('parent').set('submitterEmail', value);
-      return value;
-    }
-  }),
   hasProxy: Ember.computed('parent.hasProxy', function () {
     return this.get('parent').get('hasProxy');
   }),

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -1,10 +1,6 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  parent: Ember.inject.controller('submissions.new'),
-  hasProxy: Ember.computed('parent.hasProxy', function () {
-    return this.get('parent').get('hasProxy');
-  }),
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.grants');

--- a/app/controllers/submissions/new/metadata.js
+++ b/app/controllers/submissions/new/metadata.js
@@ -5,9 +5,6 @@ export default Controller.extend({
   didNotAgree: Ember.computed('parent.didNotAgree', function () {
     return this.get('parent').get('didNotAgree');
   }),
-  hasProxy: Ember.computed('parent.hasProxy', function () {
-    return this.get('parent').get('hasProxy');
-  }),
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.files');

--- a/app/controllers/submissions/new/metadata.js
+++ b/app/controllers/submissions/new/metadata.js
@@ -1,10 +1,6 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  parent: Ember.inject.controller('submissions.new'),
-  didNotAgree: Ember.computed('parent.didNotAgree', function () {
-    return this.get('parent').get('didNotAgree');
-  }),
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.files');

--- a/app/controllers/submissions/new/review.js
+++ b/app/controllers/submissions/new/review.js
@@ -17,12 +17,6 @@ export default Controller.extend({
       return value;
     }
   }),
-  submitterName: Ember.computed('parent.submitterName', function () {
-    return this.get('parent').get('submitterName');
-  }),
-  submitterEmail: Ember.computed('parent.submitterEmail', function () {
-    return this.get('parent').get('submitterEmail');
-  }),
   hasProxy: Ember.computed('parent.hasProxy', function () {
     return this.get('parent').get('hasProxy');
   }),

--- a/app/controllers/submissions/new/review.js
+++ b/app/controllers/submissions/new/review.js
@@ -17,9 +17,6 @@ export default Controller.extend({
       return value;
     }
   }),
-  hasProxy: Ember.computed('parent.hasProxy', function () {
-    return this.get('parent').get('hasProxy');
-  }),
   actions: {
     loadPrevious() {
       this.send('loadTab', 'submissions.new.files');

--- a/app/helpers/search-associated.js
+++ b/app/helpers/search-associated.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
 export default Ember.Helper.extend({
-  store: Ember.inject.service('store'),
+  store: service('store'),
 
   type: null,
   propertyName: null,

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -30,23 +30,20 @@ export default DS.Model.extend({
     async: true
   }),
 
-  // don't get saved to database
-  hasNewProxy: false,
+  // computed attributes for tables and to support some logic
   isProxySubmission: Ember.computed( // determines whether submission is a proxy submission.
-    'submitterEmail',
-    'submitterName',
-    'preparers',
-    'hasNewProxy',
+    'submitterEmail', 'submitterEmail.length',
+    'submitterName', 'submitterName.length',
+    'preparers', 'preparers.length',
     function () {
       return (
-        (this.get('submitterEmail') && this.get('submitterName')) ||
-        this.get('preparers.length') > 0 ||
-        this.get('hasNewProxy')
+        (this.get('submitterEmail') && this.get('submitterEmail.length') > 0
+          && this.get('submitterName') && this.get('submitterName.length') > 0
+        ) || (this.get('preparers') && this.get('preparers.length') > 0)
       );
     }
   ),
 
-  // attributes needed for tables
   publicationTitle: Ember.computed('publication', function () {
     return this.get('publication.title');
   }),

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,12 +1,9 @@
 import CheckSessionRoute from './check-session-route';
 import RSVP from 'rsvp';
-
-const {
-  service
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  currentUser: service(),
+  currentUser: service('current-user'),
 
   /* Used as route-action in templates */
   actions: {

--- a/app/routes/check-session-route.js
+++ b/app/routes/check-session-route.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
 import ENV from '../config/environment';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
-  toast: Ember.inject.service('toast'),
-  errorHandler: Ember.inject.service('error-handler'),
+  toast: service('toast'),
+  errorHandler: service('error-handler'),
   beforeModel(transition) {
     let url = 'Make sure you set your ENV.userService.url value in ~config/environment.js or your .env file';
     if (ENV.userService.url) {

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,9 +1,10 @@
 import CheckSessionRoute from './check-session-route';
 import ENV from 'pass-ember/config/environment';
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  currentUser: Ember.inject.service('current-user'),
-  ajax: Ember.inject.service(),
+  currentUser: service('current-user'),
+  ajax: service('ajax'),
   headers: { 'Content-Type': 'application/json; charset=utf-8' },
   async model() {
     const query = {

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -1,7 +1,6 @@
 import CheckSessionRoute from '../check-session-route';
 import { hash, defer } from 'rsvp';
-
-const { service } = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
   currentUser: service('current-user'),

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -1,8 +1,9 @@
 import CheckSessionRoute from '../check-session-route';
 import RSVP from 'rsvp';
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  currentUser: Ember.inject.service('current-user'),
+  currentUser: service('current-user'),
 
   model() {
     const user = this.get('currentUser.user');

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -1,11 +1,9 @@
 import CheckSessionRoute from '../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
+  currentUser: service('current-user'),
   beforeModel() {
     if (this.get('workflow').getCurrentStep() === 0) {
       this.transitionTo('submissions.new');
@@ -19,7 +17,6 @@ export default CheckSessionRoute.extend({
     }
   },
 
-  currentUser: service(),
 
   // Return a promise to load count objects starting at offsefrom of given type.
   loadObjects(type, offset, count) {

--- a/app/routes/submissions/new/basics.js
+++ b/app/routes/submissions/new/basics.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(1);

--- a/app/routes/submissions/new/files.js
+++ b/app/routes/submissions/new/files.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(6);

--- a/app/routes/submissions/new/grants.js
+++ b/app/routes/submissions/new/grants.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(2);

--- a/app/routes/submissions/new/index.js
+++ b/app/routes/submissions/new/index.js
@@ -1,11 +1,8 @@
 import Route from '@ember/routing/route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   beforeModel() {
     this.get('workflow').resetWorkflow();
     this.replaceWith('submissions.new.basics');

--- a/app/routes/submissions/new/metadata.js
+++ b/app/routes/submissions/new/metadata.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(5);

--- a/app/routes/submissions/new/policies.js
+++ b/app/routes/submissions/new/policies.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(3);

--- a/app/routes/submissions/new/repositories.js
+++ b/app/routes/submissions/new/repositories.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(4);

--- a/app/routes/submissions/new/review.js
+++ b/app/routes/submissions/new/review.js
@@ -1,11 +1,8 @@
 import CheckSessionRoute from '../../check-session-route';
-
-const {
-  service,
-} = Ember.inject;
+import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
-  workflow: service(),
+  workflow: service('workflow'),
   actions: {
     didTransition() {
       this.get('workflow').setCurrentStep(7);

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -27,8 +27,8 @@
     provide their email address and name so we may notify them:
   </p>
   <div class="form-inline">
-  {{input class=(concat "mt-1 mb-3 form-control w-50 " validEmail) keyUp=(action "validateEmail") disabled=model.newSubmission.submitter.id value=submitterEmail placeholder="Email address"}}
-  {{input class="mt-1 mb-3 form-control w-50" disabled=model.newSubmission.submitter.id value=submitterName placeholder="Name"}}
+  {{input class=(concat "mt-1 mb-3 form-control w-50 " validEmail) keyUp=(action "validateEmail") disabled=model.newSubmission.submitter.id value=inputSubmitterEmail placeholder="Email address"}}
+  {{input class="mt-1 mb-3 form-control w-50" disabled=model.newSubmission.submitter.id value=model.newSubmission.submitterName placeholder="Name"}}
   </div>
 </div>
 {{/if}}
@@ -111,8 +111,6 @@
     pageSize=modalPageSize
     totalResults=modalTotalResults
     searchInput=modalSearchInput
-    submitterEmail=submitterEmail
-    submitterName=submitterName
     users=users}}
 {{/modal-dialog}}
 {{/if}}

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -2,9 +2,8 @@
 {{#unless (or model.newSubmission.id model.preLoadedGrant)}}
 <div class="py-0 mt-2 alert alert-secondary" id="on-behalf-of-block">
   <p class="my-2 lead">I'm creating this submission on behalf of:
-    {{radio-button class="ml-3 mr-1" value=false name='showProxyWindow' checked=model.newSubmission.hasNewProxy}} Myself
-    {{radio-button class="ml-3 mr-1" value=true name='showProxyWindow' checked=model.newSubmission.hasNewProxy}} Someone
-    else
+    <input type="radio" checked={{ not model.newSubmission.hasNewProxy }} onchange={{action 'onBehalfOfToggled' false}}/> Myself
+    <input type="radio" checked={{ model.newSubmission.hasNewProxy }} onchange={{action 'onBehalfOfToggled' true}}/> Someone else
   </p>
 </div>
 {{#if model.newSubmission.hasNewProxy}}

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -2,11 +2,11 @@
 {{#unless (or model.newSubmission.id model.preLoadedGrant)}}
 <div class="py-0 mt-2 alert alert-secondary" id="on-behalf-of-block">
   <p class="my-2 lead">I'm creating this submission on behalf of:
-    <input type="radio" checked={{ not model.newSubmission.hasNewProxy }} onchange={{action 'onBehalfOfToggled' false}}/> Myself
-    <input type="radio" checked={{ model.newSubmission.hasNewProxy }} onchange={{action 'onBehalfOfToggled' true}}/> Someone else
+    <input type="radio" checked={{ not isProxySubmission }} onchange={{action 'proxyStatusToggled' false}}/> Myself
+    <input type="radio" checked={{ isProxySubmission }} onchange={{action 'proxyStatusToggled' true}}/> Someone else
   </p>
 </div>
-{{#if model.newSubmission.hasNewProxy}}
+{{#if isProxySubmission}}
 <div class="alert alert-info">
   <p>When a submission is created on someone's behalf, PASS will contact that person to acquire their approval before
     finalizing the submission and sending it to its corresponding repositories.</p>
@@ -20,7 +20,7 @@
     {{#if model.newSubmission.submitter.id}}
     <p>
       Currently selected submitter:<br>{{model.newSubmission.submitter.firstName}} {{model.newSubmission.submitter.lastName}}
-       (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)<br>(<a href="#" {{action 'removeCurrentSubmitter'}}>Remove submitter</a>)
+       (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)<br>(<a href="#" {{action 'resetSubmitter' isProxySubmission}}>Remove submitter</a>)
     </p>
     {{/if}}
   <p class="mb-0"><strong>If the person you are submitting for does not have an account with PASS</strong>, please

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -97,10 +97,10 @@
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
 <button class="btn btn-primary pull-right next" {{action "validateNext"}}>Next</button>
 {{#if isShowingModal}}
-{{#modal-dialog 
-   translucentOverlay=true 
-   onClose="toggleModal" 
-   close="toggleModal" 
+{{#modal-dialog
+   translucentOverlay=true
+   onClose="toggleModal"
+   close="toggleModal"
    tetherTarget='#on-behalf-of-block'
    attachment='top center'
    targetAttachment='top center'

--- a/app/templates/components/workflow-metadata.hbs
+++ b/app/templates/components/workflow-metadata.hbs
@@ -2,5 +2,5 @@
 <h4 class="font-weight-light pull-right" style="margin-top:6.5px;">
   Form {{displayFormStep}} of {{schemas.length}}
 </h4>
-{{metadata-form currentUser=currentUser didNotAgree=didNotAgree schema=schema model=model.newSubmission doiInfo=doiInfo currentFormStep=currentFormStep didAgree=didAgree nextForm=(action "nextForm") previousForm=(action "previousForm")}}
+{{metadata-form currentUser=currentUser schema=schema model=model.newSubmission doiInfo=doiInfo currentFormStep=currentFormStep nextForm=(action "nextForm") previousForm=(action "previousForm")}}
 {{yield}}

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -75,22 +75,7 @@
               <td>
                 <ul>
                   {{#each model.newSubmission.repositories as |repository|}}
-                  <li>
-                    {{#if (eq repository.name 'JScholarship')}}
-                    {{#if didNotAgree}}
-                    <div class="alert-danger" style="border-radius:2px; word-break:normal;  background-color: transparent;  border-color: transparent;">
-                      {{repository.name}}<br>
-                      <p class="text-danger text-left m-0"><strong>Warning:</strong> you added JScholarship as a
-                        repository but didn't agree to the deposit agreement, so your submission will not be submitted
-                        to JScholarship. To fix this, go back and agree to the deposit agreement.</p>
-                    </div>
-                    {{else}}
-                    {{repository.name}}
-                    {{/if}}
-                    {{else}}
-                    {{repository.name}}
-                    {{/if}}
-                  </li>
+                  <li>{{repository.name}}</li>
                   {{/each}}
                 </ul>
               </td>

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -218,7 +218,7 @@
                 </table>
               </td>
             </tr>
-            {{#if hasProxy}}
+            {{#if model.newSubmission.isProxySubmission}}
             <tr>
               <td>Comments</td>
               <td>

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -227,7 +227,7 @@
                   {{#if model.newSubmission.submitter}}
                   {{model.newSubmission.submitter.displayName}} (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)
                   {{else}}
-                  {{submitterName}} (<a href="mailto:{{submitterEmail}}">{{submitterEmail}}</a>)
+                  {{model.newSubmission.submitterName}} (<a href="{{model.newSubmission.submitterEmail}}">{{displaySubmitterEmail}}</a>)
                   {{/if}}
                 </p>
                 {{!-- Show the following if not saved yet. --}}
@@ -237,7 +237,7 @@
                   {{#if model.newSubmission.submitter.id}}
                   {{model.newSubmission.submitter.displayName}} (<a href="mailto:{{model.newSubmission.submitter.email}}">{{model.newSubmission.submitter.email}}</a>)
                   {{else}}
-                  {{submitterName}} (<a href="mailto:{{submitterEmail}}">{{submitterEmail}}</a>)
+                  {{model.newSubmission.submitterName}} (<a href="{{model.newSubmission.submitterEmail}}">{{displaySubmitterEmail}}</a>)
                   {{/if}}.
                   The submission will be sent to its target repositories upon approval, or be sent back to you if
                   additional edits

--- a/app/templates/submissions/new/basics.hbs
+++ b/app/templates/submissions/new/basics.hbs
@@ -3,8 +3,6 @@
   loadTab=(action "loadTab")
 }}
 {{workflow-basics
-  submitterEmail=submitterEmail
-  submitterName=submitterName
   hasProxy=hasProxy
   model=model
   next=(action "loadNext")

--- a/app/templates/submissions/new/basics.hbs
+++ b/app/templates/submissions/new/basics.hbs
@@ -3,7 +3,6 @@
   loadTab=(action "loadTab")
 }}
 {{workflow-basics
-  hasProxy=hasProxy
   model=model
   next=(action "loadNext")
 }}

--- a/app/templates/submissions/new/metadata.hbs
+++ b/app/templates/submissions/new/metadata.hbs
@@ -3,7 +3,6 @@
   loadTab=(action "loadTab")
 }}
 {{workflow-metadata
-  didNotAgree=didNotAgree
   model=model
   next=(action "loadNext")
   back=(action "loadPrevious")

--- a/app/templates/submissions/new/metadata.hbs
+++ b/app/templates/submissions/new/metadata.hbs
@@ -7,6 +7,5 @@
   model=model
   next=(action "loadNext")
   back=(action "loadPrevious")
-  hasProxy=hasProxy
 }}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/review.hbs
+++ b/app/templates/submissions/new/review.hbs
@@ -10,6 +10,5 @@
   submit=(action "submit")
   uploading=uploading
   waitingMessage=waitingMessage
-  hasProxy=hasProxy
 }}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/review.hbs
+++ b/app/templates/submissions/new/review.hbs
@@ -4,7 +4,6 @@
 }}
 {{workflow-review
   comment=comment
-  didNotAgree=didNotAgree
   model=model
   back=(action "loadPrevious")
   submit=(action "submit")

--- a/app/templates/submissions/new/review.hbs
+++ b/app/templates/submissions/new/review.hbs
@@ -4,8 +4,6 @@
 }}
 {{workflow-review
   comment=comment
-  submitterName=submitterName
-  submitterEmail=submitterEmail
   didNotAgree=didNotAgree
   model=model
   back=(action "loadPrevious")


### PR DESCRIPTION
Now that there are separate routes for the tabs, this change deals with a few pain points that were found along the way and generating unnecessary code. Full details are on each commit comment, it is easiest to look at them one at a time, but in general the following is included in this PR:

1. It replaces the proxy radio button in the basics step so that it can use an action on toggle instead of using an observer
2. It changes the workflow to use submitterEmail and submitterName on the model instead of as a property in the `submissions/new` controller
3. It formalizes `isProxySubmission` as a computed property on the submission model, and refactors the workflow code to use this instead of `hasProxy`, which was stored on the `submissions/new` controller
4.  Removes some old code relating to whether or not the user agreed to the JScholarship agreement that is no longer used.
5. Having noticed a bunch of different ways to inject a service, I went through the code and made all files use the same method, just for visual consistency.

Areas to look at that may be affected by the change:
1) Create a regular submission and proxy submission (new and existing user)
2) Check the submitter name and email appears correctly on the review page (it should not show the "mailto:" prefix)
3) Make sure that if you get halfway through the workflow and change your mind about who you are doing the submission on behalf of, or if you are doing a proxy submission, it should behave appropriately when you toggle the "on behalf of" radio button. 
4) Play with the JScholarship agreement (choosing to proceed without agreeing etc) and make sure the repository is removed or not depending on whether you proceed without checking agreement box.