### PR TITLE
Fix Schema validation

### DIFF
--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -53,6 +53,7 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+    this.set('metadata', {});
   },
 
   async willRender() {

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import _ from 'lodash';
 import { inject as service } from '@ember/service';
+import swal from 'sweetalert2';
 
 /**
  * The schema service is invoked to retrieve appropriate metadata forms.
@@ -100,6 +101,12 @@ export default Component.extend({
       if (!validation) {
         console.log('%cError(s) found while validating data', 'color:red;');
         console.log(schemaService.getErrors());
+
+        swal({
+          type: 'error',
+          title: 'Form Validation Error',
+          text: this.validationErrorMsg(schemaService.getErrors())
+        });
         return;
       }
 
@@ -213,5 +220,15 @@ export default Component.extend({
       name: M[0],
       version: M[1]
     };
+  },
+
+  validationErrorMsg(errors) {
+    let msg = '<ul>';
+    errors.forEach((error) => {
+      msg += `<li>${error.message}</li>`;
+    });
+    msg += '</ul>';
+
+    return msg;
   }
 });

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -15,7 +15,17 @@ export default Service.extend({
 
   init() {
     this._super(...arguments);
-    this.set('validator', new Ajv());
+    /**
+     * We can adjust logging for the JSON schema validator here.
+     *
+     * Currently, logging is simply disabled.
+     *
+     * We could set 'logger' to an object with `log`, `warn`, and `error` functions
+     * to handle these things, if there is a need.
+     */
+    this.set('validator', new Ajv({
+      logger: false
+    }));
   },
 
   /**

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -83,7 +83,7 @@ export default Service.extend({
   },
 
   validate(schema, data) {
-    return this.get('validator').validate(data, schema);
+    return this.get('validator').validate(schema, data);
   },
 
   getErrors() {

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -13,6 +13,11 @@ export default Service.extend({
   // JSON schema validator
   validator: undefined,
 
+  init() {
+    this._super(...arguments);
+    this.set('validator', new Ajv());
+  },
+
   /**
    *
    * @param {array} repositories list of repository URIs
@@ -25,8 +30,6 @@ export default Service.extend({
       repositories = repositories.map(repo => repo.get('id'));
     }
     const url = this.get('schemaService.url');
-
-    this.set('validator', new Ajv());
 
     return this.get('ajax').request(url, {
       method: 'POST',

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -121,7 +121,7 @@ module('Unit | Service | metadata-schema', (hooks) => {
   test('Validation should fail when "name" field is not present in data', function (assert) {
     const service = this.owner.lookup('service:metadata-schema');
 
-    assert.notOk(service.validate({}, this.get('mockSchema')), 'Should not validate');
+    assert.notOk(service.validate(this.get('mockSchema'), {}), 'Should not validate');
 
     const errors = service.getErrors();
     assert.equal(1, errors.length, 'Should be 1 error');
@@ -136,7 +136,7 @@ module('Unit | Service | metadata-schema', (hooks) => {
       ranking: 'invalid-moo'
     };
     // debugger
-    assert.notOk(service.validate(data, this.get('mockSchema')), 'Validation should fail');
+    assert.notOk(service.validate(this.get('mockSchema'), data), 'Validation should fail');
 
     const errors = service.getErrors();
     assert.equal(1, errors.length, 'Should have found 1 error');
@@ -156,7 +156,7 @@ module('Unit | Service | metadata-schema', (hooks) => {
       ]
     };
 
-    assert.notOk(service.validate(data, this.get('mockSchema')), 'Validation should fail');
+    assert.notOk(service.validate(this.get('mockSchema'), data), 'Validation should fail');
 
     const errors = service.getErrors();
     assert.equal(1, errors.length, 'Should have found 1 error');


### PR DESCRIPTION
Closes #918 

Note that merging this PR without the DOI service will break the submission workflow!

This PR fixes JSON schema validation during the metadata step of the submission workflow. Each metadata form should not be validated against it's JSON schema properly. Prior to adding the DOI service, ISSN data is received from Crossref, which has publication type information that is different from the values expected by our schemas. This means that any submission with a DOI (that has ISSN data) will be spiked at this point.

Also crucially, this **finally fixes the crazy inconsistent tests for `workflow-metadata`**!! 