### PR TITLE
Extract out call to crossref and nlmta as services

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -1,29 +1,12 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
-function resolve(publication) {
-  const base = 'https://doi.org/';
-
-  let doi = publication.get('doi');
-  doi = doi.replace(/https?:\/\/(dx\.)?doi\.org\//gi, '');
-
-  return fetch(base + encodeURI(doi), {
-    redirect: 'follow',
-    headers: { Accept: 'application/vnd.citationstyles.csl+json' }
-  })
-    .then((response) => {
-      if (response.status >= 200 && response.status < 300) return response;
-      throw new Error(`DOI lookup failed on ${response.url} status ${response.status}`);
-    })
-    .then(response => response.json());
-}
 
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),
   currentUser: service('current-user'),
-  validDOI: 'form-control',
-  isValidDOI: false,
+  doiService: service('doi'),
   isShowingUserSearchModal: false,
   isProxySubmission: Ember.computed('submission.isProxySubmission', function () {
     return this.get('submission.isProxySubmission');
@@ -48,6 +31,9 @@ export default Component.extend({
     this._super(...arguments);
     this.send('lookupDOI');
   },
+  isValidDOI: Ember.computed('publication.doi', function () {
+    return this.get('doiService').isValidDOI(this.get('publication.doi'));
+  }),
   titleClass: Ember.computed('flaggedFields', function () {
     return ((this.get('flaggedFields').indexOf('title') > -1) ? 'form-control is-invalid' : 'form-control');
   }),
@@ -56,6 +42,15 @@ export default Component.extend({
   }),
   submitterEmailClass: Ember.computed('flaggedFields', function () {
     return ((this.get('flaggedFields').indexOf('submitterEmail') > -1) ? 'is-invalid' : '');
+  }),
+  doiClass: Ember.computed('isValidDOI', function () {
+    let doi = this.get('publication.doi');
+    if (doi == null || !doi) {
+      return 'form-control';
+    } else if (this.get('isValidDOI') === true) {
+      return 'form-control is-valid';
+    }
+    return 'form-control is-invalid';
   }),
   actions: {
     proxyStatusToggled(isProxySubmission) {
@@ -87,7 +82,7 @@ export default Component.extend({
           if (result.value) {
             this.set('submission.grants', Ember.A());
             this.send('updateSubmitterModel', isProxySubmission, submitter);
-            toast.info('Submitter and related grants removed from submission.');
+            toastr.info('Submitter and related grants removed from submission.');
           }
         });
       } else {
@@ -106,88 +101,72 @@ export default Component.extend({
         this.set('submission.preparers', Ember.A());
       }
     },
-    validateDOI() {
-      // ref: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-      const doi = this.get('publication.doi');
-      const newDOIRegExp = /^(https?:\/\/(dx\.)?doi\.org\/)?10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
-      const ancientDOIRegExp = /^(https?:\/\/(dx\.)?doi\.org\/)?10.1002\/[^\s]+$/i;
-      // 0 = no value
-      if (doi == null || !doi) {
-        this.set('validDOI', 'form-control');
-        this.set('isValidDOI', false);
-      } else if (newDOIRegExp.test(doi) === true || ancientDOIRegExp.test(doi) === true) {
-        // 1 - Accepted
-        this.set('validDOI', 'form-control is-valid');
-        this.set('submission.metadata', '[]');
-        this.set('isValidDOI', true);
-      } else {
-        this.set('validDOI', 'form-control is-invalid');
-        this.set('isValidDOI', false);
-      }
-    },
     /** looks up the DIO and returns title and journal if avaiable */
     lookupDOI() {
-      if (this.get('publication.doi')) {
-        this.set('publication.doi', this.get('publication.doi').trim());
-        this.set('publication.doi', this.get('publication.doi').replace(/doi:/gi, ''));
-        this.set('publication.doi', this.get('publication.doi').replace(/https?:\/\/(dx\.)?doi\.org\//gi, ''));
-      }
       const publication = this.get('publication');
+      if (!publication || !publication.get('doi')) {
+        return;
+      }
 
-      if (publication && publication.get('doi')) {
-        this.send('validateDOI');
+      const doiService = this.get('doiService');
+      let doi = publication.get('doi');
+      doi = doiService.formatDOI(doi);
+      if (!doi || doi === '' || doiService.isValidDOI(doi) === false) {
+        return;
+      }
+      publication.set('doi', doi);
+      this.set('submission.metadata', '[]');
 
-        resolve(publication).then(async (doiInfo) => {
-          if (doiInfo.isDestroyed) {
-            return;
+      doiService.resolveDOI(doi).then(async (doiInfo) => {
+        if (doiInfo.isDestroyed) {
+          return;
+        }
+        const nlmtaDump = await this.getNlmtaFromIssn(doiInfo);
+        if (nlmtaDump) {
+          doiInfo.nlmta = nlmtaDump.nlmta;
+          doiInfo['issn-map'] = nlmtaDump.map;
+        }
+        doiInfo['journal-title'] = doiInfo['container-title'];
+        this.set('doiInfo', doiInfo);
+        publication.set('title', doiInfo.title);
+        publication.set('submittedDate', doiInfo.deposited);
+        publication.set('creationDate', doiInfo.created);
+        publication.set('issue', doiInfo.issue);
+        publication.set('volume', doiInfo.volume);
+        publication.set('abstract', doiInfo.abstract);
+
+        const desiredName = doiInfo['container-title'].trim();
+        const desiredIssn = Array.isArray(doiInfo.ISSN) // eslint-disable-line
+          ? doiInfo.ISSN[0]
+          : doiInfo.ISSN
+            ? doiInfo.ISSN
+            : '';
+
+        let query = { bool: { should: [{ match: { journalName: desiredName } }] } };
+        if (desiredIssn) query.bool.must = { term: { issns: desiredIssn } };
+        // Must match ISSN, optionally match journalName
+        // If journal is found, set it to the publication's journal.
+        // If journal is not found, make a journal based off the provided info and
+        // set it to the publication's journal.
+        this.get('store').query('journal', { query }).then((journals) => {
+          let journal = journals.get('length') > 0 ? journals.objectAt(0) : false;
+          if (!journal) {
+            const newJournal = this.get('store').createRecord('journal', {
+              journalName: doiInfo['container-title'].trim(),
+              issns: doiInfo.ISSN,
+              nlmta: doiInfo.nmlta
+            });
+            newJournal.save().then(j => publication.set('journal', j));
+          } else {
+            publication.set('journal', journal);
           }
-          const nlmtaDump = await this.getNlmtaFromIssn(doiInfo);
-          if (nlmtaDump) {
-            doiInfo.nlmta = nlmtaDump.nlmta;
-            doiInfo['issn-map'] = nlmtaDump.map;
-          }
-          doiInfo['journal-title'] = doiInfo['container-title'];
-          this.set('doiInfo', doiInfo);
-          publication.set('title', doiInfo.title);
-          publication.set('submittedDate', doiInfo.deposited);
-          publication.set('creationDate', doiInfo.created);
-          publication.set('issue', doiInfo.issue);
-          publication.set('volume', doiInfo.volume);
-          publication.set('abstract', doiInfo.abstract);
-
-          const desiredName = doiInfo['container-title'].trim();
-          const desiredIssn = Array.isArray(doiInfo.ISSN) // eslint-disable-line
-            ? doiInfo.ISSN[0]
-            : doiInfo.ISSN
-              ? doiInfo.ISSN
-              : '';
-
-          let query = { bool: { should: [{ match: { journalName: desiredName } }] } };
-          if (desiredIssn) query.bool.must = { term: { issns: desiredIssn } };
-          // Must match ISSN, optionally match journalName
-          // If journal is found, set it to the publication's journal.
-          // If journal is not found, make a journal based off the provided info and
-          // set it to the publication's journal.
-          this.get('store').query('journal', { query }).then((journals) => {
-            let journal = journals.get('length') > 0 ? journals.objectAt(0) : false;
-            if (!journal) {
-              const newJournal = this.get('store').createRecord('journal', {
-                journalName: doiInfo['container-title'].trim(),
-                issns: doiInfo.ISSN,
-                nlmta: doiInfo.nmlta
-              });
-              newJournal.save().then(j => publication.set('journal', j));
-            } else {
-              publication.set('journal', journal);
-            }
-          });
-          toast.success("We've pre-populated information from the DOI provided!");
-          this.sendAction('validateTitle');
-          this.sendAction('validateJournal');
-        }, (error) => {
-          // console.log(error.message);
-        }); // end resolve(publication).then()
-      } // end if (publication)
+        });
+        toastr.success("We've pre-populated information from the DOI provided!");
+        this.sendAction('validateTitle');
+        this.sendAction('validateJournal');
+      }, (error) => {
+        // console.log(error.message);
+      }); // end resolve(publication).then()
     },
 
     /** Sets the selected journal for the current publication.

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -7,6 +7,7 @@ export default Component.extend({
   workflow: service('workflow'),
   currentUser: service('current-user'),
   doiService: service('doi'),
+  nlmtaService: service('nlmta'),
   isShowingUserSearchModal: false,
   isProxySubmission: Ember.computed('submission.isProxySubmission', function () {
     return this.get('submission.isProxySubmission');
@@ -121,7 +122,7 @@ export default Component.extend({
         if (doiInfo.isDestroyed) {
           return;
         }
-        const nlmtaDump = await this.getNlmtaFromIssn(doiInfo);
+        const nlmtaDump = await this.get('nlmtaService').getNlmtaFromIssn(doiInfo);
         if (nlmtaDump) {
           doiInfo.nlmta = nlmtaDump.nlmta;
           doiInfo['issn-map'] = nlmtaDump.map;
@@ -176,7 +177,7 @@ export default Component.extend({
       let doiInfo = this.get('doiInfo');
       doiInfo = { 'journal-title': journal.get('journalName'), ISSN: journal.get('issns') };
 
-      const nlmtaDump = await this.getNlmtaFromIssn(doiInfo);
+      const nlmtaDump = await this.get('nlmtaService').getNlmtaFromIssn(doiInfo);
       if (nlmtaDump) {
         doiInfo.nlmta = nlmtaDump.nlmta;
         doiInfo['issn-map'] = nlmtaDump.map;
@@ -187,77 +188,5 @@ export default Component.extend({
       publication.set('journal', journal);
       this.sendAction('validateJournal');
     }
-  },
-
-  /**
-   * Use various services to fetch NLMTA and pub-type for given ISSNs found
-   * in the DOI data. This info will be merged in with the DOI data.
-   *
-   *  {
-   *    ... // other DOI data
-   *    "issn-map": {
-   *      "nlmta": "",
-   *      "map": {
-   *        "<ISSN-1>": {
-   *          "pub-type": [""]
-   *        }
-   *      }
-   *    }
-   *  }
-   */
-  async getNlmtaFromIssn(doiInfo) {
-    const issnMap = {
-      nlmta: undefined,
-      map: {}
-    };
-
-    // DOI should give ISSN as array or single string (?)
-    const issn = Array.isArray(doiInfo.ISSN) ? doiInfo.ISSN[0] : doiInfo.ISSN;
-
-    // Map of NLMIDs to objects
-    // Example: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nlmcatalog&term=0006-2952[issn]
-    const nlmidMap = await this.getNLMID(issn);
-    if (!nlmidMap || nlmidMap.length === 0) {
-      return;
-    }
-    // Example: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=nlmcatalog&retmode=json&rettype=abstract&id=101032
-    const idmap = await this.getNLMTA(nlmidMap);
-    nlmidMap.forEach((id) => {
-      const data = idmap[id];
-      if (!idmap) {
-        return;
-      }
-      issnMap.nlmta = data.medlineta;
-      data.issnlist
-        .filter(item => item.issntype !== 'Linking')
-        .forEach((item) => {
-          issnMap.map[item.issn] = { 'pub-type': [item.issntype] };
-        });
-    });
-
-    return issnMap;
-  },
-  /**
-   * TODO What happens if 'idlist' contains more than one ID?
-   * @param issn {string}
-   */
-  getNLMID(issn) {
-    const url = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nlmcatalog&term=${issn}[issn]&retmode=json`;
-    return fetch(url)
-      .then(resp => resp.json().then(data => data.esearchresult.idlist))
-      .catch((e) => {
-        console.log('NLMTA lookup failed.', e);
-      });
-  },
-  getNLMTA(nlmid) {
-    let idquery = nlmid;
-    if (Array.isArray(nlmid)) idquery = nlmid.join(',');
-    const url = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=nlmcatalog&retmode=json&rettype=abstract&id=${idquery}`;
-
-    return fetch(url)
-      .then(resp => resp.json().then(data => data.result))
-      .catch((e) => {
-        console.log('NLMTA lookup failed.', e);
-      });
   }
 });

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+
+export default Service.extend({
+  resolveDOI(doi) {
+    const base = 'https://doi.org/';
+    doi = this.formatDOI(doi);
+
+    return fetch(base + encodeURI(doi), {
+      redirect: 'follow',
+      headers: { Accept: 'application/vnd.citationstyles.csl+json' }
+    })
+      .then((response) => {
+        if (response.status >= 200 && response.status < 300) return response;
+        throw new Error(`DOI lookup failed on ${response.url} status ${response.status}`);
+      })
+      .then(response => response.json());
+  },
+
+  isValidDOI(doi) {
+    // ref: https://www.crossref.org/blog/dois-and-matching-regular-expressions/
+    const newDOIRegExp = /^(https?:\/\/(dx\.)?doi\.org\/)?10.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
+    const ancientDOIRegExp = /^(https?:\/\/(dx\.)?doi\.org\/)?10.1002\/[^\s]+$/i;
+    if (doi == null || !doi) {
+      return false;
+    } else if (newDOIRegExp.test(doi) === true || ancientDOIRegExp.test(doi) === true) {
+      return true;
+    }
+    return false;
+  },
+
+  formatDOI(doi) {
+    doi = doi.trim();
+    doi = doi.replace(/doi:/gi, '');
+    doi = doi.replace(/https?:\/\/(dx\.)?doi\.org\//gi, '');
+    return doi;
+  }
+});

--- a/app/services/nlmta.js
+++ b/app/services/nlmta.js
@@ -1,0 +1,75 @@
+import Service from '@ember/service';
+
+export default Service.extend({
+  /**
+   * Use various services to fetch NLMTA and pub-type for given ISSNs found
+   * in the DOI data. This info will be merged in with the DOI data.
+   *
+   *  {
+   *    ... // other DOI data
+   *    "issn-map": {
+   *      "nlmta": "",
+   *      "map": {
+   *        "<ISSN-1>": {
+   *          "pub-type": [""]
+   *        }
+   *      }
+   *    }
+   *  }
+   */
+  async getNlmtaFromIssn(doiInfo) {
+    const issnMap = {
+      nlmta: undefined,
+      map: {}
+    };
+
+    // DOI should give ISSN as array or single string (?)
+    const issn = Array.isArray(doiInfo.ISSN) ? doiInfo.ISSN[0] : doiInfo.ISSN;
+
+    // Map of NLMIDs to objects
+    // Example: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nlmcatalog&term=0006-2952[issn]
+    const nlmidMap = await this.getNLMID(issn);
+    if (!nlmidMap || nlmidMap.length === 0) {
+      return;
+    }
+    // Example: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=nlmcatalog&retmode=json&rettype=abstract&id=101032
+    const idmap = await this.getNLMTA(nlmidMap);
+    nlmidMap.forEach((id) => {
+      const data = idmap[id];
+      if (!idmap) {
+        return;
+      }
+      issnMap.nlmta = data.medlineta;
+      data.issnlist
+        .filter(item => item.issntype !== 'Linking')
+        .forEach((item) => {
+          issnMap.map[item.issn] = { 'pub-type': [item.issntype] };
+        });
+    });
+
+    return issnMap;
+  },
+  /**
+   * TODO What happens if 'idlist' contains more than one ID?
+   * @param issn {string}
+   */
+  getNLMID(issn) {
+    const url = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nlmcatalog&term=${issn}[issn]&retmode=json`;
+    return fetch(url)
+      .then(resp => resp.json().then(data => data.esearchresult.idlist))
+      .catch((e) => {
+        console.log('NLMTA lookup failed.', e);
+      });
+  },
+  getNLMTA(nlmid) {
+    let idquery = nlmid;
+    if (Array.isArray(nlmid)) idquery = nlmid.join(',');
+    const url = `https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=nlmcatalog&retmode=json&rettype=abstract&id=${idquery}`;
+
+    return fetch(url)
+      .then(resp => resp.json().then(data => data.result))
+      .catch((e) => {
+        console.log('NLMTA lookup failed.', e);
+      });
+  }
+});

--- a/app/services/workflow.js
+++ b/app/services/workflow.js
@@ -51,7 +51,6 @@ export default Service.extend({
   setDefaultRepoLoaded(defaultRepoLoaded) {
     this.set('defaultRepoLoaded', defaultRepoLoaded);
   },
-  // putting doiInfo here temporarily, eventually will be moved to its own service
   getDoiInfo() {
     return this.get('doiInfo');
   },

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -51,7 +51,7 @@
   </p>
 
   {{input
-  class=validDOI
+  class=doiClass
   value=publication.doi
   keyUp=(action "lookupDOI")
   mouseUp=(action "lookupDOI")
@@ -60,7 +60,7 @@
   readonly=submission.id
   }}
   <div class="text-danger">
-    {{if (eq validDOI 2) 'Please provide a valid DOI'}}
+    {{if (and publication.doi (not isValidDOI)) 'Please provide a valid DOI'}}
   </div>
 </div>
 <div class="form-group">

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:doi', 'Unit | Service | doi', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});

--- a/tests/unit/services/nlmta-test.js
+++ b/tests/unit/services/nlmta-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:nlmta', 'Unit | Service | nlmta', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
_Do not merge until PR #864 is merged and this is rebased_

This change extracts the code for the DOI lookup and the NLMTA lookup into separate Ember services (doi.js and nlmta.js respectively). Very little was done to the code, this is a copy-paste job to prepare the way for further work on these services.

Also, fixed a reference to the `toastr` service, and switched around some of the code for DOI validation.


Closes #859 