### PR TITLE
Fix doi data inconsistencies

### DIFF
--- a/app/services/error-handler.js
+++ b/app/services/error-handler.js
@@ -12,6 +12,8 @@ export default Service.extend({
 
     if (error.stack) {
       console.log(error.stack);
+    } else {
+      console.log(error);
     }
 
     if (error.name == 'TransitionAborted') {

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -1,11 +1,13 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import { click, fillIn, triggerKeyEvent, render } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
 
 module('Integration | Component | workflow basics', (hooks) => {
   setupRenderingTest(hooks);
 
-  test('it renders', function (assert) {
+  hooks.beforeEach(function () {
     let submission = Ember.Object.create({
       repositories: [],
       grants: []
@@ -25,7 +27,112 @@ module('Integration | Component | workflow basics', (hooks) => {
     this.set('validateSubmitterEmail', (actual) => { });
     this.set('loadNext', (actual) => {});
 
-    this.render(hbs`{{workflow-basics
+    const mockDoiService = Ember.Service.extend({
+      resolveDOI(doi) {
+        return Promise.resolve({
+          publisher: 'Royal Society of Chemistry (RSC)',
+          issue: 1,
+          'short-container-title': 'Analyst',
+          abstract: '<p>The investigators report a dramatically improved chemoselective analysis for carbonyls in crude biological extracts by turning to a catalyst and freezing conditions for derivatization.</p>',
+          DOI: '10.1039/c7an01256j',
+          type: 'journal-article',
+          page: '311-322',
+          'update-policy': 'http://dx.doi.org/10.1039/rsc_crossmark_policy',
+          source: 'Crossref',
+          'is-referenced-by-count': 5,
+          title: 'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS',
+          prefix: '10.1039',
+          volume: '143',
+          'container-title': 'The Analyst',
+          'original-title': '',
+          language: 'en',
+          ISSN: ['0003-2654', '1364-5528'],
+          'issn-type': [
+            { value: '0003-2654', type: 'print' },
+            { value: '1364-5528', type: 'electronic' }
+          ],
+        });
+      },
+      formatDOI(doi) {
+        return 'moo';
+      },
+      isValidDOI() {
+        return true;
+      },
+      getJournalTitle() {
+        return 'moo-title';
+      }
+    });
+
+    const mockNlmta = Ember.Service.extend({
+      getNlmtaFromIssn() {
+        return {
+          nlmta: 'nl-moo-ta',
+          'issn-map': {
+            '0003-2654': { 'pub-type': 'print' },
+            '1364-5528': { 'pub-type': 'electronic' }
+          }
+        };
+      }
+    });
+
+    const mockStore = Ember.Service.extend({
+      query(type, query) {
+        return Promise.resolve(Ember.A());
+      },
+      createRecord() {
+        return Ember.Object.create({
+          save() {
+            return Promise.resolve();
+          }
+        });
+      }
+    });
+
+    run(() => {
+      this.owner.unregister('service:doi');
+      this.owner.register('service:doi', mockDoiService);
+
+      this.owner.unregister('service:nlmta');
+      this.owner.register('service:nlmta', mockNlmta);
+
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', mockStore);
+    });
+  });
+
+  // eslint-disable-next-line prefer-arrow-callback
+  test('it renders', async function (assert) {
+    await render(hbs`{{workflow-basics
+      submission=submission
+      preLoadedGrant=preLoadedGrant
+      publication=publication
+      doiInfo=doiInfo
+      flaggedFields=flaggedFields
+      validateTitle=(action validateTitle)
+      validateJournal=(action validateJournal)
+      validateSubmitterEmail=(action validateSubmitterEmail)
+      next=(action loadNext)}}`);
+    assert.ok(true);
+  });
+
+  test('lookupDOI should create valid Publication', async function (assert) {
+    const origPub = Ember.Object.create({ doi: 'fake-doi' });
+    const publication = Ember.Object.create({
+      doi: 'fake-doi'
+    });
+    const submission = Ember.Object.create({
+      repositories: Ember.A(),
+      grants: Ember.A()
+    });
+
+    this.set('submission', submission);
+    this.set('publication', publication);
+
+    // this.set('lookupDOI', () => assert.ok(true));
+    this.set('validateTitle', () => assert.ok(true));
+
+    await render(hbs`{{workflow-basics
       submission=submission
       publication=publication
       preLoadedGrant=preLoadedGrant
@@ -35,6 +142,21 @@ module('Integration | Component | workflow basics', (hooks) => {
       validateJournal=(action validateJournal)
       validateSubmitterEmail=(action validateSubmitterEmail)
       next=(action loadNext)}}`);
-    assert.ok(true);
+
+    // Add a DOI to UI
+    await fillIn('#doi', '1234/4321');
+
+    assert.notDeepEqual(publication, origPub);
+    assert.deepEqual(
+      publication.getProperties(['abstract', 'doi', 'issue', 'title', 'volume']),
+      {
+        abstract: '<p>The investigators report a dramatically improved chemoselective analysis for carbonyls in crude biological extracts by turning to a catalyst and freezing conditions for derivatization.</p>',
+        doi: '1234/4321',
+        issue: 1,
+        title: 'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS',
+        volume: '143'
+      },
+      'Unexpected publication data found'
+    );
   });
 });

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -76,4 +76,39 @@ module('Unit | Service | doi', (hooks) => {
     assert.ok(result);
     assert.notOk(result.invalid);
   });
+
+  test('should stringify array values', function (assert) {
+    const mockDoi = {
+      publisher: 'Royal Society of Chemistry (RSC)',
+      issue: 1,
+      'short-container-title': 'Analyst',
+      abstract: '<p>The investigators report a dramatically improved chemoselective analysis for carbonyls in crude biological extracts by turning to a catalyst and freezing conditions for derivatization.</p>',
+      DOI: '10.1039/c7an01256j',
+      type: 'journal-article',
+      page: '311-322',
+      'update-policy': 'http://dx.doi.org/10.1039/rsc_crossmark_policy',
+      source: 'Crossref',
+      'is-referenced-by-count': 5,
+      title: [
+        'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS'
+      ],
+      prefix: '10.1039',
+      volume: '143',
+      'container-title': ['The Analyst'],
+      'original-title': [],
+      language: 'en',
+      ISSN: ['0003-2654', '1364-5528'],
+      'issn-type': [
+        { value: '0003-2654', type: 'print' },
+        { value: '1364-5528', type: 'electronic' }
+      ],
+    };
+
+    const result = this.owner.lookup('service:doi')._processRawDoi(mockDoi);
+    assert.ok(result);
+    assert.equal(typeof result['journal-title'], 'string', '"journal-title" should be a string');
+    assert.equal(typeof result.title, 'string', '"title" should be a string');
+    assert.equal(typeof result['short-container-title'], 'string', '"short-container-title" should be a string');
+    assert.notEqual(typeof result.ISSN, 'string', 'Should not stringify this array value');
+  });
 });


### PR DESCRIPTION
These changes are meant to address some data weirdness with DOI info coming from Crossref. We were expecting some values to be strings, but were getting arrays of strings instead. For now, we simply join these array values to "stringify" them.