### PR TITLE
Autofill doi data

### DIFF
--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -25,6 +25,7 @@ export default Component.extend({
   doiInfo: Ember.computed('workflow.doiInfo', function () {
     return this.get('workflow').getDoiInfo();
   }),
+  doiService: service('doi'),
 
   /**
    * Schema that is currently being shown to the user
@@ -57,34 +58,17 @@ export default Component.extend({
 
     // doi:10.1002/0470841559.ch1
     // 10.4137/CMC.S38446
+    // 10.1039/c7an01256j
     if (!this.get('schemas')) {
       // Add relevant fields from DOI data to submission metadata
-      const doiInfo = this.get('doiInfo');
-      // console.log(doiInfo);
-      // console.log(this.get('submission.publication'));
-      let issns = [];
-      if (doiInfo['issn-map']) {
-        Object.keys(doiInfo['issn-map']).forEach(issn => issns.push({
-          issn,
-          pubType: doiInfo['issn-map'][issn]['pub-type'][0]
-        }));
-      }
-
-      this.updateMetadata({
-        issns,
-        'journal-NLMTA-ID': doiInfo.nlmta,
-        doi: doiInfo.DOI,
-        publisher: doiInfo.publisher,
-        'journal-title-short': doiInfo['container-title-short']
-      });
+      const metadataFromDoi = this.get('doiService').doiToMetadata(this.get('doiInfo'));
+      this.updateMetadata(metadataFromDoi);
 
       const repos = this.get('submission.repositories').map(repo => repo.get('id'));
 
       // Load schemas by calling the Schema service
       try {
         const schemas = await this.get('schemaService').getMetadataSchemas(repos);
-
-        // this.set('globalSchema', schemas[0]);
 
         this.set('schemas', schemas);
         this.set('currentFormStep', 0);

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -60,15 +60,20 @@ export default Component.extend({
     // 10.4137/CMC.S38446
     // 10.1039/c7an01256j
     if (!this.get('schemas')) {
-      // Add relevant fields from DOI data to submission metadata
-      const metadataFromDoi = this.get('doiService').doiToMetadata(this.get('doiInfo'));
-      this.updateMetadata(metadataFromDoi);
-
       const repos = this.get('submission.repositories').map(repo => repo.get('id'));
 
       // Load schemas by calling the Schema service
       try {
         const schemas = await this.get('schemaService').getMetadataSchemas(repos);
+
+        const doiInfo = this.get('doiInfo');
+        // Add relevant fields from DOI data to submission metadata
+        const metadataFromDoi = this.get('doiService').doiToMetadata(
+          doiInfo,
+          this.get('schemaService').getFields(schemas)
+        );
+
+        this.updateMetadata(metadataFromDoi);
 
         this.set('schemas', schemas);
         this.set('currentFormStep', 0);

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -33,5 +33,53 @@ export default Service.extend({
     doi = doi.replace(/doi:/gi, '');
     doi = doi.replace(/https?:\/\/(dx\.)?doi\.org\//gi, '');
     return doi;
+  },
+
+  /**
+   * Translate data from the DOI to a metadata blob that can be attached to a submission.
+   *
+   * @param {object} doiInfo data retreived from the DOI
+   * @returns {object} metadata blob seeded with DOI data
+   */
+  doiToMetadata(doiInfo) {
+    // Massage ISSN data
+    let issns = [];
+    if (doiInfo['issn-map']) {
+      Object.keys(doiInfo['issn-map']).forEach(issn => issns.push({
+        issn,
+        pubType: doiInfo['issn-map'][issn]['pub-type'][0]
+      }));
+    }
+
+    // Massage 'authors' information
+    // Add expected properties and copy the field from 'author' to 'authors'
+    if (Array.isArray(doiInfo.author)) {
+      doiInfo.authors = [];
+      doiInfo.author.forEach((author) => {
+        let a = {
+          author: `${author.given} ${author.family}`,
+          orcid: author.ORCID
+        };
+        doiInfo.authors.push(Object.assign(a, author));
+      });
+    }
+
+    doiInfo.issns = issns;
+    // return doiInfo;
+    // TODO: I don't really like this sort of manual copying, since we don't necessarily know what
+    // future metadata forms are expecting
+    return {
+      abstract: doiInfo.abstract,
+      authors: doiInfo.authors,
+      issns,
+      'journal-NLMTA-ID': doiInfo.nlmta,
+      doi: doiInfo.DOI,
+      publisher: doiInfo.publisher,
+      'journal-title-short': doiInfo['container-title-short'],
+      'journal-title': doiInfo['journal-title'],
+      title: doiInfo.title,
+      issue: doiInfo.issue,
+      volume: doiInfo.volume
+    };
   }
 });

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -1,5 +1,7 @@
 import Service from '@ember/service';
-
+/**
+ * Sample DOI data as JSON: https://gist.github.com/jabrah/c268c6b027bd2646595e266f872c883c
+ */
 export default Service.extend({
   resolveDOI(doi) {
     const base = 'https://doi.org/';
@@ -39,47 +41,55 @@ export default Service.extend({
    * Translate data from the DOI to a metadata blob that can be attached to a submission.
    *
    * @param {object} doiInfo data retreived from the DOI
+   * @param {array} validFields OPTIONAL array of accepted property names on final metadata object
    * @returns {object} metadata blob seeded with DOI data
    */
-  doiToMetadata(doiInfo) {
+  doiToMetadata(doiInfo, validFields) {
+    const doiCopy = Object.assign({}, doiInfo);
     // Massage ISSN data
     let issns = [];
-    if (doiInfo['issn-map']) {
-      Object.keys(doiInfo['issn-map']).forEach(issn => issns.push({
+    if (doiCopy['issn-map']) {
+      Object.keys(doiCopy['issn-map']).forEach(issn => issns.push({
         issn,
-        pubType: doiInfo['issn-map'][issn]['pub-type'][0]
+        pubType: doiCopy['issn-map'][issn]['pub-type'][0]
       }));
     }
 
     // Massage 'authors' information
     // Add expected properties and copy the field from 'author' to 'authors'
-    if (Array.isArray(doiInfo.author)) {
-      doiInfo.authors = [];
-      doiInfo.author.forEach((author) => {
+    if (Array.isArray(doiCopy.author)) {
+      doiCopy.authors = [];
+      doiCopy.author.forEach((author) => {
         let a = {
           author: `${author.given} ${author.family}`,
           orcid: author.ORCID
         };
-        doiInfo.authors.push(Object.assign(a, author));
+        doiCopy.authors.push(Object.assign(a, author));
       });
     }
 
-    doiInfo.issns = issns;
-    // return doiInfo;
-    // TODO: I don't really like this sort of manual copying, since we don't necessarily know what
-    // future metadata forms are expecting
-    return {
-      abstract: doiInfo.abstract,
-      authors: doiInfo.authors,
-      issns,
-      'journal-NLMTA-ID': doiInfo.nlmta,
-      doi: doiInfo.DOI,
-      publisher: doiInfo.publisher,
-      'journal-title-short': doiInfo['container-title-short'],
-      'journal-title': doiInfo['journal-title'],
-      title: doiInfo.title,
-      issue: doiInfo.issue,
-      volume: doiInfo.volume
-    };
+    doiCopy.issns = issns;
+
+    // Remove "invalid" properties if given a list of valid fields
+    if (validFields && Array.isArray(validFields) && validFields.length > 0) {
+      Object.keys(doiCopy).filter(key => !validFields.includes(key))
+        .forEach(key => delete doiCopy[key]);
+    }
+
+    return doiCopy;
+    // Manual mapping of DOI data to fields expected by our metadata forms
+    // return {
+    //   abstract: doiInfo.abstract,
+    //   authors: doiInfo.authors,
+    //   issns,
+    //   'journal-NLMTA-ID': doiInfo.nlmta,
+    //   doi: doiInfo.DOI,
+    //   publisher: doiInfo.publisher,
+    //   'journal-title-short': doiInfo['container-title-short'],
+    //   'journal-title': doiInfo['journal-title'],
+    //   title: doiInfo.title,
+    //   issue: doiInfo.issue,
+    //   volume: doiInfo.volume
+    // };
   }
 });

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -230,4 +230,37 @@ module('Integration | Component | workflow-metadata', (hooks) => {
       'Unexpected value for "mooName" found'
     );
   });
+
+  /**
+   * DOI data should have invalid keys removed when translated to the 'workflow-metadata'
+   * metadata property. The mock Schema Service defined in #beforeEach above will define
+   * a set of valid fields that does NOT include the property 'badMoo'. This property
+   * then should not exist in the component's metadata blob.
+   */
+  test('DOI data should be trimmed', async function (assert) {
+    const mockWorkflow = Ember.Service.extend({
+      getDoiInfo() {
+        return {
+          ISSN: '1234-4321',
+          'journal-NLMTA-ID': 'MOO JOURNAL',
+          mooName: 'This is a moo',
+          badMoo: 'Sad moo'
+        };
+      }
+    });
+
+    run(() => {
+      this.owner.unregister('service:workflow');
+      this.owner.register('service:workflow', mockWorkflow);
+    });
+
+    await render(hbs`{{workflow-metadata submission=submission }}`);
+    assert.ok(true, 'Failed to render');
+
+    const component = this.owner.lookup('component:workflow-metadata');
+    const metadata = component.get('metadata');
+
+    assert.ok(metadata, 'No component metadata found');
+    assert.notOk(metadata.badMoo, 'metadata.badMoo property should not be found on the metadata object');
+  });
 });

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -83,9 +83,22 @@ module('Integration | Component | workflow-metadata', (hooks) => {
       }
     });
 
+    // const mockDoiService = Ember.Service.extend({
+    //   doiToMetadata() {
+    //     return {
+    //       ISSN: '1234-4321',
+    //       'journal-NLMTA-ID': 'MOO JOURNAL',
+    //       mooName: 'This is a moo'
+    //     };
+    //   }
+    // });
+
     run(() => {
       this.owner.unregister('service:ajax');
       this.owner.register('service:ajax', mockAjax);
+
+      // this.owner.unregister('service:doi');
+      // this.owner.register('service:doi', mockDoiService);
     });
   });
 
@@ -178,6 +191,43 @@ module('Integration | Component | workflow-metadata', (hooks) => {
       issnInput.value,
       expectedISSN,
       'ISSN from Form 1 should appear in Form 2'
+    );
+  });
+
+  test('DOI info should autofill into forms', async function (assert) {
+    const mockDoiService = Ember.Service.extend({
+      doiToMetadata() {
+        return {
+          ISSN: '1234-4321',
+          'journal-NLMTA-ID': 'MOO JOURNAL',
+          mooName: 'This is a moo'
+        };
+      }
+    });
+
+    run(() => {
+      this.owner.unregister('service:doi');
+      this.owner.register('service:doi', mockDoiService);
+    });
+
+    await render(hbs`{{workflow-metadata submission=submission}}`);
+    assert.ok(true, 'Failed to render');
+
+    // On render, check the 'journal-NLMTA-ID' field value in UI
+    assert.equal(
+      this.element.querySelector('input[name="journal-NLMTA-ID"]').value,
+      'MOO JOURNAL',
+      'Unexpected "journal-NLMTA-ID" value found'
+    );
+
+    await click('button[data-key="Next"]');
+    await click('button[data-key="Next"]');
+
+    // On third form, check the 'mooName' field in the UI
+    assert.equal(
+      this.element.querySelector('input[name="mooName"]').value,
+      'This is a moo',
+      'Unexpected value for "mooName" found'
     );
   });
 });

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -9,4 +9,58 @@ module('Unit | Service | doi', (hooks) => {
     let service = this.owner.lookup('service:doi');
     assert.ok(service);
   });
+
+  // Test DOI object here based on CrossRef data
+  test('check doi data processing', function (assert) {
+    const service = this.owner.lookup('service:doi');
+    const doi = {
+      'issn-map': {
+        '0003-2654': { 'pub-type': ['Print'] },
+        '1364-5528': { 'pub-type': ['Electronic'] }
+      },
+      author: [
+        {
+          ORCID: 'http://orcid.org/0000-0003-2974-7389',
+          'authenticated-orcid': false,
+          given: 'Moo',
+          family: 'Jones',
+          sequence: 'first'
+        },
+        {
+          given: 'Moo, Jr',
+          family: 'Jones',
+          sequence: 'additional'
+        }
+      ]
+    };
+
+    const result = service.doiToMetadata(doi);
+
+    assert.ok(result, 'No result was returned');
+    assert.ok(result.authors, 'Was expecting "authors" property to exist');
+    assert.ok(result.issns, 'Was expecting "issns" field to exist');
+
+    assert.deepEqual(
+      result.authors,
+      [
+        {
+          ORCID: 'http://orcid.org/0000-0003-2974-7389',
+          'authenticated-orcid': false,
+          given: 'Moo',
+          family: 'Jones',
+          sequence: 'first',
+          orcid: 'http://orcid.org/0000-0003-2974-7389',
+          author: 'Moo Jones'
+        },
+        {
+          given: 'Moo, Jr',
+          family: 'Jones',
+          sequence: 'additional',
+          orcid: undefined,
+          author: 'Moo, Jr Jones'
+        }
+      ],
+      'Unexpected "authors" found'
+    );
+  });
 });

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -4,16 +4,8 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Service | doi', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('service:doi');
-    assert.ok(service);
-  });
-
-  // Test DOI object here based on CrossRef data
-  test('check doi data processing', function (assert) {
-    const service = this.owner.lookup('service:doi');
-    const doi = {
+  hooks.beforeEach(function () {
+    this.set('mockDoi', {
       'issn-map': {
         '0003-2654': { 'pub-type': ['Print'] },
         '1364-5528': { 'pub-type': ['Electronic'] }
@@ -32,7 +24,19 @@ module('Unit | Service | doi', (hooks) => {
           sequence: 'additional'
         }
       ]
-    };
+    });
+  });
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:doi');
+    assert.ok(service);
+  });
+
+  // Test DOI object here based on CrossRef data
+  test('check doi data processing', function (assert) {
+    const service = this.owner.lookup('service:doi');
+    const doi = this.get('mockDoi');
 
     const result = service.doiToMetadata(doi);
 
@@ -62,5 +66,14 @@ module('Unit | Service | doi', (hooks) => {
       ],
       'Unexpected "authors" found'
     );
+  });
+
+  test('make sure we only get valid fields back', function (assert) {
+    let doi = this.get('mockDoi');
+    doi.invalid = 'Bad moo';
+
+    const result = this.owner.lookup('service:doi').doiToMetadata(doi, ['authors', 'issn-map']);
+    assert.ok(result);
+    assert.notOk(result.invalid);
   });
 });


### PR DESCRIPTION
Uses properties from metadata schemas to determine which DOI keys to keep, with some custom property mapping. DOI properties that are not explicitly called out in any schema are thrown out as they may be troublesome for JSON schema validation