### PR TITLE
Policy service now returns fully resolved objects instead of Promises

### DIFF
--- a/app/routes/submissions/new/repositories.js
+++ b/app/routes/submissions/new/repositories.js
@@ -11,23 +11,12 @@ export default CheckSessionRoute.extend({
 
     const repoPromise = await this.get('policyService').getRepositories(submission);
 
-    /**
-     * Can't directly use 'one-of' directly in the RSVP hash, because it is an array of arrays of Promises,
-     * so to force the RSVP hash to wait for them all, we need to flatten the weird structure.
-     */
-    const choices = [];
-    if (repoPromise['one-of']) {
-      repoPromise['one-of'].forEach((choiceGroup) => { choices.push(...choiceGroup); });
-    }
-
     return Ember.RSVP.hash({
       newSubmission: submission,
       preLoadedGrant: parentModel.preLoadedGrant,
-      requiredRepositories: Promise.all(repoPromise.required),
-      optionalRepositories: Promise.all(repoPromise.optional),
-      choiceRepositories: Promise.all(repoPromise['one-of']),
-      promise: Promise.all(choices)
-      // promise: Promise.all(promise)
+      requiredRepositories: repoPromise.required,
+      optionalRepositories: repoPromise.optional,
+      choiceRepositories: repoPromise['one-of']
     });
   },
 

--- a/tests/unit/services/policies-test.js
+++ b/tests/unit/services/policies-test.js
@@ -32,14 +32,13 @@ module('Unit | Service | policies', (hooks) => {
     const policies = await service.getPolicies(sub);
 
     assert.ok(Array.isArray(policies), 'Should be an array');
-    assert.equal(policies.length, 2, 'Should be two promises here');
-    Promise.all(policies).then((pols) => {
-      pols.forEach(policy => assert.equal(policy.get('text'), 'Moo', 'Expecting text:\'Moo\''));
-    });
+    assert.equal(policies.length, 2, 'Should be two policies here');
+
+    policies.forEach(policy => assert.equal(policy.get('text'), 'Moo', 'Expecting text:\'Moo\''));
   });
 
   test('good response to getRepositories returns object with Repository promises by DSL rules', function (assert) {
-    assert.expect(13);
+    assert.expect(17);
 
     const service = this.owner.lookup('service:policies');
     assert.ok(service, 'service not found');
@@ -74,14 +73,14 @@ module('Unit | Service | policies', (hooks) => {
       assert.ok(Array.isArray(rules.optional), 'rules.optional should be an array');
       assert.ok(Array.isArray(rules['one-of']), 'rules[\'one-of\'] should be an array');
 
-      const collection = [];
-      collection.push(...rules.required);
-      collection.push(...rules.optional);
-      rules['one-of'].forEach(arr => collection.push(...arr));
+      assert.equal(rules.required.length, 1, 'Unexpected number of required repos');
+      assert.equal(rules.optional.length, 1, 'Unexpected number of optional repos');
+      assert.equal(rules['one-of'].length, 1, 'Unexpected number of choice groups');
+      assert.equal(rules['one-of'][0].length, 2, 'Unexpected number of repos in choice group 1');
 
-      Promise.all(collection).then((repos) => {
-        repos.forEach(repo => assert.equal(repo.get('text'), 'Moo'));
-      });
+      rules.required.forEach(repo => assert.equal(repo.get('text'), 'Moo'));
+      rules.optional.forEach(repo => assert.equal(repo.get('text'), 'Moo'));
+      rules['one-of'].forEach(group => group.forEach(repo => assert.equal(repo.get('text'), 'Moo')));
     });
   });
 


### PR DESCRIPTION
Closes #915 

Refactor of policy service implementation in Ember to actually return Policy and Repository objects, instead of Promises to those objects. This simplifies the routes greatly, since they no longer need to wait for the promise returned by the service, only to wait for each object's promise.