### PR TITLE
Add tests for workflow controllers

### DIFF
--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -60,7 +60,7 @@ export default Controller.extend({
         // If a submitter is specified, it's a normal "approval-requested" scenario.
         if (s.get('submitter.id')) {
           subEvent.set('eventType', 'approval-requested');
-        } else if (this.get('model.newSubmission.submitterName') && this.get('model.newSubmission.submitterEmail')) {
+        } else if (s.get('submitterName') && s.get('submitterEmail')) {
           // debugger; // eslint-disable-line
           // If not specified but a name and email are present, create a mailto link.
           subEvent.set('eventType', 'approval-requested-newuser');

--- a/app/controllers/submissions/new/files.js
+++ b/app/controllers/submissions/new/files.js
@@ -10,13 +10,10 @@ export default Controller.extend({
   publication: alias('model.publication'),
   submissionEvents: alias('model.submissionEvents'),
   nextTabIsActive: Ember.computed('workflow.maxStep', function () {
-    console.log(`getMaxStep${this.get('workflow').getMaxStep()}` > 6);
     return (this.get('workflow').getMaxStep() > 6);
   }),
   loadingNext: false,
   needValidation: Ember.computed('nextTabIsActive', 'loadingNext', function () {
-    console.log(`nextTabIsActive${this.get('nextTabIsActive')}`);
-    console.log(`loadingNext${this.get('loadingNext')}`);
     return (this.get('nextTabIsActive') || this.get('loadingNext'));
   }),
   newFiles: Ember.computed('workflow.filesTemp', {
@@ -48,7 +45,6 @@ export default Controller.extend({
         let manuscriptFiles = [].concat(this.get('newFiles'), files && files.toArray())
           .filter(file => file && file.get('fileRole') === 'manuscript');
         let userIsSubmitter = this.get('parent').get('userIsSubmitter');
-        console.log(`userIsSubmitter${userIsSubmitter}`);
         if (manuscriptFiles.length == 0 && !userIsSubmitter) {
           swal({
             title: 'No manuscript present',

--- a/app/templates/components/workflow-basics-user-search.hbs
+++ b/app/templates/components/workflow-basics-user-search.hbs
@@ -6,7 +6,7 @@
     <div class="input-group pb-3">
       {{input value=searchInput enter=(action 'searchForUsers' 1) class="form-control"}}
       <span class="input-group-btn">
-        <button class="btn btn-primary" {{action 'searchForUsers' 1}} type="button">Search</button>
+        <button id='search-for-users' class="btn btn-primary" {{action 'searchForUsers' 1}} type="button">Search</button>
       </span>
     </div>
     <h3 class="my-4">Results</h3>

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -14,7 +14,7 @@
     <div class="input-group pb-3">
       {{input enter=(action 'toggleUserSearchModal') value=userSearchTerm class="form-control"}}
       <span class="input-group-btn">
-        <button class="btn btn-primary" {{action 'toggleUserSearchModal'}} type="button">Search</button>
+        <button id='search-for-users' class="btn btn-primary" {{action 'toggleUserSearchModal'}} type="button">Search</button>
       </span>
     </div>
     {{#if submission.submitter.id}}
@@ -93,10 +93,8 @@
      targetAttachment='top center'
      containerClass='user-search-modal'}}
     {{workflow-basics-user-search
-      model=model
       toggleUserSearchModal=(action 'toggleUserSearchModal')
       pickSubmitter=(action 'pickSubmitter')
-      searchInput=userSearchTerm
-      numPages=usersNumPages}}
+      searchInput=userSearchTerm}}
   {{/modal-dialog}}
 {{/if}}

--- a/tests/integration/components/workflow-basics-user-search-test.js
+++ b/tests/integration/components/workflow-basics-user-search-test.js
@@ -1,0 +1,21 @@
+import { setupRenderingTest } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+
+module('Integration | Component | workflow basics user search', (hooks) => {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    this.set('userSearchTerm', '');
+    // pass in actions that do nothing
+    this.set('pickSubmitter', (actual) => { });
+    this.set('toggleUserSearchModal', (actual) => { });
+
+    await this.render(hbs`{{workflow-basics-user-search
+            toggleUserSearchModal=(action toggleUserSearchModal)
+            pickSubmitter=(action pickSubmitter)
+            searchInput=userSearchTerm}}`);
+
+    assert.ok(true);
+  });
+});

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
 module('Unit | Controller | submissions/new', (hooks) => {
   setupTest(hooks);
@@ -8,5 +9,134 @@ module('Unit | Controller | submissions/new', (hooks) => {
   test('it exists', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new');
     assert.ok(controller);
+  });
+
+  test('finish and save non-proxy submission', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new');
+    this.owner.register('service:current-user', Ember.Object.extend({
+      user: { id: 'submitter:test-id' }
+    }));
+
+    let submissionEvent = Ember.Object.create({ });
+    controller.set('store', {
+      createRecord() { return submissionEvent; }
+    });
+
+    let submissionSaved = false;
+    // 2 repositories so we can check web-link repo is removed from list
+    let repository1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+    let submission = Ember.Object.create({
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      repositories: Ember.A([repository1, repository2]),
+      save() {
+        submissionSaved = true;
+        return new Promise(resolve => (assert.ok(true)));
+      }
+    });
+    controller.set('comment', 'test comment');
+
+    run(() => {
+      controller.send('finishSubmission', submission);
+    });
+
+    assert.equal(submission.submissionStatus, 'submitted');
+    // check web-linked repo is removed
+    assert.equal(submission.repositories.length, 1);
+    assert.equal(submission.repositories[0].id, 'test:repo1');
+    assert.equal(submissionEvent.comment, 'test comment');
+    assert.equal(submissionEvent.performedBy.id, 'submitter:test-id');
+    assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
+    assert.equal(submissionEvent.comment, 'test comment');
+    assert.equal(submissionEvent.performerRole, 'submitter');
+    assert.equal(submissionEvent.eventType, 'submitted');
+    // because the promise doesnt return anything at the moment,
+    // only submission will be saved
+    assert.equal(submissionSaved, true);
+  });
+
+  test('finish and save proxy submission', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new');
+    this.owner.register('service:current-user', Ember.Object.extend({
+      user: { id: 'submitter:test-proxy-id' }
+    }));
+
+    let submissionEvent = Ember.Object.create({ });
+    controller.set('store', {
+      createRecord() { return submissionEvent; }
+    });
+
+    let submissionSaved = false;
+    let repository1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'one-way' });
+    let submission = Ember.Object.create({
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      repositories: Ember.A([repository1, repository2]),
+      save() {
+        submissionSaved = true;
+        return new Promise(resolve => (assert.ok(true)));
+      }
+    });
+    controller.set('comment', 'test comment');
+
+    run(() => {
+      controller.send('finishSubmission', submission);
+    });
+
+    assert.equal(submission.submissionStatus, 'approval-requested');
+    assert.equal(submission.repositories.length, 2);
+    assert.equal(submissionEvent.comment, 'test comment');
+    assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
+    assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
+    assert.equal(submissionEvent.comment, 'test comment');
+    assert.equal(submissionEvent.performerRole, 'preparer');
+    assert.equal(submissionEvent.eventType, 'approval-requested');
+    // because the promise doesnt return anything at the moment,
+    // only submission will be saved
+    assert.equal(submissionSaved, true);
+  });
+
+  test('finish and save proxy submission with new user', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new');
+    this.owner.register('service:current-user', Ember.Object.extend({
+      user: { id: 'submitter:test-proxy-id' }
+    }));
+
+    let submissionEvent = Ember.Object.create({ });
+    controller.set('store', {
+      createRecord() { return submissionEvent; }
+    });
+
+    let submissionSaved = false;
+    let repository = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let submission = Ember.Object.create({
+      submitterName: 'test name',
+      submitterEmail: 'mailto:test@email.com',
+      repositories: Ember.A([repository]),
+      save() {
+        submissionSaved = true;
+        return new Promise(resolve => (assert.ok(true)));
+      }
+    });
+
+    run(() => {
+      controller.send('finishSubmission', submission);
+    });
+
+    assert.equal(submission.submitter, null);
+    assert.equal(submission.submitterName, 'test name');
+    assert.equal(submission.submitterEmail, 'mailto:test@email.com');
+    assert.equal(submission.submissionStatus, 'approval-requested');
+    assert.equal(submission.repositories.length, 1);
+    assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
+    assert.equal(submissionEvent.performerRole, 'preparer');
+    assert.equal(submissionEvent.eventType, 'approval-requested-newuser');
+    // because the promise doesnt return anything at the moment,
+    // only submission will be saved
+    assert.equal(submissionSaved, true);
   });
 });

--- a/tests/unit/controllers/submissions/new/basics-test.js
+++ b/tests/unit/controllers/submissions/new/basics-test.js
@@ -9,4 +9,194 @@ module('Unit | Controller | submissions/new/basics', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/basics');
     assert.ok(controller);
   });
+
+  test('ensure email format validation works', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let submission = Ember.Object.create({
+      submitterEmailDisplay: 'badtestemail',
+      repositories: [],
+      grants: []
+    });
+    let model = {
+      newSubmission: submission
+    };
+    controller.set('model', model);
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'bademail.com');
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'bad|#$~email.com');
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'mailto:bad@email.com');
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'bad@email+com');
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'good@email.com');
+    assert.equal(controller.get('submitterEmailIsInvalid'), false);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'good.email@email.co.uk');
+    assert.equal(controller.get('submitterEmailIsInvalid'), false);
+
+    controller.set('model.newSubmission.submitterEmailDisplay', 'good_email55@ema-il.co.uk');
+    assert.equal(controller.get('submitterEmailIsInvalid'), false);
+  });
+
+  test('check submitter validation', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let submission = Ember.Object.create({
+      repositories: [],
+      grants: []
+    });
+    let submitter = Ember.Object.create({
+      id: 'https://fake.id'
+    });
+    let model = {
+      newSubmission: submission
+    };
+    controller.set('model', model);
+    assert.equal(controller.get('submitterEmailIsInvalid'), true);
+    assert.equal(controller.get('submitterIsInvalid'), true);
+
+    controller.set('model.newSubmission.submitterName', 'Test Name');
+    controller.set('model.newSubmission.submitterEmail', 'mailto:good@email.com');
+    assert.equal(controller.get('submitterIsInvalid'), false);
+
+    controller.set('model.newSubmission.submitterName', null);
+    controller.set('model.newSubmission.submitterEmailDisplay', null);
+    controller.set('model.newSubmission.submitter', submitter);
+    assert.equal(controller.get('submitterIsInvalid'), false);
+  });
+
+  test('check title and journal validation', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let submission = Ember.Object.create({ });
+    let publication = Ember.Object.create({
+      journal: []
+    });
+    let model = {
+      newSubmission: submission,
+      publication
+    };
+    controller.set('model', model);
+    assert.equal(controller.get('journalIsInvalid'), true);
+    assert.equal(controller.get('titleIsInvalid'), true);
+
+    controller.set('model.publication.title', 'Test title');
+    assert.equal(controller.get('titleIsInvalid'), false);
+
+    controller.set('model.publication.journal.id', 'test:journal_id');
+    assert.equal(controller.get('journalIsInvalid'), false);
+
+    controller.set('model.publication.journal.id', null);
+    controller.set('model.publication.journal.journalName', 'Test journal name');
+    assert.equal(controller.get('journalIsInvalid'), false);
+  });
+
+  test('check validateAndLoadTab rejects empty journal and title', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let submission = Ember.Object.create({ });
+    let publication = Ember.Object.create({
+      journal: []
+    });
+    let model = {
+      newSubmission: submission,
+      publication
+    };
+    controller.set('model', model);
+    assert.equal(controller.get('titleError'), false);
+    assert.equal(controller.get('journalError'), false);
+    assert.equal(controller.get('flaggedFields').indexOf('title'), -1);
+    assert.equal(controller.get('flaggedFields').indexOf('journal'), -1);
+
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+
+    assert.equal(controller.get('titleError'), true);
+    assert.equal(controller.get('journalError'), true);
+    assert.ok(controller.get('flaggedFields').indexOf('title') > -1);
+    assert.ok(controller.get('flaggedFields').indexOf('journal') > -1);
+  });
+
+  test('check validateAndLoadTab rejects incomplete submitter', function (assert) {
+    assert.expect(9);
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let loadTabAccessed = false;
+    let submission = Ember.Object.create({
+      isProxySubmission: true
+    });
+    let publication = Ember.Object.create({
+      title: 'Test publication title',
+      journal: {
+        id: 'journal:id'
+      }
+    });
+    let model = {
+      newSubmission: submission,
+      publication
+    };
+    controller.set('model', model);
+    controller.transitionToRoute = function () {
+      assert.ok(true);
+      loadTabAccessed = true;
+    };
+
+    // this will error if it proceeds to loadTab.
+    assert.equal(controller.get('model.newSubmission.isProxySubmission'), true);
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+
+    assert.equal(controller.get('submitterIsInvalid'), true);
+    // no flagged fields in this instance and loadTab not accessed
+    assert.equal(controller.get('titleError'), false);
+    assert.equal(controller.get('journalError'), false);
+    assert.equal(controller.get('submitterEmailError'), false);
+    assert.equal(controller.get('flaggedFields').indexOf('journal'), -1);
+    assert.equal(controller.get('flaggedFields').indexOf('title'), -1);
+    assert.equal(controller.get('flaggedFields').indexOf('submitterEmail'), -1);
+    assert.equal(loadTabAccessed, false);
+  });
+
+  test('check validateAndLoadTab accepts complete information', function (assert) {
+    assert.expect(10);
+
+    let controller = this.owner.lookup('controller:submissions/new/basics');
+    let loadTabAccessed = false;
+    let submission = Ember.Object.create({
+      isProxySubmission: true,
+      submitterName: 'Test Submitter',
+      submitterEmail: 'mailto:test@email.com',
+      submitterEmailDisplay: 'test@email.com'
+    });
+    let publication = Ember.Object.create({
+      title: 'Test publication title',
+      journal: {
+        id: 'journal:id'
+      }
+    });
+    let model = {
+      newSubmission: submission,
+      publication
+    };
+
+    controller.set('model', model);
+    controller.transitionToRoute = function () {
+      assert.ok(true);
+      loadTabAccessed = true;
+    };
+
+    assert.equal(controller.get('model.newSubmission.isProxySubmission'), true);
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+
+    // no errors and loadTab accessed
+    assert.equal(controller.get('submitterIsInvalid'), false);
+    assert.equal(controller.get('titleError'), false);
+    assert.equal(controller.get('journalError'), false);
+    assert.equal(controller.get('submitterEmailError'), false);
+    assert.equal(controller.get('flaggedFields').indexOf('journal'), -1);
+    assert.equal(controller.get('flaggedFields').indexOf('title'), -1);
+    assert.equal(controller.get('flaggedFields').indexOf('submitterEmail'), -1);
+    assert.equal(loadTabAccessed, true);
+  });
 });

--- a/tests/unit/controllers/submissions/new/files-test.js
+++ b/tests/unit/controllers/submissions/new/files-test.js
@@ -9,4 +9,101 @@ module('Unit | Controller | submissions/new/files', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/files');
     assert.ok(controller);
   });
+
+  test('No manuscript files, user is submitter, stops transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/files');
+    let loadTabAccessed = false;
+    this.owner.register('controller:submissions.new', Ember.Object.extend({
+      userIsSubmitter: true
+    }));
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getFilesTemp() { return []; },
+      getMaxStep() { return 6; }
+    }));
+    let model = { files: [] };
+    controller.set('model', model);
+    controller.set('loadingNext', true);
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    assert.equal(controller.get('workflow').getFilesTemp().length, 0);
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+    assert.equal(loadTabAccessed, false);
+  });
+
+  test('No manuscript files, user not submitter, warns before transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/files');
+    let loadTabAccessed = false;
+    this.owner.register('controller:submissions.new', Ember.Object.extend({
+      userIsSubmitter: false
+    }));
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getFilesTemp() { return []; },
+      getMaxStep() { return 7; }
+    }));
+    let model = { files: [] };
+    controller.set('model', model);
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    assert.equal(controller.get('workflow').getFilesTemp().length, 0);
+    // override swal so it doesn't pop up
+    swal = result => new Promise(resolve => (assert.ok(true)));
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+    assert.equal(loadTabAccessed, false);
+  });
+
+  test('Multiple manuscript files stops transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/files');
+    let loadTabAccessed = false;
+    let file = Ember.Object.create({
+      fileRole: 'manuscript'
+    });
+    this.owner.register('controller:submissions.new', Ember.Object.extend({
+      userIsSubmitter: false
+    }));
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getFilesTemp() {
+        return [file];
+      },
+      getMaxStep() { return 7; }
+    }));
+    let files = [file];
+    let model = { files };
+    controller.set('model', model);
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    assert.equal(controller.get('workflow').getFilesTemp().length, 1);
+    assert.equal(controller.get('model.files').length, 1);
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+    assert.equal(loadTabAccessed, false);
+  });
+
+  test('Valid files page does transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/files');
+    let loadTabAccessed = false;
+    let file = Ember.Object.create({
+      fileRole: 'manuscript'
+    });
+    this.owner.register('controller:submissions.new', Ember.Object.extend({
+      userIsSubmitter: false
+    }));
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getFilesTemp() {
+        return [];
+      },
+      getMaxStep() { return 7; }
+    }));
+    let files = [file];
+    let model = { files };
+    controller.set('model', model);
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    assert.equal(controller.get('workflow').getFilesTemp().length, 0);
+    assert.equal(controller.get('model.files').length, 1);
+    controller.send('validateAndLoadTab', 'submissions.new.basics');
+    assert.equal(loadTabAccessed, true);
+  });
 });

--- a/tests/unit/controllers/submissions/new/grants-test.js
+++ b/tests/unit/controllers/submissions/new/grants-test.js
@@ -9,4 +9,26 @@ module('Unit | Controller | submissions/new/grants', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/grants');
     assert.ok(controller);
   });
+
+  test('loadPrevious triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/grants');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.basics', route);
+    };
+    controller.send('loadPrevious');
+    assert.equal(loadTabAccessed, true);
+  });
+
+  test('loadNext triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/grants');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.policies', route);
+    };
+    controller.send('loadNext');
+    assert.equal(loadTabAccessed, true);
+  });
 });

--- a/tests/unit/controllers/submissions/new/metadata-test.js
+++ b/tests/unit/controllers/submissions/new/metadata-test.js
@@ -9,4 +9,26 @@ module('Unit | Controller | submissions/new/metadata', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/metadata');
     assert.ok(controller);
   });
+
+  test('loadPrevious triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/metadata');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.repositories', route);
+    };
+    controller.send('loadPrevious');
+    assert.equal(loadTabAccessed, true);
+  });
+
+  test('loadNext triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/metadata');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.files', route);
+    };
+    controller.send('loadNext');
+    assert.equal(loadTabAccessed, true);
+  });
 });

--- a/tests/unit/controllers/submissions/new/policies-test.js
+++ b/tests/unit/controllers/submissions/new/policies-test.js
@@ -9,4 +9,26 @@ module('Unit | Controller | submissions/new/policies', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/policies');
     assert.ok(controller);
   });
+
+  test('loadPrevious triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/policies');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.grants', route);
+    };
+    controller.send('loadPrevious');
+    assert.equal(loadTabAccessed, true);
+  });
+
+  test('loadNext triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/policies');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.repositories', route);
+    };
+    controller.send('loadNext');
+    assert.equal(loadTabAccessed, true);
+  });
 });

--- a/tests/unit/controllers/submissions/new/repositories-test.js
+++ b/tests/unit/controllers/submissions/new/repositories-test.js
@@ -9,4 +9,75 @@ module('Unit | Controller | submissions/new/repositories', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/repositories');
     assert.ok(controller);
   });
+
+  test('transition aborted if no repositories', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/repositories');
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getMaxStep() { return 5; }
+    }));
+    let submission = Ember.Object.create({
+      repositories: []
+    });
+    let model = Ember.Object.create({
+      newSubmission: submission
+    });
+    controller.set('model', model);
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    // override swal so it doesn't pop up
+    swal = result => new Promise(resolve => (assert.ok(true)));
+    controller.send('validateAndLoadTab');
+    assert.equal(loadTabAccessed, false);
+  });
+
+  test('transition if there are repositories', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/repositories');
+    this.owner.register('service:workflow', Ember.Object.extend({
+      getMaxStep() { return 5; }
+    }));
+
+    let repository = Ember.Object.create({
+      id: 'test:repo',
+      formSchema: '{ "id": "nih", "title": "med data" }'
+    });
+    let submission = Ember.Object.create({
+      repositories: Ember.A([repository])
+    });
+    let model = Ember.Object.create({
+      newSubmission: submission
+    });
+    controller.set('model', model);
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function () {
+      loadTabAccessed = true;
+    };
+    controller.send('validateAndLoadTab');
+    assert.equal(loadTabAccessed, true);
+  });
+
+  test('updateRelatedData removes metadata for repos not assigned', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/repositories');
+    let repository = Ember.Object.create({
+      id: 'test:repo',
+      formSchema: '{ "id": "nih", "title": "med data" }'
+    });
+
+    let md = '[{"id": "foo", "title": "bar"}, {"id": "nih", "title": "med data"}]';
+    let submission = Ember.Object.create({
+      repositories: Ember.A([repository]),
+      metadata: md
+    });
+    let model = Ember.Object.create({
+      newSubmission: submission
+    });
+    controller.set('model', model);
+    assert.equal(controller.get('submission.metadata'), md);
+    controller.send('updateRelatedData');
+    // check the metadata that does not match a repo has been removed.
+    let updatedMetadata = JSON.parse(controller.get('submission.metadata'));
+    assert.equal(updatedMetadata[0].id, 'nih');
+    assert.equal(updatedMetadata.length, 1);
+  });
 });

--- a/tests/unit/controllers/submissions/new/review-test.js
+++ b/tests/unit/controllers/submissions/new/review-test.js
@@ -9,4 +9,31 @@ module('Unit | Controller | submissions/new/review', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/review');
     assert.ok(controller);
   });
+
+  test('loadPrevious triggers transition', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/review');
+    let loadTabAccessed = false;
+    controller.transitionToRoute = function (route) {
+      loadTabAccessed = true;
+      assert.equal('submissions.new.files', route);
+    };
+    controller.send('loadPrevious');
+    assert.equal(loadTabAccessed, true);
+  });
+
+  test('parent properties are retreived', function (assert) {
+    let controller = this.owner.lookup('controller:submissions/new/review');
+    let submitTriggered = false;
+    this.owner.register('controller:submissions/new', Ember.Object.extend({
+      uploading: 'is uploading',
+      comment: 'test comment',
+      waitingMessage: 'test waiting message'
+    }));
+
+    assert.equal(controller.get('uploading'), 'is uploading');
+    assert.equal(controller.get('waitingMessage'), 'test waiting message');
+    assert.equal(controller.get('comment'), 'test comment');
+    controller.set('comment', 'comment changed');
+    assert.equal(controller.get('comment'), 'comment changed');
+  });
 });


### PR DESCRIPTION
This PR:
* Adds unit tests to `submissions\new`, and the controllers for its sub-routes.  
* Adds a missing test file for `workflow-basics-user-search`
* Adds some minor changes to `workflow-basics` to support integration test that will be written
* Removes some stray console logs.

Interesting lesson learned: some controllers use the `swal` popup. This will actually popup in tests if not overridden like this, for example:
`swal = result => new Promise(resolve => (assert.ok(true)));`
If we develop these tests in the future, it would be useful to configure the swal property to return different responses (ok, cancel etc). For now, I am submitting as is so that this work can move forward.

Part of #854 