### PR TITLE
Repair broken tests, update test format per 3.5.0 Ember documentation

### DIFF
--- a/tests/integration/components/commenting-block-test.js
+++ b/tests/integration/components/commenting-block-test.js
@@ -1,24 +1,25 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('commenting-block', 'Integration | Component | commenting block', {
-  integration: true
-});
+module('Integration | Component | commenting block', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{commenting-block}}`);
+    this.render(hbs`{{commenting-block}}`);
 
-  assert.equal(this.$().text().trim(), '');
+    assert.equal(this.$().text().trim(), '');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#commenting-block}}
-      template block text
-    {{/commenting-block}}
-  `);
+    // Template block usage:
+    this.render(hbs`
+      {{#commenting-block}}
+        template block text
+      {{/commenting-block}}
+    `);
 
-  assert.equal(this.$().text().trim(), '');
+    assert.equal(this.$().text().trim(), '');
+  });
 });

--- a/tests/integration/components/date-cell-test.js
+++ b/tests/integration/components/date-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('date-cell', 'Integration | Component | date cell', {
-  integration: true
-});
+module('Integration | Component | date cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{date-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{date-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/find-journal-test.js
+++ b/tests/integration/components/find-journal-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('find-journal', 'Integration | Component | find journal', {
-  integration: true
-});
+module('Integration | Component | find journal', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{find-journal}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{find-journal}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/grant-action-cell-test.js
+++ b/tests/integration/components/grant-action-cell-test.js
@@ -1,20 +1,21 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('grant-action-cell', 'Integration | Component | grant action cell', {
-  integration: true
-});
+module('Integration | Component | grant action cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{grant-action-cell}}`);
+    await this.render(hbs`{{grant-action-cell}}`);
 
-  assert.equal(this.$().text().trim(), 'New submission');
+    assert.equal(this.$().text().trim(), 'New submission');
 
-  // Template block usage:
-  this.render(hbs`{{#grant-action-cell}}template block text{{/grant-action-cell}}`);
+    // Template block usage:
+    await this.render(hbs`{{#grant-action-cell}}template block text{{/grant-action-cell}}`);
 
-  assert.equal(this.$().text().trim(), 'New submission\ntemplate block text');
+    assert.equal(this.$().text().trim(), 'New submission\ntemplate block text');
+  });
 });

--- a/tests/integration/components/grant-link-cell-test.js
+++ b/tests/integration/components/grant-link-cell-test.js
@@ -1,13 +1,12 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | grant-link-cell', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', async (assert) => {
-    await render(hbs`{{grant-link-cell}}`);
+
+  test('it renders', async function (assert) {
+    await this.render(hbs`{{grant-link-cell}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/grant-submission-cell-test.js
+++ b/tests/integration/components/grant-submission-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('grant-submission-cell', 'Integration | Component | grant submission cell', {
-  integration: true
-});
+module('Integration | Component | grant submission cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{grant-submission-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{grant-submission-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/message-dialog-test.js
+++ b/tests/integration/components/message-dialog-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('message-dialog', 'Integration | Component | message-dialog', {
-  integration: true
-});
+module('Integration | Component | message-dialog', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{message-dialog}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{message-dialog}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/metadata-form-test.js
+++ b/tests/integration/components/metadata-form-test.js
@@ -1,16 +1,12 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | metadata-form', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', function (assert) {
-    let model = {};
 
-    // TODO: add actual tests here
-    model = Ember.Object.create({
+  test('it renders', async function (assert) {
+    let submission = Ember.Object.create({
       metadata: '[]'
     });
     let schema = {
@@ -33,14 +29,19 @@ module('Integration | Component | metadata-form', (hooks) => {
     };
 
     this.set('schema', schema);
-    this.set('model', model);
+    this.set('submission', submission);
 
     let doiInfo = [];
     this.set('doiInfo', doiInfo);
     let currentFormStep = 0;
     this.set('currentFormStep', currentFormStep);
 
-    render(hbs`{{metadata-form schema=schema model=model doiInfo=doiInfo currentFormStep=currentFormStep}}`);
+    this.render(hbs`{{metadata-form
+        currentUser=currentUser
+        schema=schema
+        submission=submission
+        doiInfo=doiInfo
+        currentFormStep=currentFormStep}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/nav-bar-test.js
+++ b/tests/integration/components/nav-bar-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('nav-bar', 'Integration | Component | nav bar', {
-  integration: true
-});
+module('Integration | Component | nav bar', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{nav-bar}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{nav-bar}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/oap-compliance-cell-test.js
+++ b/tests/integration/components/oap-compliance-cell-test.js
@@ -1,15 +1,15 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('oap-compliance-cell', 'Integration | Component | oap compliance cell', {
-  integration: true
-});
+module('Integration | Component | oap compliance cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{oap-compliance-cell}}`);
-
-  assert.ok(true);
+    this.render(hbs`{{oap-compliance-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/pi-list-cell-test.js
+++ b/tests/integration/components/pi-list-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('pi-list-cell', 'Integration | Component | pi list cell', {
-  integration: true
-});
+module('Integration | Component | pi list cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{pi-list-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{pi-list-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/policy-card-test.js
+++ b/tests/integration/components/policy-card-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('policy-card', 'Integration | Component | policy card', {
-  integration: true
-});
+module('Integration | Component | policy card', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{policy-card}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{policy-card}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/repo-copy-display-test.js
+++ b/tests/integration/components/repo-copy-display-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('repocopy-display', 'Integration | Component | repocopy display', {
-  integration: true
-});
+module('Integration | Component | repocopy display', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{repocopy-display}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{repocopy-display}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/select-row-toggle-test.js
+++ b/tests/integration/components/select-row-toggle-test.js
@@ -1,22 +1,23 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('select-row-toggle', 'Integration | Component | select row toggle', {
-  integration: true
-});
+module('Integration | Component | select row toggle', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{select-row-toggle}}`);
+    this.render(hbs`{{select-row-toggle}}`);
 
-  // Template block usage:
-  this.render(hbs`
-    {{#select-row-toggle}}
-      template block text
-    {{/select-row-toggle}}
-  `);
+    // Template block usage:
+    this.render(hbs`
+      {{#select-row-toggle}}
+        template block text
+      {{/select-row-toggle}}
+    `);
 
-  assert.ok(true);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submission-action-cell-test.js
+++ b/tests/integration/components/submission-action-cell-test.js
@@ -1,30 +1,31 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submission-action-cell', 'Integration | Component | submission action cell', {
-  integration: true
-});
+module('Integration | Component | submission action cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  let record = {};
+  test('it renders', async function (assert) {
+    let record = {};
 
-  // TODO: add actual tests here
-  record = Ember.Object.create({
-    preparers: []
+    // TODO: add actual tests here
+    record = Ember.Object.create({
+      preparers: []
+    });
+
+    this.set('record', record);
+
+    await this.render(hbs`{{submission-action-cell record=record}}`);
+
+    assert.equal(this.$().text().trim(), 'No actions available.');
+
+    // Template block usage:
+    await this.render(hbs`
+      {{#submission-action-cell record=record}}
+        template block text
+      {{/submission-action-cell}}
+    `);
+
+    assert.equal(this.$().text().trim(), 'No actions available.');
   });
-
-  this.set('record', record);
-
-  this.render(hbs`{{submission-action-cell record=record}}`);
-
-  assert.equal(this.$().text().trim(), 'No actions available.');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#submission-action-cell record=record}}
-      template block text
-    {{/submission-action-cell}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'No actions available.');
 });

--- a/tests/integration/components/submission-author-cell-test.js
+++ b/tests/integration/components/submission-author-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submission-author-cell', 'Integration | Component | submission author cell', {
-  integration: true
-});
+module('Integration | Component | submission author cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submission-author-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submission-author-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submission-funding-table-test.js
+++ b/tests/integration/components/submission-funding-table-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submission-funding-table', 'Integration | Component | submission-funding-table', {
-  integration: true
-});
+module('Integration | Component | submission-funding-table', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submission-funding-table}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submission-funding-table}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submission-nav-test.js
+++ b/tests/integration/components/submission-nav-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submission-nav', 'Integration | Component | grant submission cell', {
-  integration: true
-});
+module('Integration | Component | grant submission cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submission-nav}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submission-nav}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submission-repo-details-test.js
+++ b/tests/integration/components/submission-repo-details-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submission-repo-details', 'Integration | Component | submission repo details', {
-  integration: true
-});
+module('Integration | Component | submission repo details', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submission-repo-details}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submission-repo-details}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-author-cell-test.js
+++ b/tests/integration/components/submissions-author-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submissions-author-cell', 'Integration | Component | submissions author cell', {
-  integration: true
-});
+module('Integration | Component | submissions author cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submissions-author-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submissions-author-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-award-cell-test.js
+++ b/tests/integration/components/submissions-award-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submissions-award-cell', 'Integration | Component | submissions award cell', {
-  integration: true
-});
+module('Integration | Component | submissions award cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submissions-award-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submissions-award-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-repo-cell-test.js
+++ b/tests/integration/components/submissions-repo-cell-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submissions-repo-cell', 'Integration | Component | submissions repo cell', {
-  integration: true
-});
+module('Integration | Component | submissions repo cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  // Template usage:
-  this.render(hbs`{{submissions-repo-cell}}`);
-  assert.ok(true);
+    // Template usage:
+    this.render(hbs`{{submissions-repo-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-repoid-cell-test.js
+++ b/tests/integration/components/submissions-repoid-cell-test.js
@@ -1,15 +1,30 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { run } from '@ember/runloop';
 
-moduleForComponent('submissions-repoid-cell', 'Integration | Component | submissions repoid cell', {
-  integration: true
-});
+module('Integration | Component | submissions repoid cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  // Inject mocked store that on query returns a single user
+  hooks.beforeEach(function () {
+    let store = Ember.Service.extend({
+      query: (type, q) => Promise.resolve([Ember.Object.create({ id: 'test' })])
+    });
 
-  // Template usage:
-  this.render(hbs`{{submissions-repoid-cell}}`);
-  assert.ok(true);
+    run(() => {
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', store);
+      this.store = this.owner.lookup('service:store');
+    });
+  });
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
+
+    // Template usage:
+    await this.render(hbs`{{submissions-repoid-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-status-cell-test.js
+++ b/tests/integration/components/submissions-status-cell-test.js
@@ -1,17 +1,18 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('submissions-status-cell', 'Integration | Component | submissions status cell', {
-  integration: true
-});
+module('Integration | Component | submissions status cell', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.on('myAction', function(val) { ... });
 
-  this.render(hbs`{{submissions-status-cell submissionStatus="submitted"}}`);
-  assert.ok(true);
+    this.render(hbs`{{submissions-status-cell submissionStatus="submitted"}}`);
+    assert.ok(true);
 
-  // Template block usage:
-  // this.render(hbs`{{submissions-status-cell status=""}}`);
+    // Template block usage:
+    // this.render(hbs`{{submissions-status-cell status=""}}`);
+  });
 });

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -1,20 +1,40 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('workflow-basics', 'Integration | Component | workflow basics', {
-  integration: true
-});
+module('Integration | Component | workflow basics', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  let model = {};
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
+      repositories: [],
+      grants: []
+    });
+    let publication = Ember.Object.create({});
+    let preLoadedGrant = Ember.Object.create({});
+    let flaggedFields = [];
+    let doiInfo = [];
+    this.set('submission', submission);
+    this.set('publication', publication);
+    this.set('preLoadedGrant', preLoadedGrant);
+    this.set('doiInfo', doiInfo);
+    this.set('flaggedFields', '[]');
+    // pass in actions that do nothing
+    this.set('validateTitle', (actual) => { });
+    this.set('validateJournal', (actual) => { });
+    this.set('validateSubmitterEmail', (actual) => { });
+    this.set('loadNext', (actual) => {});
 
-  model = Ember.Object.create({
-    newSubmission: Ember.Object.create({
-    })
+    this.render(hbs`{{workflow-basics
+      submission=submission
+      publication=publication
+      preLoadedGrant=preLoadedGrant
+      doiInfo=doiInfo
+      flaggedFields=flaggedFields
+      validateTitle=(action validateTitle)
+      validateJournal=(action validateJournal)
+      validateSubmitterEmail=(action validateSubmitterEmail)
+      next=(action loadNext)}}`);
+    assert.ok(true);
   });
-
-  this.set('model', model);
-
-  this.render(hbs`{{workflow-basics model=model}}`);
-  assert.ok(true);
 });

--- a/tests/integration/components/workflow-files-test.js
+++ b/tests/integration/components/workflow-files-test.js
@@ -1,15 +1,29 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('workflow-files', 'Integration | Component | workflow files', {
-  integration: true
-});
+module('Integration | Component | workflow files', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
+      repositories: [],
+      grants: []
+    });
+    let files = [Ember.Object.create({})];
+    let newFiles = Ember.A();
+    this.set('submission', submission);
+    this.set('files', files);
+    this.set('newFiles', newFiles);
+    this.set('loadPrevious', (actual) => {});
+    this.set('loadNext', (actual) => {});
 
-  // Template usage:
-  this.render(hbs`{{workflow-files}}`);
-  assert.ok(true);
+    this.render(hbs`{{workflow-files
+      submission=submission
+      previouslyUploadedFiles=files
+      newFiles=newFiles
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/workflow-grants-test.js
+++ b/tests/integration/components/workflow-grants-test.js
@@ -1,26 +1,26 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | workflow grants', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', function (assert) {
-    let model = {};
 
-    // TODO: add actual tests here
-    model.newSubmission = Ember.Object.create({
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
       repositories: [],
       grants: []
     });
-    model.grants = [];
-    let maxStep = 2;
+    let preLoadedGrant = Ember.Object.create({});
+    this.set('submission', submission);
+    this.set('preLoadedGrant', preLoadedGrant);
+    this.set('loadPrevious', (actual) => {});
+    this.set('loadNext', (actual) => {});
 
-    this.set('model', model);
-    this.set('maxStep', maxStep);
-
-    render(hbs`{{workflow-grants model=model maxStep=maxStep}}`);
+    this.render(hbs`{{workflow-grants
+      submission=submission
+      preLoadedGrant=preLoadedGrant
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -1,29 +1,27 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | workflow metadata', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', function (assert) {
-    let model = {};
 
-    // TODO: add actual tests here
-    model.newSubmission = Ember.Object.create({
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
       repositories: [],
       grants: []
     });
-    model.metadataForms = [Ember.Object.create()];
+    let repositories = Ember.Object.create({});
+    this.set('submission', submission);
+    this.set('repositories', repositories);
+    this.set('loadPrevious', (actual) => {});
+    this.set('loadNext', (actual) => {});
+    // this.set('metadataForms', [Ember.Object.create()]);
 
-    let doiInfo = Ember.Object.create();
-
-    this.set('model', model);
-    this.set('doiInfo', doiInfo);
-
-    console.log('hi there');
-
-    render(hbs`{{workflow-metadata model=model doiInfo=doiInfo}}`);
+    this.render(hbs`{{workflow-metadata
+      submission=submission
+      repositories=repositories
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/workflow-policies-test.js
+++ b/tests/integration/components/workflow-policies-test.js
@@ -1,24 +1,30 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | workflow policies', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', function (assert) {
-    let model = {};
 
-    // TODO: add actual tests here
-    model.newSubmission = Ember.Object.create({
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
       repositories: [],
       grants: []
     });
-    model.policies = [];
+    let policies = [];
+    let publication = Ember.Object.create({});
 
-    this.set('model', model);
+    this.set('submission', submission);
+    this.set('policies', policies);
+    this.set('publication', publication);
+    this.set('loadPrevious', (actual) => {});
+    this.set('loadNext', (actual) => {});
 
-    render(hbs`{{workflow-policies model=model}}`);
+    this.render(hbs`{{workflow-policies
+      submission=submission
+      policies=policies
+      publication=publication
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/workflow-repositories-test.js
+++ b/tests/integration/components/workflow-repositories-test.js
@@ -1,16 +1,12 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
-
+import { module, test } from 'qunit';
 
 module('Integration | Component | workflow repositories', (hooks) => {
   setupRenderingTest(hooks);
-  test('it renders', function (assert) {
-    let model = {};
 
-    // TODO: add actual tests here
-    model.newSubmission = Ember.Object.create({
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({
       repositories: [
       ],
       grants: [
@@ -23,10 +19,18 @@ module('Integration | Component | workflow repositories', (hooks) => {
         }),
       ]
     });
-    model.repositories = [];
+    let repositories = [];
 
-    this.set('model', model);
-    render(hbs`{{workflow-repositories model=model}}`);
+    this.set('repositories', repositories);
+    this.set('submission', submission);
+    this.set('loadPrevious', (actual) => {});
+    this.set('loadNext', (actual) => {});
+
+    this.render(hbs`{{workflow-repositories
+      submission=submission
+      repositories=repositories
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -1,24 +1,36 @@
-import { moduleForComponent, test, setupRenderingTest } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { module } from 'qunit';
-import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
 
-
-module('Integration | Component | workflow-review', (hooks) => {
+module('Integration | Component | workflow review', (hooks) => {
   setupRenderingTest(hooks);
+
   test('it renders', function (assert) {
-    let model = {};
-
-    // TODO: add actual tests here
-    model = Ember.Object.create({
-      newSubmission: Ember.Object.create({
-        metadata: '[]',
-        repositories: []
-      })
+    let submission = Ember.Object.create({
+      metadata: '[]',
+      repositories: []
     });
-    this.set('model', model);
+    let publication = Ember.Object.create({});
+    let files = [Ember.Object.create({})];
 
-    render(hbs`{{workflow-review model=model}}`);
+    this.set('submission', submission);
+    this.set('publication', publication);
+    this.set('submit', (actual) => {});
+    this.set('loadPrevious', (actual) => {});
+    this.set('files', files);
+    this.set('comment', '');
+    this.set('uploading', '');
+    this.set('waitingMessage', '');
+
+    this.render(hbs`{{workflow-review
+      submission=submission
+      publication=publication
+      previouslyUploadedFiles=files
+      comment=comment
+      back=(action loadPrevious)
+      submit=(action submit)
+      uploading=uploading
+      waitingMessage=waitingMessage}}`);
     assert.ok(true);
   });
 });

--- a/tests/integration/components/workflow-wrapper-test.js
+++ b/tests/integration/components/workflow-wrapper-test.js
@@ -1,21 +1,25 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('workflow-wrapper', 'Integration | Component | workflow wrapper', {
-  integration: true
-});
+module('Integration | Component | workflow wrapper', (hooks) => {
+  setupRenderingTest(hooks);
 
-test('it renders', function (assert) {
-  let model = {};
+  test('it renders', function (assert) {
+    let submission = Ember.Object.create({ });
+    let publication = Ember.Object.create({ });
+    let submissionEvent = Ember.Object.create({ });
 
-  // TODO: add actual tests here
-  model = Ember.Object.create({
-    newSubmission: Ember.Object.create({
-    })
+    this.set('submission', submission);
+    this.set('publication', publication);
+    this.set('submissionEvents', [submissionEvent]);
+    this.set('validateAndLoadTab', (actual) => {});
+
+    this.render(hbs`{{workflow-wrapper
+      submission=submission
+      publication=publication
+      submissionEvents=submissionEvents
+      loadTab=(action validateAndLoadTab)}}`);
+    assert.ok(true);
   });
-
-  this.set('model', model);
-
-  this.render(hbs`{{workflow-wrapper model=model}}`);
-  assert.ok(true);
 });

--- a/tests/integration/helpers/format-date-test.js
+++ b/tests/integration/helpers/format-date-test.js
@@ -1,15 +1,16 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('format-date', 'helper:format-date', {
-  integration: true
-});
+module('Integration | Helper | format date', (hooks) => {
+  setupRenderingTest(hooks);
 
-// Replace this with your real tests.
-test('it renders', function(assert) { // eslint-disable-line
-  this.set('inputValue', 'August 19, 1975 23:15:30');
+  // Replace this with your real tests.
+  test('it renders', async function(assert) { // eslint-disable-line
+    this.set('inputValue', 'August 19, 1975 23:15:30');
 
-  this.render(hbs`{{format-date inputValue}}`);
+    await this.render(hbs`{{format-date inputValue}}`);
 
-  assert.equal(this.$().text().trim(), '08/19/1975');
+    assert.equal(this.$().text().trim(), '08/19/1975');
+  });
 });

--- a/tests/integration/helpers/format-oap-compliance-test.js
+++ b/tests/integration/helpers/format-oap-compliance-test.js
@@ -1,16 +1,16 @@
-
-import { moduleForComponent, test } from 'ember-qunit';
+import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
 
-moduleForComponent('format-oap-compliance', 'helper:format-oap-compliance', {
-  integration: true
-});
+module('Integration | Helper | format oap compliance', (hooks) => {
+  setupRenderingTest(hooks);
 
-// Replace this with your real tests.
-test('it renders', function (assert) {
-  this.set('inputValue', 'Yes');
+  // Replace this with your real tests.
+  test('it renders', async function(assert) { // eslint-disable-line
+    this.set('inputValue', 'Yes');
 
-  this.render(hbs`{{format-oap-compliance inputValue}}`);
+    await this.render(hbs`{{format-oap-compliance inputValue}}`);
 
-  assert.equal(this.$().text().trim(), 'Yes');
+    assert.equal(this.$().text().trim(), 'Yes');
+  });
 });

--- a/tests/unit/adapters/application-test.js
+++ b/tests/unit/adapters/application-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleFor('adapter:application', 'Unit | Adapter | application', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser']
-});
+module('Unit | Adapter | application', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let adapter = this.subject();
-  assert.ok(adapter);
+  test('it exists', function (assert) {
+    let adapter = this.owner.lookup('adapter:application');
+    assert.ok(adapter);
+  });
 });

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:application', 'Unit | Controller | application', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser']
-});
+module('Unit | Controller | application', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', (assert) => {
-  // let controller = this.subject();
-  assert.ok(true);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:application');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/grants/detail-test.js
+++ b/tests/unit/controllers/grants/detail-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:grants/detail', 'Unit | Controller | grants/detail', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser']
-});
+module('Unit | Controller | submissions/new', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:grants/detail');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/grants/index-test.js
+++ b/tests/unit/controllers/grants/index-test.js
@@ -1,31 +1,30 @@
-import { moduleFor, test } from 'ember-qunit';
-import User from 'pass-ember/models/user';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:grants/index', 'Unit | Controller | grants/index', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:ajax']
-});
+module('Unit | Controller | grants/index', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
-});
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:grants/index');
+    assert.ok(controller);
+  });
 
-test('properly returns admin roles', function (assert) {
-  let controller = this.subject();
-  controller.set('currentUser.user', Ember.Object.create({
-    isAdmin: true
-  }));
+  test('properly returns admin roles', function (assert) {
+    let controller = this.owner.lookup('controller:grants/index');
+    controller.set('currentUser.user', Ember.Object.create({
+      isAdmin: true
+    }));
 
-  assert.equal(controller.get('adminColumns'), controller.get('columns'));
-});
+    assert.equal(controller.get('adminColumns'), controller.get('columns'));
+  });
 
-test('properly returns submitter roles', function (assert) {
-  let controller = this.subject();
-  controller.set('currentUser.user', Ember.Object.create({
-    isSubmitter: true
-  }));
+  test('properly returns submitter roles', function (assert) {
+    let controller = this.owner.lookup('controller:grants/index');
+    controller.set('currentUser.user', Ember.Object.create({
+      isSubmitter: true
+    }));
 
-  assert.equal(controller.get('piColumns'), controller.get('columns'));
+    assert.equal(controller.get('piColumns'), controller.get('columns'));
+  });
 });

--- a/tests/unit/controllers/submissions-test.js.js
+++ b/tests/unit/controllers/submissions-test.js.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/index', 'Unit | Controller | submissions/index', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/detail-test.js
+++ b/tests/unit/controllers/submissions/detail-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/detail', 'Unit | Controller | submissions/detail', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:metadata-blob', 'service:toast']
-});
+module('Unit | Controller | submissions/detail', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/detail');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/index-test.js
+++ b/tests/unit/controllers/submissions/index-test.js
@@ -1,28 +1,28 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/index', 'Unit | Controller | submissions/index', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:ajax']
-});
+module('Unit | Controller | submissions/index', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
-});
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/index');
+    assert.ok(controller);
+  });
 
-test('properly returns admin roles', function (assert) {
-  let controller = this.subject();
-  controller.set('currentUser.user', Ember.Object.create({
-    isAdmin: true
-  }));
-  assert.equal(controller.get('columns.length'), 6);
-});
+  test('properly returns admin roles', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/index');
+    controller.set('currentUser.user', Ember.Object.create({
+      isAdmin: true
+    }));
+    assert.equal(controller.get('columns.length'), 6);
+  });
 
-test('properly returns submitter roles', function (assert) {
-  let controller = this.subject();
-  controller.set('currentUser.user', Ember.Object.create({
-    isSubmitter: true
-  }));
-  assert.equal(controller.get('columns.length'), 7);
+  test('properly returns submitter roles', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/index');
+    controller.set('currentUser.user', Ember.Object.create({
+      isSubmitter: true
+    }));
+    assert.equal(controller.get('columns.length'), 7);
+  });
 });

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new', 'Unit | Controller | submissions/new', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser']
-});
+module('Unit | Controller | submissions/new', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/basics-test.js
+++ b/tests/unit/controllers/submissions/new/basics-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/basics', 'Unit | Controller | submissions/new/basics', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/basics', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/files-test.js
+++ b/tests/unit/controllers/submissions/new/files-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/files', 'Unit | Controller | submissions/new/files', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/files', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/files');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/grants-test.js
+++ b/tests/unit/controllers/submissions/new/grants-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/grants', 'Unit | Controller | submissions/new/grants', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/grants', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/grants');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/metadata-test.js
+++ b/tests/unit/controllers/submissions/new/metadata-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/metadata', 'Unit | Controller | submissions/new/metadata', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/metadata', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/metadata');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/policies-test.js
+++ b/tests/unit/controllers/submissions/new/policies-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/policies', 'Unit | Controller | submissions/new/policies', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/policies', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/policies');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/repositories-test.js
+++ b/tests/unit/controllers/submissions/new/repositories-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/repositories', 'Unit | Controller | submissions/new/repositories', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/repositories', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/repositories');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/submissions/new/review-test.js
+++ b/tests/unit/controllers/submissions/new/review-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:submissions/new/review', 'Unit | Controller | submissions/new/review', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | submissions/new/review', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/review');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/controllers/thanks-test.js
+++ b/tests/unit/controllers/thanks-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('controller:thanks', 'Unit | Controller | thanks', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Controller | thanks', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let controller = this.subject();
-  assert.ok(controller);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let controller = this.owner.lookup('controller:thanks');
+    assert.ok(controller);
+  });
 });

--- a/tests/unit/instance-initializers/error-handler-test.js
+++ b/tests/unit/instance-initializers/error-handler-test.js
@@ -3,24 +3,28 @@ import { run } from '@ember/runloop';
 import { initialize } from 'pass-ember/instance-initializers/error-handler';
 import { module, test } from 'qunit';
 import destroyApp from '../../helpers/destroy-app';
+import { setupTest } from 'ember-qunit';
 
-module('Unit | Instance Initializer | error handler', {
-  beforeEach() {
+module('Unit | Instance Initializers | error handler', (hooks) => {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
     run(() => {
-      this.application = Application.create();
+      this.application = Application.create({ autoboot: false });
       this.appInstance = this.application.buildInstance();
     });
-  },
-  afterEach() {
+  });
+
+  hooks.afterEach(function () {
     run(this.appInstance, 'destroy');
     destroyApp(this.application);
-  }
-});
+  });
 
-// Replace this with your real tests.
-test('it works', function (assert) {
-  initialize(this.appInstance);
+  // Replace this with your real tests.
+  test('it works', function (assert) {
+    initialize(this.appInstance);
 
-  // you would normally confirm the results of the initializer here
-  assert.ok(true);
+    // you would normally confirm the results of the initializer here
+    assert.ok(true);
+  });
 });

--- a/tests/unit/models/contributor-test.js
+++ b/tests/unit/models/contributor-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('contributor', 'Unit | Model | contributor', {
-  // Specify the other units that are required for this test.
-  needs: ['model:publication', 'model:user']
-});
+module('Unit | Model | contributor', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const contributor = run(() => this.owner.lookup('service:store').createRecord('contributor'));
+    assert.ok(contributor);
+  });
 });

--- a/tests/unit/models/file-test.js
+++ b/tests/unit/models/file-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('file', 'Unit | Model | file', {
-  // Specify the other units that are required for this test.
-  needs: ['model:submission']
-});
+module('Unit | Model | file', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const file = run(() => this.owner.lookup('service:store').createRecord('file'));
+    assert.ok(file);
+  });
 });

--- a/tests/unit/models/funder-test.js
+++ b/tests/unit/models/funder-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('funder', 'Unit | Model | funder', {
-  // Specify the other units that are required for this test.
-  needs: ['model:policy', 'model:repository']
-});
+module('Unit | Model | funder', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const funder = run(() => this.owner.lookup('service:store').createRecord('funder'));
+    assert.ok(funder);
+  });
 });

--- a/tests/unit/models/grant-test.js
+++ b/tests/unit/models/grant-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('grant', 'Unit | Model | grant', {
-  // Specify the other units that are required for this test.
-  needs: ['model:funder', 'model:user', 'model:submission', 'model:contributor']
-});
+module('Unit | Model | grant', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const grant = run(() => this.owner.lookup('service:store').createRecord('grant'));
+    assert.ok(grant);
+  });
 });

--- a/tests/unit/models/journal.js
+++ b/tests/unit/models/journal.js
@@ -5,15 +5,8 @@ import { run } from '@ember/runloop';
 module('Unit | Model | journal', (hooks) => {
   setupTest(hooks);
 
-  // Specify the other units that are required for this test.
   test('it exists', function (assert) {
     const journal = run(() => this.owner.lookup('service:store').createRecord('journal'));
-    assert.ok(!!journal);
-
-    // wrap asynchronous call in run loop
-    // run(() => player.levelUp());
-
-    // assert.equal(player.get('level'), 5, 'level gets incremented');
-    // assert.equal(player.get('levelName'), 'Professional', 'new level is called professional');
+    assert.ok(journal);
   });
 });

--- a/tests/unit/models/policy-test.js
+++ b/tests/unit/models/policy-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('policy', 'Unit | Model | policy', {
-  // Specify the other units that are required for this test.
-  needs: ['model:repository', 'model:funder']
-});
+module('Unit | Model | policy', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const policy = run(() => this.owner.lookup('service:store').createRecord('policy'));
+    assert.ok(policy);
+  });
 });

--- a/tests/unit/models/publication-test.js
+++ b/tests/unit/models/publication-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('publication', 'Unit | Model | publication', {
-  // Specify the other units that are required for this test.
-  needs: ['model:journal', 'model:submission']
-});
+module('Unit | Model | publication', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const publication = run(() => this.owner.lookup('service:store').createRecord('publication'));
+    assert.ok(publication);
+  });
 });

--- a/tests/unit/models/repository-copy-test.js
+++ b/tests/unit/models/repository-copy-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('repository-copy', 'Unit | Model | repo copy', {
-  // Specify the other units that are required for this test.
-  needs: ['model:publication', 'model:repository']
-});
+module('Unit | Model | repository copy', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const repositoryCopy = run(() => this.owner.lookup('service:store').createRecord('repository-copy'));
+    assert.ok(repositoryCopy);
+  });
 });

--- a/tests/unit/models/repository-test.js
+++ b/tests/unit/models/repository-test.js
@@ -1,12 +1,12 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('repository', 'Unit | Model | repository', {
-  // Specify the other units that are required for this test.
-  needs: ['model:policy', 'model:submission']
-});
+module('Unit | Model | repository', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
-  // let store = this.store();
-  assert.ok(!!model);
+  test('it exists', function (assert) {
+    const repository = run(() => this.owner.lookup('service:store').createRecord('repository'));
+    assert.ok(repository);
+  });
 });

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,25 +1,24 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-moduleForModel('user', 'Unit | Model | user', {
-  // Specify the other units that are required for this test.
-  needs: ['model:submission']
-});
+module('Unit | Model | user', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let model = this.subject();
+  test('it exists', function (assert) {
+    const user = run(() => this.owner.lookup('service:store').createRecord('user'));
+    assert.ok(user);
 
-  assert.ok(!!model);
+    return run(() => {
+      assert.equal(user.get('isAdmin'), false);
+      assert.equal(user.get('isSubmitter'), false);
 
-  return run(() => {
-    assert.equal(model.get('isAdmin'), false);
-    assert.equal(model.get('isSubmitter'), false);
+      user.set('roles', ['admin']);
+      assert.equal(user.get('isAdmin'), true);
 
-    model.set('roles', ['admin']);
-    assert.equal(model.get('isAdmin'), true);
-
-    model.get('roles').push('submitter');
-    assert.equal(model.get('isSubmitter'), true);
-    assert.equal(model.get('isAdmin'), true);
+      user.get('roles').push('submitter');
+      assert.equal(user.get('isSubmitter'), true);
+      assert.equal(user.get('isAdmin'), true);
+    });
   });
 });

--- a/tests/unit/routes/404-test.js
+++ b/tests/unit/routes/404-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:404', 'Unit | Route | 404', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | 404', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:404');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/about-test.js
+++ b/tests/unit/routes/about-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:about', 'Unit | Route | about', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | about', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:about');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:application', 'Unit | Route | application', {
-  // Specify the other units that are required for this test.
-  needs: ['service:session', 'service:currentUser', 'service:toast', 'service:error-handler']
-});
+module('Unit | Route | application', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:application');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/contact-test.js
+++ b/tests/unit/routes/contact-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:contact', 'Unit | Route | contact', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | contact', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:contact');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/dashboard-test.js
+++ b/tests/unit/routes/dashboard-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:dashboard', 'Unit | Route | dashboard', {
-  // Specify the other units that are required for this test.
-  needs: ['service:session', 'service:currentUser', 'service:toast', 'service:error-handler', 'service:ajax']
-});
+module('Unit | Route | dashboard', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:dashboard');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/faq-test.js
+++ b/tests/unit/routes/faq-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:faq', 'Unit | Route | faq', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | faq', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:faq');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/grants/detail-test.js
+++ b/tests/unit/routes/grants/detail-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:grants/detail', 'Unit | Route | grants/detail', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:toast', 'service:error-handler']
-});
+module('Unit | Route | grants/detail', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:grants/detail');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/grants/index-test.js
+++ b/tests/unit/routes/grants/index-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:grants/index', 'Unit | Route | grants/index', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:toast', 'service:error-handler']
-});
+module('Unit | Route | grants/index', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:grants/index');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/index-test.js
+++ b/tests/unit/routes/index-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:index', 'Unit | Route | index', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | index', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:index');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:login', 'Unit | Route | login', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | login', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:login');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/detail-test.js
+++ b/tests/unit/routes/submissions/detail-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/detail', 'Unit | Route | submissions/detail', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | submissions/detail', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/detail');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/index-test.js
+++ b/tests/unit/routes/submissions/index-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/index', 'Unit | Route | submissions/index', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:toast', 'service:error-handler']
-});
+module('Unit | Route | submissions/index', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/index');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new-test.js
+++ b/tests/unit/routes/submissions/new-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new', 'Unit | Route | submissions/new', {
-  // Specify the other units that are required for this test.
-  needs: ['service:currentUser', 'service:toast', 'service:error-handler']
-});
+module('Unit | Route | submissions/new', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('route:submissions/new');
+    assert.ok(service);
+  });
 });

--- a/tests/unit/routes/submissions/new/basics-test.js
+++ b/tests/unit/routes/submissions/new/basics-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/basics', 'Unit | Route | submissions/new/basics', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/basics', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/basics');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/files-test.js
+++ b/tests/unit/routes/submissions/new/files-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/files', 'Unit | Route | submissions/new/files', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/files', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/files');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/grants-test.js
+++ b/tests/unit/routes/submissions/new/grants-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/grants', 'Unit | Route | submissions/new/grants', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/grants', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/grants');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/index-test.js
+++ b/tests/unit/routes/submissions/new/index-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/index', 'Unit | Route | submissions/new/index', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/index', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/index');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/metadata-test.js
+++ b/tests/unit/routes/submissions/new/metadata-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/metadata', 'Unit | Route | submissions/new/metadata', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/metadata', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/metadata');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/policies-test.js
+++ b/tests/unit/routes/submissions/new/policies-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/policies', 'Unit | Route | submissions/new/policies', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/policies', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/policies');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/repositories-test.js
+++ b/tests/unit/routes/submissions/new/repositories-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/repositories', 'Unit | Route | submissions/new/repositories', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/repositories', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/repositories');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/submissions/new/review-test.js
+++ b/tests/unit/routes/submissions/new/review-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:submissions/new/review', 'Unit | Route | submissions/new/review', {
-  // Specify the other units that are required for this test.
-  // needs: ['controller:foo']
-});
+module('Unit | Route | submissions/new/review', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:submissions/new/review');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/routes/thanks-test.js
+++ b/tests/unit/routes/thanks-test.js
@@ -1,11 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('route:thanks', 'Unit | Route | thanks', {
-  // Specify the other units that are required for this test.
-  needs: ['service:toast', 'service:error-handler']
-});
+module('Unit | Route | thanks', (hooks) => {
+  setupTest(hooks);
 
-test('it exists', function (assert) {
-  let route = this.subject();
-  assert.ok(route);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let route = this.owner.lookup('route:thanks');
+    assert.ok(route);
+  });
 });

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,15 +1,18 @@
-import { moduleForModel, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
-moduleForModel('user', 'Unit | Serializer | application', {
-  // Specify the other units that are required for this test.
-  needs: ['serializer:application', 'model:submission']
-});
+module('Unit | Serializer | application', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it serializes records', function (assert) {
-  let record = this.subject();
+  test('it serializes', function (assert) {
+    let store = this.owner.lookup('service:store');
 
-  let serializedRecord = record.serialize();
+    run(() => {
+      let record = store.createRecord('submission', {});
+      let serializedRecord = record.serialize();
 
-  assert.ok(serializedRecord);
+      assert.ok(serializedRecord);
+    });
+  });
 });

--- a/tests/unit/services/autocomplete-test.js
+++ b/tests/unit/services/autocomplete-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import RSVP from 'rsvp';
 
-module('service:autocomplete', 'Unit | Service | autocomplete', (hooks) => {
+module('Unit | Service | autocomplete', (hooks) => {
   setupTest(hooks);
 
   test('it exists and posts', function (assert) {

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('service:doi', 'Unit | Service | doi', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+module('Unit | Service | doi', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let service = this.subject();
-  assert.ok(service);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:doi');
+    assert.ok(service);
+  });
 });

--- a/tests/unit/services/error-handler-test.js
+++ b/tests/unit/services/error-handler-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('service:error-handler', 'Unit | Service | error handler', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+module('Unit | Service | error handler', (hooks) => {
+  setupTest(hooks);
 
-// Do to errors throwing a page redirect this can not be tested as a unit test.
-test('it exists', function (assert) {
-  let service = this.subject();
-  assert.ok(service);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:error-handler');
+    assert.ok(service);
+  });
 });

--- a/tests/unit/services/nlmta-test.js
+++ b/tests/unit/services/nlmta-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('service:nlmta', 'Unit | Service | nlmta', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+module('Unit | Service | nlmta', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function(assert) {
-  let service = this.subject();
-  assert.ok(service);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:nlmta');
+    assert.ok(service);
+  });
 });

--- a/tests/unit/services/workflow-test.js
+++ b/tests/unit/services/workflow-test.js
@@ -1,12 +1,12 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('service:workflow', 'Unit | Service | workflow', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+module('Unit | Service | workflow', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let service = this.subject();
-  assert.ok(service);
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:workflow');
+    assert.ok(service);
+  });
 });


### PR DESCRIPTION
There are 3 things in this PR:
1. all existing unit and integration tests in pass-ember have been repaired since they were broken after the recent refactoring. 
2. tests have been rewritten to match the format described in the Ember 3.5.0 documentation (e.g. using `module('Unit | Route | submissions/new', (hooks) => {` and so on)
3. as an experiment several tests were written for the Submission model's calculated properties - further tests will be created in the next set of PRs.

This is the first step of #854 