### PR TITLE
Autosave inprogress submissions

### DIFF
--- a/app/components/metadata-form.js
+++ b/app/components/metadata-form.js
@@ -29,6 +29,13 @@ export default Ember.Component.extend({
             that.previousForm(this.getValue());
           },
         },
+        Abort: {
+          label: 'Abort',
+          styles: 'pull-left btn btn-outline-danger ml-2',
+          click() {
+            that.cancel();
+          }
+        }
       },
     };
 

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -4,6 +4,8 @@ import swal from 'sweetalert2';
 
 export default Component.extend({
   currentUser: service('current-user'),
+  submissionHandler: service('submission-handler'),
+
   isPreparer: Ember.computed('currentUser', 'record', function () {
     let userId = this.get('currentUser.user.id');
     let preparers = this.get('record.preparers');
@@ -38,8 +40,7 @@ export default Component.extend({
         // }
       }).then((result) => {
         if (result.value) {
-          submission.deleteRecord();
-          submission.save();
+          this.get('submissionHandler').deleteSubmission(submission);
         }
       });
     }

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -10,5 +10,21 @@ export default Component.extend({
   }),
   isSubmitter: Ember.computed('currentUser', 'record', function () {
     return this.get('currentUser.user.id') === this.get('record.submitter.id');
-  })
+  }),
+  submissionIsDraft: Ember.computed('record', function () {
+    // TODO: after model update, we can just check if submission status === 'draft'
+    // return this.get('record.submissinoStatus') === 'draft';
+    return !this.get('record.submitted') && !this.get('record.submissionStatus');
+  }),
+
+  actions: {
+    /**
+     * TODO: when things are merged, call 'submission-handler' to remove this submission
+     * @param {object} submission model object to be removed
+     */
+    deleteSubmission(submission) {
+      console.log('Will delete submission');
+      console.log(submission);
+    }
+  }
 });

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import swal from 'sweetalert2';
 
 export default Component.extend({
   currentUser: service('current-user'),
@@ -10,11 +11,6 @@ export default Component.extend({
   }),
   isSubmitter: Ember.computed('currentUser', 'record', function () {
     return this.get('currentUser.user.id') === this.get('record.submitter.id');
-  }),
-  submissionIsDraft: Ember.computed('record', function () {
-    // TODO: after model update, we can just check if submission status === 'draft'
-    // return this.get('record.submissinoStatus') === 'draft';
-    return !this.get('record.submitted') && !this.get('record.submissionStatus');
   }),
 
   actions: {
@@ -28,7 +24,24 @@ export default Component.extend({
      * @param {object} submission model object to be removed
      */
     deleteSubmission(submission) {
-      submission.deleteRecord();
+      swal({
+        // title: 'Are you sure?',
+        text: 'Are you sure you want to delete this draft submission? This cannot be undone.',
+        confirmButtonText: 'Delete',
+        confirmButtonColor: '#f86c6b',
+        showCancelButton: true,
+        // buttonsStyling: false,
+        // confirmButtonClass: 'btn btn-danger',
+        // cancelButtonText: 'No',
+        // customClass: {
+        //   confirmButton: 'btn btn-danger'
+        // }
+      }).then((result) => {
+        if (result.value) {
+          submission.deleteRecord();
+          submission.save();
+        }
+      });
     }
   }
 });

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -19,12 +19,16 @@ export default Component.extend({
 
   actions: {
     /**
-     * TODO: when things are merged, call 'submission-handler' to remove this submission
+     * Delete the specified submission record from Fedora.
+     *
+     * Note: `ember-fedora-adapter#deleteRecord` behaves like `ember-data#destroyRecord`
+     * in that the deletion is pushed to the back end automatically, such that a
+     * subsequent 'save()' will fail.
+     *
      * @param {object} submission model object to be removed
      */
     deleteSubmission(submission) {
-      console.log('Will delete submission');
-      console.log(submission);
+      submission.deleteRecord();
     }
   }
 });

--- a/app/components/submissions-repoid-cell.js
+++ b/app/components/submissions-repoid-cell.js
@@ -10,6 +10,10 @@ export default Component.extend({
     this._super(...arguments);
 
     const publicationId = this.get('record.publication.id');
+    if (!publicationId) {
+      this.set('repoCopies', Ember.A());
+      return;
+    }
     this.get('store').query('repositoryCopy', {
       query: {
         term: { publication: publicationId }

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -196,6 +196,10 @@ export default Component.extend({
       const publication = this.get('publication');
       publication.set('journal', journal);
       this.sendAction('validateJournal');
+    },
+
+    cancel() {
+      this.sendAction('abort');
     }
   }
 });

--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -60,6 +60,9 @@ export default Component.extend({
       let files = this.get('newFiles');
       files.removeObject(file);
       this.set('files', files);
+    },
+    cancel() {
+      this.sendAction('abort');
     }
   },
 });

--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -133,5 +133,9 @@ export default Component.extend({
       // undo progress, make user redo metadata step.
       this.get('workflow').setMaxStep(2);
     },
+
+    abortSubmission() {
+      this.sendAction('abort');
+    }
   },
 });

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -116,6 +116,10 @@ export default Component.extend({
         this.sendAction('back');
       }
     },
+
+    cancel() {
+      this.sendAction('abort');
+    }
   },
 
   /**

--- a/app/components/workflow-policies.js
+++ b/app/components/workflow-policies.js
@@ -19,4 +19,10 @@ export default Component.extend({
     policies = policies.uniqBy('id');
     return policies;
   }),
+
+  actions: {
+    cancel() {
+      this.sendAction('abort');
+    }
+  }
 });

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -107,5 +107,8 @@ export default Component.extend({
       if (event.target.checked) this.send('addRepository', repository);
       else this.send('removeRepository', repository);
     },
+    cancel() {
+      this.sendAction('abort');
+    }
   }
 });

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -215,6 +215,9 @@ export default Component.extend({
           win.focus();
         }
       });
+    },
+    cancel() {
+      this.sendAction('abort');
     }
   }
 });

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -425,8 +425,7 @@ export default Controller.extend({
         showCancelButton: true
       }).then((result) => {
         if (result.value) {
-          submission.deleteRecord();
-          submission.save();
+          this.get('submissionHandler').deleteSubmission(submission);
         }
       });
     }

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -416,6 +416,19 @@ export default Controller.extend({
           this.get('submissionHandler').cancelSubmission(sub, message).then(() => window.location.reload(true));
         }
       });
+    },
+    deleteSubmission(submission) {
+      swal({
+        text: 'Are you sure you want to delete this draft submission? This cannot be undone.',
+        confirmButtonText: 'Delete',
+        confirmButtonColor: '#f86c6b',
+        showCancelButton: true
+      }).then((result) => {
+        if (result.value) {
+          submission.deleteRecord();
+          submission.save();
+        }
+      });
     }
   }
 });

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -66,6 +66,22 @@ export default Controller.extend({
           this.transitionToRoute('thanks', { queryParams: { submission: sub.get('id') } });
         });
       }
+    },
+    abort() {
+      const submission = this.get('model.newSubmission');
+
+      swal({
+        title: 'Discard Draft',
+        text: 'This will abort the current submission and discard progress you\'ve made. This cannot be undone.',
+        confirmButtonText: 'Abort',
+        confirmButtonColor: '#f86c6b',
+        showCancelButton: true
+      }).then((result) => {
+        if (result.value) {
+          this.get('submissionHandler').deleteSubmission(submission);
+          this.transitionToRoute('submissions');
+        }
+      });
     }
   }
 });

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -78,8 +78,8 @@ export default Controller.extend({
         showCancelButton: true
       }).then((result) => {
         if (result.value) {
-          this.get('submissionHandler').deleteSubmission(submission);
-          this.transitionToRoute('submissions');
+          this.get('submissionHandler').deleteSubmission(submission)
+            .then(() => this.transitionToRoute('submissions'));
         }
       });
     }

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -8,6 +8,7 @@ export default Controller.extend({
   publication: alias('model.publication'),
   preLoadedGrant: alias('model.preLoadedGrant'),
   submissionEvents: alias('model.submissionEvents'),
+  parent: Ember.inject.controller('submissions.new'),
 
   // these errors start as false since you don't want to immediately have all fields turn red
   titleError: false,
@@ -105,6 +106,9 @@ export default Controller.extend({
     },
     validateSubmitterEmail() {
       this.set('submitterEmailError', this.get('submitterEmailIsInvalid'));
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 });

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -57,7 +57,8 @@ export default Controller.extend({
     loadTab(gotoRoute) {
       if (!this.get('doiInfo.title')) this.set('doiInfo.title', this.get('publication.title'));
       toastr.remove();
-      this.transitionToRoute(gotoRoute);
+
+      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
     },
     validateAndLoadTab(gotoRoute) {
       this.set('titleError', false);

--- a/app/controllers/submissions/new/files.js
+++ b/app/controllers/submissions/new/files.js
@@ -35,8 +35,10 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       this.send('updateRelatedData');
-      this.transitionToRoute(gotoRoute);
-      this.set('loadingNext', false); // reset for next time
+      this.get('submission').save().then(() => {
+        this.transitionToRoute(gotoRoute);
+        this.set('loadingNext', false); // reset for next time
+      });
     },
     validateAndLoadTab(gotoTab) {
       let needValidation = this.get('needValidation');

--- a/app/controllers/submissions/new/files.js
+++ b/app/controllers/submissions/new/files.js
@@ -82,6 +82,9 @@ export default Controller.extend({
           }
         });
       }
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 

--- a/app/controllers/submissions/new/grants.js
+++ b/app/controllers/submissions/new/grants.js
@@ -6,6 +6,8 @@ export default Controller.extend({
   preLoadedGrant: alias('model.preLoadedGrant'),
   publication: alias('model.publication'),
   submissionEvents: alias('model.submissionEvents'),
+  parent: Ember.inject.controller('submissions.new'),
+
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.policies');
@@ -16,6 +18,9 @@ export default Controller.extend({
     loadTab(gotoRoute) {
       // add validation, processing
       this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 });

--- a/app/controllers/submissions/new/grants.js
+++ b/app/controllers/submissions/new/grants.js
@@ -15,7 +15,7 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       // add validation, processing
-      this.transitionToRoute(gotoRoute);
+      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
     }
   }
 });

--- a/app/controllers/submissions/new/metadata.js
+++ b/app/controllers/submissions/new/metadata.js
@@ -15,7 +15,7 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       // add validation, processing
-      this.transitionToRoute(gotoRoute);
+      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
     }
   }
 });

--- a/app/controllers/submissions/new/metadata.js
+++ b/app/controllers/submissions/new/metadata.js
@@ -6,6 +6,8 @@ export default Controller.extend({
   repositories: alias('model.repositories'),
   publication: alias('model.publication'),
   submissionEvents: alias('model.submissionEvents'),
+  parent: Ember.inject.controller('submissions.new'),
+
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.files');
@@ -16,6 +18,9 @@ export default Controller.extend({
     loadTab(gotoRoute) {
       // add validation, processing
       this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 });

--- a/app/controllers/submissions/new/policies.js
+++ b/app/controllers/submissions/new/policies.js
@@ -15,7 +15,7 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       // add validation, processing
-      this.transitionToRoute(gotoRoute);
+      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
     }
   }
 });

--- a/app/controllers/submissions/new/policies.js
+++ b/app/controllers/submissions/new/policies.js
@@ -6,6 +6,8 @@ export default Controller.extend({
   policies: alias('model.policies'),
   publication: alias('model.publication'),
   submissionEvents: alias('model.submissionEvents'),
+  parent: Ember.inject.controller('submissions.new'),
+
   actions: {
     loadNext() {
       this.send('loadTab', 'submissions.new.repositories');
@@ -16,6 +18,9 @@ export default Controller.extend({
     loadTab(gotoRoute) {
       // add validation, processing
       this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 });

--- a/app/controllers/submissions/new/repositories.js
+++ b/app/controllers/submissions/new/repositories.js
@@ -24,9 +24,11 @@ export default Controller.extend({
       this.send('loadTab', 'submissions.new.policies');
     },
     loadTab(gotoRoute) {
-      this.send('updateRelatedData');
-      this.transitionToRoute(gotoRoute);
-      this.set('loadingNext', false); // reset for next time
+      // this.send('updateRelatedData'); // I think this is only relevant for old style metadata blob
+      this.get('submission').save().then(() => {
+        this.transitionToRoute(gotoRoute);
+        this.set('loadingNext', false); // reset for next time
+      });
     },
     validateAndLoadTab(gotoRoute) {
       let needValidation = this.get('needValidation');

--- a/app/controllers/submissions/new/repositories.js
+++ b/app/controllers/submissions/new/repositories.js
@@ -51,19 +51,19 @@ export default Controller.extend({
         this.send('loadTab', gotoRoute);
       }
     },
-    updateRelatedData() {
-      // Remove any schemas not associated with the repositories attached to the submission or not on the whitelist.
-      // Whitelisted schemas are not associated with repositories but still required by deposit services.
-      let metadata;
-      if (this.get('submission.metadata')) {
-        metadata = JSON.parse(this.get('submission.metadata'));
-      } else {
-        metadata = [];
-      }
-      let schemaWhitelist = ['common', 'crossref', 'agent_information', 'pmc'];
-      let schemaIds = this.get('submission.repositories').map(x => JSON.parse(x.get('formSchema')).id);
-      metadata = metadata.filter(md => schemaIds.includes(md.id) || schemaWhitelist.includes(md.id));
-      this.set('submission.metadata', JSON.stringify(metadata));
-    }
+    // updateRelatedData() {
+    //   // Remove any schemas not associated with the repositories attached to the submission or not on the whitelist.
+    //   // Whitelisted schemas are not associated with repositories but still required by deposit services.
+    //   let metadata;
+    //   if (this.get('submission.metadata')) {
+    //     metadata = JSON.parse(this.get('submission.metadata'));
+    //   } else {
+    //     metadata = [];
+    //   }
+    //   let schemaWhitelist = ['common', 'crossref', 'agent_information', 'pmc'];
+    //   let schemaIds = this.get('submission.repositories').map(x => JSON.parse(x.get('formSchema')).id);
+    //   metadata = metadata.filter(md => schemaIds.includes(md.id) || schemaWhitelist.includes(md.id));
+    //   this.set('submission.metadata', JSON.stringify(metadata));
+    // }
   }
 });

--- a/app/controllers/submissions/new/repositories.js
+++ b/app/controllers/submissions/new/repositories.js
@@ -8,6 +8,8 @@ export default Controller.extend({
   repositories: alias('model.repositories'),
   publication: alias('model.publication'),
   submissionEvents: alias('model.submissionEvents'),
+  parent: Ember.inject.controller('submissions.new'),
+
   nextTabIsActive: Ember.computed('workflow.maxStep', function () {
     return (this.get('workflow').getMaxStep() > 4);
   }),
@@ -36,7 +38,7 @@ export default Controller.extend({
         swal({
           type: 'warning',
           title: 'No repositories selected',
-          html: 'If you don\'t plan on submitting to any repositories, you can stop at this time. Click "Exit '
+          html: 'If you don\'t pan on submitting to any repositories, you can stop at this time. Click "Exit '
                 + 'submission" to return to the dashboard, or "Continue submission" to go back and select a repository',
           showCancelButton: true,
           cancelButtonText: 'Exit Submission',
@@ -65,5 +67,8 @@ export default Controller.extend({
     //   metadata = metadata.filter(md => schemaIds.includes(md.id) || schemaWhitelist.includes(md.id));
     //   this.set('submission.metadata', JSON.stringify(metadata));
     // }
+    abort() {
+      this.get('parent').send('abort');
+    }
   }
 });

--- a/app/controllers/submissions/new/review.js
+++ b/app/controllers/submissions/new/review.js
@@ -28,7 +28,8 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       // add validation, processing
-      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
+      // this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
+      this.transitionToRoute(gotoRoute);
     },
     submit() {
       this.get('parent').send('submit');

--- a/app/controllers/submissions/new/review.js
+++ b/app/controllers/submissions/new/review.js
@@ -33,6 +33,9 @@ export default Controller.extend({
     },
     submit() {
       this.get('parent').send('submit');
+    },
+    abort() {
+      this.get('parent').send('abort');
     }
   }
 });

--- a/app/controllers/submissions/new/review.js
+++ b/app/controllers/submissions/new/review.js
@@ -28,7 +28,7 @@ export default Controller.extend({
     },
     loadTab(gotoRoute) {
       // add validation, processing
-      this.transitionToRoute(gotoRoute);
+      this.get('submission').save().then(() => this.transitionToRoute(gotoRoute));
     },
     submit() {
       this.get('parent').send('submit');

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -73,5 +73,14 @@ export default DS.Model.extend({
   }),
   isStub: Ember.computed('source', 'submitted', function () {
     return this.get('source') === 'other' && !(this.get('submitted'));
+  }),
+
+  /**
+   * @returns {boolean} is this a draft submission?
+   */
+  isDraft: Ember.computed('submitted', 'submissionStatus', function () {
+    // TODO: after model update, we can just check if submission status === 'draft'
+    // return this.get('record.submissinoStatus') === 'draft';
+    return !this.get('submitted') && !this.get('submissionStatus');
   })
 });

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -278,6 +278,16 @@ export default Service.extend({
   },
 
   /**
+   * @param {string} submissionId
+   * @returns {array} query result set of all files linked to the given submission ID
+   */
+  _getFiles(submissionId) {
+    return this.get('store').query('file', {
+      term: { submission: submissionId }
+    });
+  },
+
+  /**
    * Delete a draft submission object and it's associated Publication object,
    * if applicable. Persist all changes.
    *
@@ -285,10 +295,19 @@ export default Service.extend({
    * @returns {Promise} that returns once the submission deletion is persisted
    */
   async deleteSubmission(submission) {
+    const result = [];
+
     const pub = submission.get('publication');
     if (pub && pub.hasOwnProperty('destroyRecord')) {
-      await pub.destroyRecord();
+      result.push(pub.destroyRecord());
     }
-    return submission.destroyRecord();
+
+    // eslint-disable-next-line function-paren-newline
+    result.push(
+      this._getFiles(submission.get('id')).then(files => files.map(file => file.destroyRecord()))
+    ); // eslint-disable-line function-paren-newline
+
+    result.push(submission.destroyRecord());
+    return Promise.all(result);
   }
 });

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -275,5 +275,22 @@ export default Service.extend({
       submission.set('submissionStatus', 'cancelled');
       return submission.save();
     });
+  },
+
+  /**
+   * Delete a draft submission object and it's associated Publication object,
+   * if applicable.
+   *
+   * @param {Submission} submission submission to delete
+   */
+  deleteSubmission(submission) {
+    const pub = submission.get('publication');
+    if (pub) {
+      pub.deleteRecord();
+      pub.save();
+    }
+
+    submission.deleteRecord();
+    submission.save();
   }
 });

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -284,14 +284,11 @@ export default Service.extend({
    * @param {Submission} submission submission to delete
    * @returns {Promise} that returns once the submission deletion is persisted
    */
-  deleteSubmission(submission) {
+  async deleteSubmission(submission) {
     const pub = submission.get('publication');
-    if (pub && pub.hasOwnProperty('deleteRecord')) {
-      pub.deleteRecord();
-      pub.save();
+    if (pub && pub.hasOwnProperty('destroyRecord')) {
+      await pub.destroyRecord();
     }
-
-    submission.deleteRecord();
-    return submission.save();
+    return submission.destroyRecord();
   }
 });

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -292,6 +292,6 @@ export default Service.extend({
     }
 
     submission.deleteRecord();
-    submission.save();
+    return submission.save();
   }
 });

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -279,13 +279,14 @@ export default Service.extend({
 
   /**
    * Delete a draft submission object and it's associated Publication object,
-   * if applicable.
+   * if applicable. Persist all changes.
    *
    * @param {Submission} submission submission to delete
+   * @returns {Promise} that returns once the submission deletion is persisted
    */
   deleteSubmission(submission) {
     const pub = submission.get('publication');
-    if (pub) {
+    if (pub && pub.hasOwnProperty('deleteRecord')) {
       pub.deleteRecord();
       pub.save();
     }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -798,11 +798,14 @@ footer {
 .complete>.fa-circle, .complete .fa-info-circle {
   color: #00AB8E;
 }
+.draft>.fa-circle, .draft .fa-info-circle {
+  color: $jhu-grey3;
+}
 .ember-modal-dialog.user-search-modal {
   width: 90%;
   min-width: 20rem;
   max-width: 60rem;
-  min-height: 25rem; 
+  min-height: 25rem;
 }
 .user-search-results .col-6 {
   max-width:100%;

--- a/app/templates/components/submission-action-cell.hbs
+++ b/app/templates/components/submission-action-cell.hbs
@@ -18,11 +18,11 @@
   {{#link-to "submissions.detail" record.id class="btn btn-outline-primary"}}
     Review submission
   {{/link-to}}
-{{else if submissionIsDraft}}
+{{else if record.isDraft}}
   {{#link-to "submissions.new" (query-params submission=record.id) class="btn btn-outline-primary w-100 mb-2"}}
     Edit
   {{/link-to}}
-  <a class="btn btn-outline-danger text-danger w-100" {{action "deleteSubmission" record}}>
+  <a class="btn btn-outline-danger text-danger w-100 delete-button" {{action "deleteSubmission" record}}>
     Delete
   </a>
 {{else}}

--- a/app/templates/components/submission-action-cell.hbs
+++ b/app/templates/components/submission-action-cell.hbs
@@ -18,6 +18,13 @@
   {{#link-to "submissions.detail" record.id class="btn btn-outline-primary"}}
     Review submission
   {{/link-to}}
+{{else if submissionIsDraft}}
+  {{#link-to "submissions.new" (query-params submission=record.id) class="btn btn-outline-primary w-100 mb-2"}}
+    Edit
+  {{/link-to}}
+  <a class="btn btn-outline-danger text-danger w-100" {{action "deleteSubmission" record}}>
+    Delete
+  </a>
 {{else}}
   <span style="min-width: 130px;display: block;"><i>No actions available.</i></span>
 {{/if}}

--- a/app/templates/components/submission-action-cell.hbs
+++ b/app/templates/components/submission-action-cell.hbs
@@ -19,7 +19,7 @@
     Review submission
   {{/link-to}}
 {{else if record.isDraft}}
-  {{#link-to "submissions.new" (query-params submission=record.id) class="btn btn-outline-primary w-100 mb-2"}}
+  {{#link-to "submissions.new" (query-params submission=record.id) disabled=true class="btn btn-outline-primary w-100 mb-2"}}
     Edit
   {{/link-to}}
   <a class="btn btn-outline-danger text-danger w-100 delete-button" {{action "deleteSubmission" record}}>

--- a/app/templates/components/submission-status.hbs
+++ b/app/templates/components/submission-status.hbs
@@ -34,4 +34,9 @@
         <i class="fas fa-info-circle"></i> complete
       </span>
     {{/if}}
+    {{#if (eq submissionStatus "draft")}}
+      <span tooltip-position="left" tooltip="This submission is a draft. No action will be taken on this submission until it is completed.">
+        <i class="fas fa-info-circle"></i> draft
+      </span>
+    {{/if}}
   </span>

--- a/app/templates/components/submissions-article-cell.hbs
+++ b/app/templates/components/submissions-article-cell.hbs
@@ -1,3 +1,5 @@
-{{#link-to "submissions.detail" record.id class="moo"}}
-  {{get record 'publication.title'}}
-{{/link-to}}
+{{#if (get record 'publication')}}
+  {{#link-to "submissions.detail" record.id class="moo"}}
+    {{get record 'publication.title'}}
+  {{/link-to}}
+{{/if}}

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -84,6 +84,7 @@
   </div>
 </div>
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
+<button class="btn btn-outline-danger ml-2" {{action 'cancel'}}>Cancel</button>
 <button class="btn btn-primary pull-right next" {{action next}}>Next</button>
 {{#if isShowingUserSearchModal}}
   {{#modal-dialog

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -84,7 +84,7 @@
   </div>
 </div>
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
-<button class="btn btn-outline-danger ml-2" {{action 'cancel'}}>Cancel</button>
+<button class="btn btn-outline-danger ml-2" {{action 'cancel'}}>Abort</button>
 <button class="btn btn-primary pull-right next" {{action next}}>Next</button>
 {{#if isShowingUserSearchModal}}
   {{#modal-dialog

--- a/app/templates/components/workflow-files.hbs
+++ b/app/templates/components/workflow-files.hbs
@@ -93,4 +93,5 @@
 </div>
 <p><strong>Tip:</strong> Use the Control or the Shift key to select multiple files.</p>
 <button class="btn btn-outline-primary" {{action back}}>Back</button>
+<button class="btn btn-outline-danger ml-2" {{action "cancel"}}>Abort</button>
 <button class="btn btn-primary pull-right next" {{action next}}>Next</button>

--- a/app/templates/components/workflow-grants.hbs
+++ b/app/templates/components/workflow-grants.hbs
@@ -58,5 +58,6 @@
 {{/if}}
 <br>
 <button class="btn btn-outline-primary" {{action back}}>Back</button>
+<button class="btn btn-outline-danger ml-2" {{action "abortSubmission"}}>Abort</button>
 <button class="btn btn-primary next pull-right" {{action next}}>Next</button>
 {{yield}}

--- a/app/templates/components/workflow-metadata.hbs
+++ b/app/templates/components/workflow-metadata.hbs
@@ -6,6 +6,7 @@
 {{metadata-form
   schema=currentSchema
   nextForm=(action "nextForm")
-  previousForm=(action "previousForm")}}
+  previousForm=(action "previousForm")
+  cancel=(action "cancel")}}
 {{/if}}
 {{yield}}

--- a/app/templates/components/workflow-policies.hbs
+++ b/app/templates/components/workflow-policies.hbs
@@ -9,4 +9,5 @@
 </div>
 
 <button class="btn btn-outline-primary" {{action back}}>Back</button>
+<button class="btn btn-outline-danger ml-2" {{action "cancel"}}>Abort</button>
 <button class="btn btn-primary next pull-right" {{action next}}>Next</button>

--- a/app/templates/components/workflow-repositories.hbs
+++ b/app/templates/components/workflow-repositories.hbs
@@ -30,4 +30,5 @@
 </div>
 {{/if}}
 <button class="btn btn-outline-primary mt-3" {{action back}}>Back</button>
+<button class="btn btn-outline-danger ml-2 mt-3" {{action "cancel"}}>Abort</button>
 <button class="btn btn-primary next pull-right mt-3" {{action next}}>Next</button> {{yield}}

--- a/app/templates/components/workflow-review.hbs
+++ b/app/templates/components/workflow-review.hbs
@@ -200,6 +200,7 @@
   </div>
 </div>
 <button class="btn btn-outline-primary" {{action "back"}}>Back</button>
+<button class="btn btn-outline-danger ml-2" {{action "cancel"}}>Abort</button>
 {{#if uploading}}
 <button class="btn btn-primary pull-right submit" disabled>{{waitingMessage}}</button>
 {{else}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -67,7 +67,7 @@
         Finish submission
       {{/link-to}}
     {{else if model.sub.isDraft}}
-      {{#link-to 'submissions.new' (query-params submission=model.sub.id) class="btn btn-outline-primary text-right"}}
+      {{#link-to 'submissions.new' (query-params submission=model.sub.id) disabled=true class="btn btn-outline-primary text-right"}}
         Edit submission
       {{/link-to}}
       {{#link-to (action 'deleteSubmission' model.sub) class="btn btn-outline-danger text-right"}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -63,9 +63,16 @@
   </div>
   <div class="col-6 text-right">
     {{#if model.sub.isStub}}
-    {{#link-to 'submissions.new' (query-params submission=record.id) class="btn btn-outline-primary text-right" }}
-    Finish submission
-    {{/link-to}}
+      {{#link-to 'submissions.new' (query-params submission=model.sub.id) class="btn btn-outline-primary text-right" }}
+        Finish submission
+      {{/link-to}}
+    {{else if model.sub.isDraft}}
+      {{#link-to 'submissions.new' (query-params submission=model.sub.id) class="btn btn-outline-primary text-right"}}
+        Edit submission
+      {{/link-to}}
+      {{#link-to (action 'deleteSubmission' model.sub) class="btn btn-outline-danger text-right"}}
+        Delete
+      {{/link-to}}
     {{/if}}
   </div>
 </div>

--- a/app/templates/submissions/new/basics.hbs
+++ b/app/templates/submissions/new/basics.hbs
@@ -14,5 +14,6 @@
   validateJournal=(action "validateJournal")
   validateSubmitterEmail=(action "validateSubmitterEmail")
   next=(action "loadNext")
+  abort=(action "abort")
 }}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/files.hbs
+++ b/app/templates/submissions/new/files.hbs
@@ -9,5 +9,6 @@
   previouslyUploadedFiles=files
   newFiles=newFiles
   next=(action "loadNext")
-  back=(action "loadPrevious")}}
+  back=(action "loadPrevious")
+  abort=(action "abort")}}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/grants.hbs
+++ b/app/templates/submissions/new/grants.hbs
@@ -8,5 +8,7 @@
   submission=submission
   preLoadedGrant=preLoadedGrant
   next=(action "loadNext")
-  back=(action "loadPrevious")}}
+  back=(action "loadPrevious")
+  abort=(action "abort")
+}}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/metadata.hbs
+++ b/app/templates/submissions/new/metadata.hbs
@@ -9,5 +9,6 @@
   repositories=repositories
   next=(action "loadNext")
   back=(action "loadPrevious")
+  abort=(action "abort")
 }}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/policies.hbs
+++ b/app/templates/submissions/new/policies.hbs
@@ -9,5 +9,6 @@
   policies=policies
   publication=publication
   next=(action "loadNext")
-  back=(action "loadPrevious")}}
+  back=(action "loadPrevious")
+  abort=(action "abort")}}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/repositories.hbs
+++ b/app/templates/submissions/new/repositories.hbs
@@ -8,5 +8,6 @@
   submission=submission
   repositories=repositories
   next=(action "loadNext")
-  back=(action "loadPrevious")}}
+  back=(action "loadPrevious")
+  abort=(action "abort")}}
 {{/workflow-wrapper}}

--- a/app/templates/submissions/new/review.hbs
+++ b/app/templates/submissions/new/review.hbs
@@ -13,5 +13,6 @@
   submit=(action "submit")
   uploading=uploading
   waitingMessage=waitingMessage
+  abort=(action "abort")
 }}
 {{/workflow-wrapper}}

--- a/tests/integration/components/metadata-form-test.js
+++ b/tests/integration/components/metadata-form-test.js
@@ -34,9 +34,9 @@ module('Integration | Component | metadata-form', (hooks) => {
     assert.ok(el);
 
     assert.equal(
-      2,
+      3,
       el.querySelectorAll('button').length,
-      'There should be two form control buttons (prev, next)'
+      'There should be three form control buttons (prev, abort, next)'
     );
   });
 });

--- a/tests/integration/components/submission-action-cell-test.js
+++ b/tests/integration/components/submission-action-cell-test.js
@@ -1,7 +1,7 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
-import { render, findAll } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 
 module('Integration | Component | submission action cell', (hooks) => {
   setupRenderingTest(hooks);
@@ -33,26 +33,34 @@ module('Integration | Component | submission action cell', (hooks) => {
 
   /**
    * Make sure that the 'deleteSubmission' action calls `submission#deleteRecord` on the
-   * supplied submission
+   * supplied submission, then `#save()` should be called
    */
-  test('should delete submission', async function (assert) {
-    assert.expect(1);
+  test('should delete and persist submission', async function (assert) {
+    assert.expect(2);
 
     const record = Ember.Object.create({
+      preparers: Ember.A(),
+      isDraft: true,
       deleteRecord() {
         assert.ok(true);
+      },
+      save() {
+        assert.ok(true);
+        return Promise.resolve();
       }
     });
 
-    const component = this.owner.lookup('component:submission-action-cell');
-    component.send('deleteSubmission', record);
+    this.set('record', record);
+
+    await render(hbs`{{#submission-action-cell record=record}}{{/submission-action-cell}}`);
+    await click('a.delete-button');
+    await click('.swal2-confirm');
   });
 
   test('Draft submissions should display Edit and Delete buttons', async function (assert) {
     const record = Ember.Object.create({
       preparers: Ember.A(),
-      submitted: false,
-      submissionStatus: undefined,
+      isDraft: true
       // submissionStatus: 'draft'
     });
     this.set('record', record);

--- a/tests/integration/components/submission-action-cell-test.js
+++ b/tests/integration/components/submission-action-cell-test.js
@@ -2,9 +2,23 @@ import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import { render, click } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
 
 module('Integration | Component | submission action cell', (hooks) => {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const mockStore = Ember.Service.extend({
+      query() {
+        return Promise.resolve(Ember.A());
+      }
+    });
+
+    run(() => {
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', mockStore);
+    });
+  });
 
   test('it renders', async function (assert) {
     let record = {};
@@ -36,18 +50,15 @@ module('Integration | Component | submission action cell', (hooks) => {
    * supplied submission, then `#save()` should be called
    */
   test('should delete and persist submission', async function (assert) {
-    assert.expect(2);
+    assert.expect(1);
 
     const record = Ember.Object.create({
       preparers: Ember.A(),
       isDraft: true,
-      deleteRecord() {
-        assert.ok(true);
-      },
-      save() {
+      destroyRecord() {
         assert.ok(true);
         return Promise.resolve();
-      }
+      },
     });
 
     this.set('record', record);

--- a/tests/integration/components/submission-action-cell-test.js
+++ b/tests/integration/components/submission-action-cell-test.js
@@ -1,6 +1,7 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import { render, findAll } from '@ember/test-helpers';
 
 module('Integration | Component | submission action cell', (hooks) => {
   setupRenderingTest(hooks);
@@ -28,5 +29,41 @@ module('Integration | Component | submission action cell', (hooks) => {
     `);
 
     assert.equal(this.$().text().trim(), 'No actions available.');
+  });
+
+  /**
+   * Make sure that the 'deleteSubmission' action calls `submission#deleteRecord` on the
+   * supplied submission
+   */
+  test('should delete submission', async function (assert) {
+    assert.expect(1);
+
+    const record = Ember.Object.create({
+      deleteRecord() {
+        assert.ok(true);
+      }
+    });
+
+    const component = this.owner.lookup('component:submission-action-cell');
+    component.send('deleteSubmission', record);
+  });
+
+  test('Draft submissions should display Edit and Delete buttons', async function (assert) {
+    const record = Ember.Object.create({
+      preparers: Ember.A(),
+      submitted: false,
+      submissionStatus: undefined,
+      // submissionStatus: 'draft'
+    });
+    this.set('record', record);
+
+    await render(hbs`{{#submission-action-cell record=record}}{{/submission-action-cell}}`);
+
+    const buttons = this.element.querySelectorAll('a');
+
+    assert.ok(buttons, 'No buttons were found');
+    assert.equal(buttons.length, 2, `There should be two buttons, instead, ${buttons.length} were found`);
+    assert.equal(buttons[0].textContent.trim(), 'Edit');
+    assert.equal(buttons[1].textContent.trim(), 'Delete');
   });
 });

--- a/tests/integration/components/submission-action-cell-test.js
+++ b/tests/integration/components/submission-action-cell-test.js
@@ -10,7 +10,8 @@ module('Integration | Component | submission action cell', (hooks) => {
 
     // TODO: add actual tests here
     record = Ember.Object.create({
-      preparers: []
+      preparers: [],
+      submitted: true
     });
 
     this.set('record', record);

--- a/tests/integration/components/submissions-repoid-cell-test.js
+++ b/tests/integration/components/submissions-repoid-cell-test.js
@@ -27,4 +27,24 @@ module('Integration | Component | submissions repoid cell', (hooks) => {
     await this.render(hbs`{{submissions-repoid-cell}}`);
     assert.ok(true);
   });
+
+  /**
+   * Make sure the component renders when `record.publication.id` returns no value
+   */
+  test('it renders with when data is missing', async function (assert) {
+    assert.expect(1);
+
+    this.set('store', Ember.Service.extend({
+      query(type, q) {
+        assert.ok(true);
+      }
+    }));
+    const record = Ember.Object.create({
+      publication: Ember.Object.create({})
+    });
+    this.set('record', record);
+
+    await this.render(hbs`{{submission-repoid-cell}}`);
+    assert.ok(true);
+  });
 });

--- a/tests/integration/components/submissions-status-cell-test.js
+++ b/tests/integration/components/submissions-status-cell-test.js
@@ -1,6 +1,7 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
 
 module('Integration | Component | submissions status cell', (hooks) => {
   setupRenderingTest(hooks);
@@ -14,5 +15,17 @@ module('Integration | Component | submissions status cell', (hooks) => {
 
     // Template block usage:
     // this.render(hbs`{{submissions-status-cell status=""}}`);
+  });
+
+  test('draft submission renders', async function (assert) {
+    const record = Ember.Object.create({
+      submissionStatus: 'draft'
+    });
+    this.set('record', record);
+
+    await render(hbs`{{submissions-status-cell record=record}}`);
+
+    assert.ok(this.element, 'Failed to render');
+    assert.ok(this.element.textContent.includes('draft'), 'unexpected text found');
   });
 });

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -125,10 +125,10 @@ module('Integration | Component | workflow-metadata', (hooks) => {
     await render(hbs`{{workflow-metadata submission=submission}}`);
 
     const buttons = this.element.querySelectorAll('button');
-    assert.equal(2, buttons.length, 'should be two buttons');
+    assert.equal(3, buttons.length, 'should be two buttons');
 
     Object.keys(buttons).map(key => buttons[key].textContent).forEach((btn) => {
-      assert.ok(btn === 'Back' || btn === 'Next');
+      assert.ok(btn === 'Back' || btn === 'Next' || btn === 'Abort');
     });
   });
 

--- a/tests/unit/controllers/submissions/detail-test.js
+++ b/tests/unit/controllers/submissions/detail-test.js
@@ -10,8 +10,8 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     assert.ok(controller);
   });
 
-  test('delete action should trigger delete and save on model object', function (assert) {
-    assert.expect(3);
+  test('delete action should trigger destroy on model object', function (assert) {
+    assert.expect(2);
 
     // Mock the global SweetAlert object to always return immediately
     swal = () => Promise.resolve({
@@ -19,11 +19,12 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     });
 
     const submission = {
-      deleteRecord() {
-        assert.ok(true);
+      get() {
+        return undefined;
       },
-      save() {
+      destroyRecord() {
         assert.ok(true);
+        return Promise.resolve();
       }
     };
 

--- a/tests/unit/controllers/submissions/detail-test.js
+++ b/tests/unit/controllers/submissions/detail-test.js
@@ -9,4 +9,27 @@ module('Unit | Controller | submissions/detail', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/detail');
     assert.ok(controller);
   });
+
+  test('delete action should trigger delete and save on model object', function (assert) {
+    assert.expect(3);
+
+    // Mock the global SweetAlert object to always return immediately
+    swal = () => Promise.resolve({
+      value: 'moo'
+    });
+
+    const submission = {
+      deleteRecord() {
+        assert.ok(true);
+      },
+      save() {
+        assert.ok(true);
+      }
+    };
+
+    const controller = this.owner.lookup('controller:submissions/detail');
+    assert.ok(controller, 'controller not found');
+
+    controller.send('deleteSubmission', submission);
+  });
 });

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -259,4 +259,45 @@ module('Unit | Controller | submissions/new', (hooks) => {
 
     controller.send('submit');
   });
+
+  /**
+   * Three things are mocked, each of which run an assertion (that always passes). This
+   * test passes when exactly 3 assertions are run, and the controller tries to transition
+   * to the expected route.
+   *
+   * This action should first create a SweetAlert (swal), then call 'deleteSubmission' in the
+   * submission handler, finally call 'transitionToRoute' to transition to the 'submissions'
+   * route.
+   */
+  test('abort should delete submission and transition', async function (assert) {
+    assert.expect(3);
+
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create()
+    });
+    const controller = this.owner.lookup('controller:submissions/new');
+
+    controller.set('model', model);
+
+    // Mock global 'swal' for this test
+    swal = () => {
+      assert.ok(true);
+      return Promise.resolve({
+        value: 'moo'
+      });
+    };
+
+    // Having this mocked function run shows that the service will delete the submission
+    controller.set('submissionHandler', Ember.Object.create({
+      deleteSubmission(sub) {
+        assert.ok(sub);
+        return Promise.resolve();
+      }
+    }));
+    controller.set('transitionToRoute', (name) => {
+      assert.equal(name, 'submissions', 'unexpected transition was named');
+    });
+
+    controller.send('abort');
+  });
 });

--- a/tests/unit/controllers/submissions/new/files-test.js
+++ b/tests/unit/controllers/submissions/new/files-test.js
@@ -82,10 +82,7 @@ module('Unit | Controller | submissions/new/files', (hooks) => {
 
   test('Valid files page does transition', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new/files');
-    let loadTabAccessed = false;
-    let file = Ember.Object.create({
-      fileRole: 'manuscript'
-    });
+
     this.owner.register('controller:submissions.new', Ember.Object.extend({
       userIsSubmitter: false
     }));
@@ -95,15 +92,29 @@ module('Unit | Controller | submissions/new/files', (hooks) => {
       },
       getMaxStep() { return 7; }
     }));
-    let files = [file];
-    let model = { files };
+
+    let subSaved = false;
+
+    let file = Ember.Object.create({
+      fileRole: 'manuscript'
+    });
+
+    let model = {
+      files: [file],
+      newSubmission: Ember.Object.create({
+        save: () => {
+          subSaved = true;
+          return Promise.resolve();
+        }
+      })
+    };
     controller.set('model', model);
     controller.transitionToRoute = function () {
-      loadTabAccessed = true;
+      assert.ok(subSaved, 'Submission was not saved');
+      assert.equal(controller.get('workflow').getFilesTemp().length, 0);
+      assert.equal(controller.get('model.files').length, 1);
     };
-    assert.equal(controller.get('workflow').getFilesTemp().length, 0);
-    assert.equal(controller.get('model.files').length, 1);
+
     controller.send('validateAndLoadTab', 'submissions.new.basics');
-    assert.equal(loadTabAccessed, true);
   });
 });

--- a/tests/unit/controllers/submissions/new/grants-test.js
+++ b/tests/unit/controllers/submissions/new/grants-test.js
@@ -11,24 +11,59 @@ module('Unit | Controller | submissions/new/grants', (hooks) => {
   });
 
   test('loadPrevious triggers transition', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/new/grants');
-    let loadTabAccessed = false;
+    assert.expect(2);
+
+    const controller = this.owner.lookup('controller:submissions/new/grants');
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
+
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
       assert.equal('submissions.new.basics', route);
     };
     controller.send('loadPrevious');
-    assert.equal(loadTabAccessed, true);
   });
 
   test('loadNext triggers transition', function (assert) {
+    assert.expect(2);
+
     let controller = this.owner.lookup('controller:submissions/new/grants');
-    let loadTabAccessed = false;
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
+
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
       assert.equal('submissions.new.policies', route);
     };
     controller.send('loadNext');
-    assert.equal(loadTabAccessed, true);
+  });
+
+  /**
+   * Assertions are called only when the mock submission object is saved. This should happen
+   * once for each action sent to the controller.
+   */
+  test('transitions to other workflow steps saves the in progress submission', function (assert) {
+    assert.expect(2);
+
+    const controller = this.owner.lookup('controller:submissions/new/grants');
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
+    controller.set('transitionToRoute', () => {});
+
+    controller.send('loadNext');
+    controller.send('loadPrevious');
   });
 });

--- a/tests/unit/controllers/submissions/new/metadata-test.js
+++ b/tests/unit/controllers/submissions/new/metadata-test.js
@@ -12,23 +12,44 @@ module('Unit | Controller | submissions/new/metadata', (hooks) => {
 
   test('loadPrevious triggers transition', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new/metadata');
-    let loadTabAccessed = false;
+
+    let subSaved = false;
+
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => {
+          subSaved = true;
+          return Promise.resolve();
+        }
+      })
+    });
+
+    controller.set('model', model);
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
+      assert.ok(subSaved, 'submission was not saved');
       assert.equal('submissions.new.repositories', route);
     };
     controller.send('loadPrevious');
-    assert.equal(loadTabAccessed, true);
   });
 
   test('loadNext triggers transition', function (assert) {
     let controller = this.owner.lookup('controller:submissions/new/metadata');
-    let loadTabAccessed = false;
+
+    let subSaved = false;
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => {
+          subSaved = true;
+          return Promise.resolve();
+        }
+      })
+    });
+
+    controller.set('model', model);
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
+      assert.ok(subSaved, 'submission was not saved');
       assert.equal('submissions.new.files', route);
     };
     controller.send('loadNext');
-    assert.equal(loadTabAccessed, true);
   });
 });

--- a/tests/unit/controllers/submissions/new/policies-test.js
+++ b/tests/unit/controllers/submissions/new/policies-test.js
@@ -11,24 +11,56 @@ module('Unit | Controller | submissions/new/policies', (hooks) => {
   });
 
   test('loadPrevious triggers transition', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/new/policies');
-    let loadTabAccessed = false;
+    assert.expect(2);
+
+    const controller = this.owner.lookup('controller:submissions/new/policies');
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
       assert.equal('submissions.new.grants', route);
     };
     controller.send('loadPrevious');
-    assert.equal(loadTabAccessed, true);
   });
 
   test('loadNext triggers transition', function (assert) {
-    let controller = this.owner.lookup('controller:submissions/new/policies');
-    let loadTabAccessed = false;
+    assert.expect(2);
+
+    const controller = this.owner.lookup('controller:submissions/new/policies');
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
     controller.transitionToRoute = function (route) {
-      loadTabAccessed = true;
       assert.equal('submissions.new.repositories', route);
     };
     controller.send('loadNext');
-    assert.equal(loadTabAccessed, true);
+  });
+
+  test('navigating to other workflow steps should save the submission', function (assert) {
+    assert.expect(4);
+
+    const controller = this.owner.lookup('controller:submissions/new/policies');
+    const model = Ember.Object.create({
+      newSubmission: Ember.Object.create({
+        save: () => Promise.resolve(assert.ok(true))
+      })
+    });
+
+    controller.set('model', model);
+    controller.set(
+      'transitionToRoute',
+      route => assert.ok(route === 'submissions.new.repositories' || route === 'submissions.new.grants')
+    );
+
+    controller.send('loadNext');
+    controller.send('loadPrevious');
   });
 });

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
 module('Unit | Service | doi', (hooks) => {
   setupTest(hooks);
@@ -111,4 +112,69 @@ module('Unit | Service | doi', (hooks) => {
     assert.equal(typeof result['short-container-title'], 'string', '"short-container-title" should be a string');
     assert.notEqual(typeof result.ISSN, 'string', 'Should not stringify this array value');
   });
+
+//   test('should create a valid publication', function (assert) {
+//     const mockDoi = {
+//       publisher: 'Royal Society of Chemistry (RSC)',
+//       issue: '1',
+//       'short-container-title': 'Analyst',
+//       abstract: '<p>The investigators report a dramatically improved chemoselective analysis for carbonyls in crude biological extracts by turning to a catalyst and freezing conditions for derivatization.</p>',
+//       DOI: '10.1039/c7an01256j',
+//       type: 'journal-article',
+//       page: '311-322',
+//       'update-policy': 'http://dx.doi.org/10.1039/rsc_crossmark_policy',
+//       source: 'Crossref',
+//       'is-referenced-by-count': 5,
+//       title: [
+//         'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS'
+//       ],
+//       prefix: '10.1039',
+//       volume: '143',
+//       'container-title': ['The Analyst'],
+//       'original-title': [],
+//       language: 'en',
+//       ISSN: ['0003-2654', '1364-5528'],
+//       'issn-type': [
+//         { value: '0003-2654', type: 'print' },
+//         { value: '1364-5528', type: 'electronic' }
+//       ]
+//     };
+
+//     const mockStore = ({
+//       createRecord(type) {
+//         return Ember.Object.create({
+//           save() {
+//             return Promise.resolve();
+//           }
+//         });
+//       }
+//     });
+
+//     const expected = {
+//       doi: '10.1039/c7an01256j',
+//       title: 'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS',
+//       issue: '1',
+//       volume: '143',
+//       abstract: '<p>The investigators report a dramatically improved chemoselective analysis for carbonyls in crude biological extracts by turning to a catalyst and freezing conditions for derivatization.</p>'
+//     };
+
+//     run(async () => {
+//       // this.owner.unregister('store');
+//       // this.owner.register('store', mockStore);
+
+//       const service = this.owner.lookup('service:doi');
+//       assert.ok(service, 'service not found');
+
+//       service.set('store', mockStore);
+
+//       const result = await service.createPublication(mockDoi);
+// debugger
+//       assert.ok(result, 'no publication object was created');
+//       assert.equal(result.get('title'), expected.title, 'unexpected title found');
+//       assert.equal(result.get('doi'), expected.doi, 'unexpected doi value found');
+//       assert.equal(result.get('issue'), expected.issue, 'unexpected issue found');
+//       assert.equal(result.get('volume'), expected.volume, 'unexpected volume found');
+//       assert.equal(result.get('abstract'), expected.abstract, 'unexpected abstract found');
+//     });
+//   });
 });

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -280,4 +280,35 @@ module('Unit | Service | submission-handler', (hooks) => {
       assert.ok(submissionEvent.get('link').includes(submission.get('id')));
     });
   });
+
+  /**
+   * `#destroyRecord` should be called on the given Submission object
+   * Associated files should be queried from the Store
+   */
+  test('delete submission', function (assert) {
+    assert.expect(4);
+
+    const service = this.owner.lookup('service:submission-handler');
+
+    service.set('store', Ember.Object.create({
+      query(type, query) {
+        assert.equal(type, 'file', 'Unexpected store query found');
+        assert.ok(query);
+        return Promise.resolve(Ember.A());
+      }
+    }));
+
+    const sub = Ember.Object.create({
+      // publication: Ember.Object.create()
+      destroyRecord() {
+        assert.ok(true);
+        return Promise.resolve();
+      }
+    });
+
+    const result = service.deleteSubmission(sub);
+    result.then(() => {
+      assert.ok(true);
+    });
+  });
 });


### PR DESCRIPTION
Closes #887 

Work In Progress PR that adds lots of things that support saving draft submissions. This is incomplete for several reasons:

* Data model needs to be updated to add the `submissionStatus=draft`
* No real tests :(
* Can't edit draft submissions yet because Publication objects are not actually persisted
* Can't navigate to submission details page because there is no Publication object

## Changes

* Submissions save as "drafts" as a user navigates between each step in the submission workflow
* User can "abort" the submission workflow to delete the active draft
  * Once deleted, the app will load the Submissions table
* Draft submissions are displayed in Submissions table
* Draft submissions can be deleted

A few other supporting changes were made

* `submission-handler` has a new `deleteSubmission` function that looks for and deletes the submission and related objects
* `doi` service has a function to create a new publication object from a Crossref blob
