### PR TITLE
Refactor submission handling into service

### DIFF
--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -1,0 +1,246 @@
+import Service from '@ember/service';
+import ENV from 'pass-ember/config/environment';
+
+export default Service.extend({
+  store: Ember.inject.service('store'),
+  currentUser: Ember.inject.service('current-user'),
+  metadataService: Ember.inject.service('metadata-blob'),
+
+  /**
+  * Internal method which returns the URL to view a submission.
+  *
+  */
+  _getSubmissionView(submission) {
+    let baseURL = window.location.href.replace(new RegExp(`${ENV.rootURL}.*`), '');
+
+    return `${baseURL}${ENV.rootURL}submissions/${encodeURIComponent(`${submission.id}`)}`;
+  },
+
+  /**
+  * Internal method to finish a submission which has had all its files uploaded.
+  * Adds a submitted event with the given comment.
+  * Returns a promise which resolves to the updated submission.
+  */
+  _finishSubmission(submission, comment) {
+    let subEvent = this.store.createRecord('submissionEvent');
+
+    subEvent.set('performedBy', this.get('currentUser.user'));
+    subEvent.set('comment', comment);
+    subEvent.set('performedDate', new Date());
+    subEvent.set('submission', submission);
+    subEvent.set('link', this._getSubmissionView(submission));
+
+    // If the person clicking submit *is* the submitter, actually submit the submission.
+    if (submission.get('submitter.id') === this.get('currentUser.user.id')) {
+      submission.set('submitted', true);
+      submission.set('submissionStatus', 'submitted');
+      submission.set('submittedDate', new Date());
+      submission.set(
+        'repositories',
+        submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
+      );
+
+      subEvent.set('performerRole', 'submitter');
+      subEvent.set('eventType', 'submitted');
+    } else {
+      // If they *aren't* the submitter, they're the preparer.
+      submission.set('submissionStatus', 'approval-requested');
+      subEvent.set('performerRole', 'preparer');
+
+      // If a submitter is specified, it's a normal "approval-requested" scenario.
+      if (submission.get('submitter.id')) {
+        subEvent.set('eventType', 'approval-requested');
+      } else if (submission.get('submitterName') && submission.get('submitterEmail')) {
+        // If not specified but a name and email are present, create a mailto link.
+        subEvent.set('eventType', 'approval-requested-newuser');
+      }
+    }
+
+    // Save the updated submission, then save the submissionEvent
+    return subEvent.save().then(() => submission.save());
+  },
+
+  /**
+  * Internal method which adds a file to a submission.
+  * The bytes of the local file corresponding to the File object are read and
+  * uploaded to the Submission container. The modified File object is updated.
+  * Returns a promise which resolves to the File object.
+  */
+  _uploadFile(sub, file) {
+    return new Promise((resolve, reject) => {
+      var reader = new FileReader();
+
+      reader.onload = (evt) => {
+        let data = evt.target.result;
+
+        let xhr = new XMLHttpRequest();
+        xhr.open('POST', `${sub.get('id')}`, true);
+        xhr.setRequestHeader('Content-Disposition', `attachment; filename="${encodeURI(file.get('name'))}"`);
+        let contentType = file.get('_file.type') ? file.get('_file.type') : 'application/octet-stream';
+        xhr.setRequestHeader('Content-Type', contentType);
+
+        // Hacks to handle different environments
+        if (ENV.environment === 'travis' || ENV.environment === 'development') xhr.withCredentials = true;
+        if (ENV.environment === 'development') xhr.setRequestHeader('Authorization', 'Basic YWRtaW46bW9v');
+
+        xhr.onload = (results) => {
+          file.set('submission', sub);
+          file.set('uri', results.target.response);
+
+          file.save().then((f) => {
+            resolve(f);
+          }).catch((error) => {
+            console.log(error);
+            reject(new Error(`Error creating file object: ${error.message}`));
+          });
+        };
+
+        xhr.onerror = (error) => {
+          console.log(error);
+          reject(new Error(`Error uploading file: ${error.message}`));
+        };
+
+        xhr.send(data);
+      };
+
+      reader.onerror = (event) => {
+        console.log(error);
+        reject(new Error(`Error reading file: ${error.message}`));
+      };
+
+      reader.readAsArrayBuffer(file.get('_file'));
+    });
+  },
+
+  /**
+  * Perform a submission.
+  * Persists the publication, associate the submission with the saved publication,
+  * modify the submission appropriately, uploads files, and finally persists the submission
+  * with an appropraite event to hold the comment.
+
+  * Return a promise that does these things. See _uploadFile for how various errors may
+  * be reported.
+  */
+  submit(submission, publication, files, comment) {
+    return publication.save().then((p) => {
+      submission.set('submitted', false);
+      submission.set('source', 'pass');
+      submission.set('aggregatedDepositStatus', 'not-started');
+      submission.set('publication', p);
+
+      return submission.save();
+    }).then(s => Promise.all(files.map(f => this._uploadFile(f))).then(() => this._finishSubmission(s, comment)));
+  },
+
+  /**
+  * If the submission is submitted, return external-submissions object from metadata.
+  * Otherwise generate what it should be from external repositories.
+  */
+  _getExternalSubmissionsMetadata(submission) {
+    if (submission.get('submitted')) {
+      const metadata = JSON.parse(submission.get('metadata'));
+      let values = Ember.A();
+
+      // TODO Hack for old style metadata blob. Should remove later.
+      if (Array.isArray(metadata)) {
+        values = metadata.filter(x => x.id === 'external-submissions');
+
+        if (values.length == 0) {
+          return null;
+        }
+
+        return values[0];
+      }
+
+      return metadata;
+    }
+
+    return this.get('metadataService').getExternalReposBlob(submission.get('repositories'));
+  },
+
+  // Submitter approves submission.
+  // Metadata is added to external-submissions for all web-link repos and those
+  // repos are removed.
+  // Attaches a SubmissionEvent of type submitted with the given comment and
+  // sets the status of the Submission to changes-requested.
+  // Returns a promise that makes those changes.
+  approveSubmission(submission, comment) {
+    const extmd = _getExternalSubmissionsMetadata(submission);
+
+    // Add external submissions metadata
+    if (extmd) {
+      let md = JSON.parse(submission.get('metadata'));
+      this.get('metadataService').mergeBlobs(md, extmd);
+      submission.set('metadata', JSON.stringify(md));
+    }
+
+    // Remove external repositories
+    submission.set(
+      'repositories',
+      submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
+    );
+
+    let se = this.get('store').createRecord('submissionEvent', {
+      submission,
+      performedBy: this.get('currentUser.user'),
+      performedDate: new Date(),
+      comment,
+      performerRole: 'submitter',
+      eventType: 'submitted',
+      link: this._getSubmissionView(submission)
+    });
+
+    return se.save().then(() => {
+      submission.set('submissionStatus', 'submitted');
+      submission.set('submittedDate', new Date());
+      submission.set('submitted', true);
+      return submission.save();
+    });
+  },
+
+  /**
+  * Request that submission be changed before approval on behalf of submitter.
+  * Attaches a SubmissionEvent of type changes-requested with the given comment and
+  * sets the status of the Submission to changes-requested.
+  * Returns a promise that makes those changes.
+  */
+  requestSubmissionChanges(submission, comment) {
+    let se = this.get('store').createRecord('submissionEvent', {
+      submission,
+      comment,
+      performedBy: submission.get('submitter'),
+      performedDate: new Date(),
+      performerRole: 'submitter',
+      eventType: 'changes-requested',
+      link: this._getSubmissionView(submission)
+    });
+
+    return se.save().then(() => {
+      submission.set('submissionStatus', 'changes-requested');
+      return submission.save();
+    });
+  },
+
+  /**
+  * Cancel a prepared submission on behalf of submitter.
+  * Attaches a SubmissionEvent of type cancelled with the given comment and
+  * sets the status of the Submission to cancelled.
+  * Returns a promise that makes those changes.
+  */
+  cancelSubmission(submission, comment) {
+    let se = this.get('store').createRecord('submissionEvent', {
+      submission,
+      comment,
+      performedBy: submission.get('submitter'),
+      performedDate: new Date(),
+      performerRole: 'submitter',
+      eventType: 'cancelled',
+      link: this._getSubmissionView(submission)
+    });
+
+    return se.save().then(() => {
+      submission.set('submissionStatus', 'cancelled');
+      return submission.save();
+    });
+  }
+});

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -33,7 +33,7 @@ export default Service.extend({
    * @returns {Promise}          Promise resolves to the updated submission.
    */
   _finishSubmission(submission, comment) {
-    let subEvent = this.store.createRecord('submissionEvent');
+    let subEvent = this.get('store').createRecord('submissionEvent');
 
     subEvent.set('performedBy', this.get('currentUser.user'));
     subEvent.set('comment', comment);
@@ -83,7 +83,7 @@ export default Service.extend({
    */
   _uploadFile(sub, file) {
     return new Promise((resolve, reject) => {
-      var reader = new FileReader();
+      let reader = new FileReader();
 
       reader.onload = (evt) => {
         let data = evt.target.result;
@@ -118,7 +118,7 @@ export default Service.extend({
         xhr.send(data);
       };
 
-      reader.onerror = (event) => {
+      reader.onerror = (error) => {
         console.log(error);
         reject(new Error(`Error reading file: ${error.message}`));
       };
@@ -148,7 +148,7 @@ export default Service.extend({
       submission.set('publication', p);
 
       return submission.save();
-    }).then(s => Promise.all(files.map(f => this._uploadFile(f))).then(() => this._finishSubmission(s, comment)));
+    }).then(s => Promise.all(files.map(f => this._uploadFile(s, f))).then(() => this._finishSubmission(s, comment)));
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-composable-helpers": "^2.1.0",
     "ember-data": "^2.18.5",
     "ember-export-application-global": "^2.0.0",
-    "ember-fedora-adapter": "0.0.3",
+    "ember-fedora-adapter": "0.0.4",
     "ember-font-awesome": "^4.0.0-rc.4",
     "ember-load-initializers": "^1.1.0",
     "ember-modal-dialog": "^2.4.4",

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -11,132 +11,252 @@ module('Unit | Controller | submissions/new', (hooks) => {
     assert.ok(controller);
   });
 
-  test('finish and save non-proxy submission', function (assert) {
+  test('finish and save non-proxy submission', async function (assert) {
     let controller = this.owner.lookup('controller:submissions/new');
+    let submissionHandler = this.owner.lookup('service:submission-handler');
+
     this.owner.register('service:current-user', Ember.Object.extend({
       user: { id: 'submitter:test-id' }
     }));
 
-    let submissionEvent = Ember.Object.create({ });
-    controller.set('store', {
-      createRecord() { return submissionEvent; }
+    let submissionSaved = false;
+    let submissionEventSaved = false;
+    let publicationSaved = false;
+
+    let submissionEvent = Ember.Object.create({
+      save() {
+        submissionEventSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    let submissionSaved = false;
-    // 2 repositories so we can check web-link repo is removed from list
+    submissionHandler.set('store', Ember.Object.create({
+      createRecord() { return submissionEvent; }
+    }));
+
     let repository1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
     let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+
     let submission = Ember.Object.create({
+      id: 'sub:0',
       submitter: {
         id: 'submitter:test-id'
       },
       repositories: Ember.A([repository1, repository2]),
       save() {
         submissionSaved = true;
-        return new Promise(resolve => (assert.ok(true)));
+        return new Promise(resolve => resolve(this));
       }
     });
-    controller.set('comment', 'test comment');
 
-    run(() => {
-      controller.send('finishSubmission', submission);
+    let publication = Ember.Object.create({
+      id: 'pub:0',
+      save() {
+        publicationSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    assert.equal(submission.submissionStatus, 'submitted');
-    // check web-linked repo is removed
-    assert.equal(submission.repositories.length, 1);
-    assert.equal(submission.repositories[0].id, 'test:repo1');
-    assert.equal(submissionEvent.comment, 'test comment');
-    assert.equal(submissionEvent.performedBy.id, 'submitter:test-id');
-    assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
-    assert.equal(submissionEvent.comment, 'test comment');
-    assert.equal(submissionEvent.performerRole, 'submitter');
-    assert.equal(submissionEvent.eventType, 'submitted');
-    // because the promise doesnt return anything at the moment,
-    // only submission will be saved
-    assert.equal(submissionSaved, true);
+    let file = Ember.Object.create({
+      fileRole: 'manuscript'
+    });
+
+    let comment = 'moo';
+
+    let model = Ember.Object.create({
+      newSubmission: submission,
+      files: Ember.A([file]),
+      publication
+    });
+
+    assert.expect(13);
+
+    // After the route transition to thanks, all promises should be resolved handler
+    // and tests can be run.
+    controller.set('transitionToRoute', (name) => {
+      assert.equal(name, 'thanks');
+
+      assert.equal(publicationSaved, true);
+      assert.equal(submissionSaved, true);
+      assert.equal(submissionEventSaved, true);
+
+      assert.equal(submission.submitted, true);
+      assert.equal(submission.submissionStatus, 'submitted');
+
+      // check web-linked repo is removed
+      assert.equal(submission.repositories.length, 1);
+      assert.equal(submission.repositories[0].id, 'test:repo1');
+
+      assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
+      assert.equal(submissionEvent.performedBy.id, 'submitter:test-id');
+      assert.equal(submissionEvent.performerRole, 'submitter');
+      assert.equal(submissionEvent.comment, comment);
+      assert.equal(submissionEvent.eventType, 'submitted');
+    });
+
+    controller.set('model', model);
+    controller.set('comment', comment);
+    controller.set('filesTemp', Ember.A());
+
+    controller.send('submit');
   });
 
   test('finish and save proxy submission', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new');
+    let submissionHandler = this.owner.lookup('service:submission-handler');
+
     this.owner.register('service:current-user', Ember.Object.extend({
       user: { id: 'submitter:test-proxy-id' }
     }));
 
-    let submissionEvent = Ember.Object.create({ });
-    controller.set('store', {
-      createRecord() { return submissionEvent; }
+    let submissionSaved = false;
+    let submissionEventSaved = false;
+    let publicationSaved = false;
+
+    let submissionEvent = Ember.Object.create({
+      save() {
+        submissionEventSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    let submissionSaved = false;
-    let repository1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
-    let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'one-way' });
+    submissionHandler.set('store', Ember.Object.create({
+      createRecord() { return submissionEvent; }
+    }));
+
+    let repository = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+
     let submission = Ember.Object.create({
+      id: 'sub:0',
       submitter: {
         id: 'submitter:test-id'
       },
-      repositories: Ember.A([repository1, repository2]),
+      repositories: Ember.A([repository]),
       save() {
         submissionSaved = true;
-        return new Promise(resolve => (assert.ok(true)));
+        return new Promise(resolve => resolve(this));
       }
     });
-    controller.set('comment', 'test comment');
 
-    run(() => {
-      controller.send('finishSubmission', submission);
+    let publication = Ember.Object.create({
+      id: 'pub:0',
+      save() {
+        publicationSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    assert.equal(submission.submissionStatus, 'approval-requested');
-    assert.equal(submission.repositories.length, 2);
-    assert.equal(submissionEvent.comment, 'test comment');
-    assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
-    assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
-    assert.equal(submissionEvent.comment, 'test comment');
-    assert.equal(submissionEvent.performerRole, 'preparer');
-    assert.equal(submissionEvent.eventType, 'approval-requested');
-    // because the promise doesnt return anything at the moment,
-    // only submission will be saved
-    assert.equal(submissionSaved, true);
+    let comment = 'moo';
+
+    let model = Ember.Object.create({
+      newSubmission: submission,
+      publication
+    });
+
+    assert.expect(11);
+
+    // After the route transition to thanks, all promises should be resolved handler
+    // and tests can be run.
+    controller.set('transitionToRoute', (name) => {
+      assert.equal(name, 'thanks');
+
+      assert.equal(publicationSaved, true);
+      assert.equal(submissionSaved, true);
+      assert.equal(submissionEventSaved, true);
+
+      assert.equal(submission.submissionStatus, 'approval-requested');
+      assert.equal(submission.repositories.length, 1);
+      assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');
+      assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
+      assert.equal(submissionEvent.performerRole, 'preparer');
+      assert.equal(submissionEvent.eventType, 'approval-requested');
+      assert.equal(submissionEvent.comment, comment);
+    });
+
+    controller.set('model', model);
+    controller.set('comment', comment);
+    controller.set('filesTemp', Ember.A());
+
+    controller.send('submit');
   });
 
   test('finish and save proxy submission with new user', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new');
+    let submissionHandler = this.owner.lookup('service:submission-handler');
+
     this.owner.register('service:current-user', Ember.Object.extend({
       user: { id: 'submitter:test-proxy-id' }
     }));
 
-    let submissionEvent = Ember.Object.create({ });
-    controller.set('store', {
-      createRecord() { return submissionEvent; }
+    let submissionSaved = false;
+    let submissionEventSaved = false;
+    let publicationSaved = false;
+
+    let submissionEvent = Ember.Object.create({
+      save() {
+        submissionEventSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    let submissionSaved = false;
+    submissionHandler.set('store', Ember.Object.create({
+      createRecord() { return submissionEvent; }
+    }));
+
     let repository = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+
     let submission = Ember.Object.create({
+      id: 'sub:0',
       submitterName: 'test name',
       submitterEmail: 'mailto:test@email.com',
       repositories: Ember.A([repository]),
       save() {
         submissionSaved = true;
-        return new Promise(resolve => (assert.ok(true)));
+        return new Promise(resolve => resolve(this));
       }
     });
 
-    run(() => {
-      controller.send('finishSubmission', submission);
+    let publication = Ember.Object.create({
+      id: 'pub:0',
+      save() {
+        publicationSaved = true;
+        return new Promise(resolve => resolve(this));
+      }
     });
 
-    assert.equal(submission.submitter, null);
-    assert.equal(submission.submitterName, 'test name');
-    assert.equal(submission.submitterEmail, 'mailto:test@email.com');
-    assert.equal(submission.submissionStatus, 'approval-requested');
-    assert.equal(submission.repositories.length, 1);
-    assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
-    assert.equal(submissionEvent.performerRole, 'preparer');
-    assert.equal(submissionEvent.eventType, 'approval-requested-newuser');
-    // because the promise doesnt return anything at the moment,
-    // only submission will be saved
-    assert.equal(submissionSaved, true);
+    let comment = 'moo';
+
+    let model = Ember.Object.create({
+      newSubmission: submission,
+      publication
+    });
+
+    assert.expect(13);
+
+    // After the route transition to thanks, all promises should be resolved handler
+    // and tests can be run.
+    controller.set('transitionToRoute', (name) => {
+      assert.equal(name, 'thanks');
+
+      assert.equal(publicationSaved, true);
+      assert.equal(submissionSaved, true);
+      assert.equal(submissionEventSaved, true);
+
+      assert.equal(submission.submitter, null);
+      assert.equal(submission.submitterName, 'test name');
+      assert.equal(submission.submitterEmail, 'mailto:test@email.com');
+      assert.equal(submission.submissionStatus, 'approval-requested');
+      assert.equal(submission.repositories.length, 1);
+      assert.equal(submissionEvent.performedBy.id, 'submitter:test-proxy-id');
+      assert.equal(submissionEvent.performerRole, 'preparer');
+      assert.equal(submissionEvent.eventType, 'approval-requested-newuser');
+      assert.equal(submissionEvent.comment, comment);
+    });
+
+    controller.set('model', model);
+    controller.set('comment', comment);
+    controller.set('filesTemp', Ember.A());
+
+    controller.send('submit');
   });
 });

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -1,12 +1,283 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Service | submission-handker', (hooks) => {
+module('Unit | Service | submission-handler', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
+  test('prepare submission', function (assert) {
     let service = this.owner.lookup('service:submission-handler');
-    assert.ok(service);
+
+    this.owner.register('service:current-user', Ember.Object.extend({
+      user: { id: 'proxy-user-id' }
+    }));
+
+    let submissionEvent = {};
+
+    service.set('store', Ember.Object.create({
+      createRecord(type, values) {
+        submissionEvent = Ember.Object.create(values);
+
+        submissionEvent.set('save', () => {
+          assert.ok(true);
+          return new Promise(resolve => resolve(this));
+        });
+
+        return submissionEvent;
+      }
+    }));
+
+    let repo1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repo2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+
+    let submission = Ember.Object.create({
+      id: '0',
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      metadata: '{}',
+      repositories: Ember.A([repo1, repo2]),
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let publication = Ember.Object.create({
+      id: '1',
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let files = Ember.A();
+    let comment = 'blarg';
+
+    assert.expect(13);
+
+    return service.submit(submission, publication, files, comment).then(() => {
+      assert.equal(submission.get('submitted'), false);
+      assert.equal(submission.get('submissionStatus'), 'approval-requested');
+
+      // web-link repo should not be removed
+      assert.equal(submission.get('repositories.length'), 2);
+
+      assert.equal(submissionEvent.get('eventType'), 'approval-requested');
+      assert.equal(submissionEvent.get('performerRole'), 'preparer');
+      assert.equal(submissionEvent.get('performedBy.id'), 'proxy-user-id');
+      assert.equal(submissionEvent.get('comment'), comment);
+      assert.equal(submissionEvent.get('submission.id'), submission.get('id'));
+      assert.ok(submissionEvent.get('link').includes(submission.get('id')));
+    });
+  });
+
+  test('submit', function (assert) {
+    let service = this.owner.lookup('service:submission-handler');
+
+    this.owner.register('service:current-user', Ember.Object.extend({
+      user: { id: 'submitter:test-id' }
+    }));
+
+    let submissionEvent = {};
+
+    service.set('store', Ember.Object.create({
+      createRecord(type, values) {
+        submissionEvent = Ember.Object.create(values);
+
+        submissionEvent.set('save', () => {
+          assert.ok(true);
+          return new Promise(resolve => resolve(this));
+        });
+
+        return submissionEvent;
+      }
+    }));
+
+    let repo1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repo2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+
+    let submission = Ember.Object.create({
+      id: '0',
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      metadata: '{}',
+      repositories: Ember.A([repo1, repo2]),
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let publication = Ember.Object.create({
+      id: '1',
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let files = Ember.A();
+    let comment = 'blarg';
+
+    assert.expect(13);
+
+    return service.submit(submission, publication, files, comment).then(() => {
+      assert.equal(submission.get('submitted'), true);
+      assert.equal(submission.get('submissionStatus'), 'submitted');
+
+      // web-link repo should be removed
+      assert.equal(submission.get('repositories.length'), 1);
+      assert.equal(submission.get('repositories.firstObject.id'), repo1.id);
+
+      assert.equal(submissionEvent.get('eventType'), 'submitted');
+      assert.equal(submissionEvent.get('performerRole'), 'submitter');
+      assert.equal(submissionEvent.get('comment'), comment);
+      assert.equal(submissionEvent.get('submission.id'), submission.get('id'));
+      assert.ok(submissionEvent.get('link').includes(submission.get('id')));
+    });
+  });
+
+  test('approve submission', function (assert) {
+    let service = this.owner.lookup('service:submission-handler');
+
+    let submissionEvent = {};
+
+    service.set('store', Ember.Object.create({
+      createRecord(type, values) {
+        submissionEvent = Ember.Object.create(values);
+
+        submissionEvent.set('save', () => {
+          assert.ok(true);
+          return new Promise(resolve => resolve(this));
+        });
+
+        return submissionEvent;
+      }
+    }));
+
+    let repo1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repo2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+
+    let submission = Ember.Object.create({
+      id: '0',
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      metadata: '{}',
+      repositories: Ember.A([repo1, repo2]),
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let comment = 'blarg';
+
+    assert.expect(12);
+
+    return service.approveSubmission(submission, comment).then(() => {
+      assert.equal(submission.get('submitted'), true);
+      assert.equal(submission.get('submissionStatus'), 'submitted');
+
+      // web-link repo should be removed and external-submissions added
+      assert.equal(submission.get('repositories.length'), 1);
+      assert.equal(submission.get('repositories.firstObject.id'), repo1.id);
+      assert.ok(submission.get('metadata').includes('external-submissions'));
+
+      assert.equal(submissionEvent.get('eventType'), 'submitted');
+      assert.equal(submissionEvent.get('performerRole'), 'submitter');
+      assert.equal(submissionEvent.get('comment'), comment);
+      assert.equal(submissionEvent.get('submission.id'), submission.get('id'));
+      assert.ok(submissionEvent.get('link').includes(submission.get('id')));
+    });
+  });
+
+  test('cancel submission', function (assert) {
+    let service = this.owner.lookup('service:submission-handler');
+
+    let submissionEvent = {};
+
+    service.set('store', Ember.Object.create({
+      createRecord(type, values) {
+        submissionEvent = Ember.Object.create(values);
+
+        submissionEvent.set('save', () => {
+          assert.ok(true);
+          return new Promise(resolve => resolve(this));
+        });
+
+        return submissionEvent;
+      }
+    }));
+
+    let submission = Ember.Object.create({
+      id: '0',
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      repositories: Ember.A(),
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let comment = 'blarg';
+
+    assert.expect(8);
+
+    return service.cancelSubmission(submission, comment).then(() => {
+      assert.equal(submission.get('submissionStatus'), 'cancelled');
+      assert.equal(submissionEvent.get('eventType'), 'cancelled');
+      assert.equal(submissionEvent.get('performerRole'), 'submitter');
+      assert.equal(submissionEvent.get('comment'), comment);
+      assert.equal(submissionEvent.get('submission.id'), submission.get('id'));
+      assert.ok(submissionEvent.get('link').includes(submission.get('id')));
+    });
+  });
+
+  test('request changes', function (assert) {
+    let service = this.owner.lookup('service:submission-handler');
+
+    let submissionEvent = {};
+
+    service.set('store', Ember.Object.create({
+      createRecord(type, values) {
+        submissionEvent = Ember.Object.create(values);
+
+        submissionEvent.set('save', () => {
+          assert.ok(true);
+          return new Promise(resolve => resolve(this));
+        });
+
+        return submissionEvent;
+      }
+    }));
+
+    let submission = Ember.Object.create({
+      id: '0',
+      submitter: {
+        id: 'submitter:test-id'
+      },
+      repositories: Ember.A(),
+      save() {
+        assert.ok(true);
+        return new Promise(resolve => resolve(this));
+      }
+    });
+
+    let comment = 'blarg';
+
+    assert.expect(8);
+
+    return service.requestSubmissionChanges(submission, comment).then(() => {
+      assert.equal(submission.get('submissionStatus'), 'changes-requested');
+      assert.equal(submissionEvent.get('eventType'), 'changes-requested');
+      assert.equal(submissionEvent.get('performerRole'), 'submitter');
+      assert.equal(submissionEvent.get('comment'), comment);
+      assert.equal(submissionEvent.get('submission.id'), submission.get('id'));
+      assert.ok(submissionEvent.get('link').includes(submission.get('id')));
+    });
   });
 });

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | submission-handker', (hooks) => {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:submission-handler');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
This pr pulls out most of the logic surrounding persisting and changing submissions into a service. The pr does not consolidate the logic surrounding popups as in #881.

Tasks:
* [x]  Create submission handling service
* [x] Unit test submission handling service
* [x] Update pass-ember to use new service
* [x] Manual user testing of pass-ember for regressions

In order to test, bring up the docker environment and try all of the submission operations: prepare a submission, perform a submission, approve a submission, request submission changes, and cancel a prepared submission. Also try various varieties of file upload.

resolves https://github.com/OA-PASS/pass-ember/issues/896