### PR TITLE
Add agreements to metadata blob

### DIFF
--- a/app/services/metadata-blob.js
+++ b/app/services/metadata-blob.js
@@ -54,6 +54,31 @@ export default Service.extend({
   },
 
   /**
+   * Get a metadata blob containing information about repository agreements. The resulting
+   * object can be merged into the larger metadata blob with #mergeBlobs.
+   *
+   * @param {object} repositories list of Repository model objects
+   * @returns {
+   *    'agreements': [
+   *      {
+   *        Repository.name: Repository.agreementText
+   *      }
+   *    ]
+   * }
+   */
+  getAgreementsBlob(repositories) {
+    const result = [];
+
+    repositories.filter(repo => repo.get('agreementText')).forEach(repo => result.push({
+      [repo.get('name')]: repo.get('agreementText')
+    }));
+
+    return {
+      agreements: result
+    };
+  },
+
+  /**
    * Transform a given metadata object into another object with keys/values suitable for dislplay
    * to a user in the UI.
    *

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -46,6 +46,16 @@ export default Service.extend({
       submission.set('submitted', true);
       submission.set('submissionStatus', 'submitted');
       submission.set('submittedDate', new Date());
+
+      // Add agreements metadata
+      const agreemd = this.get('metadataService').getAgreementsBlob(submission.get('repositories'));
+
+      if (agreemd) {
+        let md = JSON.parse(submission.get('metadata'));
+        this.get('metadataService').mergeBlobs(md, agreemd);
+        submission.set('metadata', JSON.stringify(md));
+      }
+
       submission.set(
         'repositories',
         submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
@@ -131,8 +141,8 @@ export default Service.extend({
    * submit - Perform or prepares a submission. Persists the publication, associate
    *   the submission with the saved publication, modify the submission appropriately,
    *   uploads files, and finally persists the submission with an appropraite event
-   *   to hold the comment. The metadata is not modified. Repositories of type
-   *   web-link are removed if submission is actually submitted.
+   *   to hold the comment. Repositories of type web-link are removed if submission
+   *   is actually submitted.
    *
    * @param  {Submission} submission
    * @param  {Publication} publication Persisted and associated with Submission.
@@ -198,6 +208,15 @@ export default Service.extend({
     if (extmd) {
       let md = JSON.parse(submission.get('metadata'));
       this.get('metadataService').mergeBlobs(md, extmd);
+      submission.set('metadata', JSON.stringify(md));
+    }
+
+    // Add agreements metadata
+    const agreemd = this.get('metadataService').getAgreementsBlob(submission.get('repositories'));
+
+    if (agreemd) {
+      let md = JSON.parse(submission.get('metadata'));
+      this.get('metadataService').mergeBlobs(md, agreemd);
       submission.set('metadata', JSON.stringify(md));
     }
 

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -34,7 +34,9 @@ module('Unit | Controller | submissions/new', (hooks) => {
       createRecord() { return submissionEvent; }
     }));
 
-    let repository1 = Ember.Object.create({ id: 'test:repo1', integrationType: 'full' });
+    let repository1 = Ember.Object.create({
+      id: 'test:repo1', integrationType: 'full', name: 'moo', agreementText: 'Milk cows'
+    });
     let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
 
     let submission = Ember.Object.create({
@@ -42,6 +44,7 @@ module('Unit | Controller | submissions/new', (hooks) => {
       submitter: {
         id: 'submitter:test-id'
       },
+      metadata: '{}',
       repositories: Ember.A([repository1, repository2]),
       save() {
         submissionSaved = true;
@@ -69,7 +72,7 @@ module('Unit | Controller | submissions/new', (hooks) => {
       publication
     });
 
-    assert.expect(13);
+    assert.expect(16);
 
     // After the route transition to thanks, all promises should be resolved handler
     // and tests can be run.
@@ -92,6 +95,13 @@ module('Unit | Controller | submissions/new', (hooks) => {
       assert.equal(submissionEvent.performerRole, 'submitter');
       assert.equal(submissionEvent.comment, comment);
       assert.equal(submissionEvent.eventType, 'submitted');
+
+      let md = JSON.parse(submission.get('metadata'));
+      assert.ok(md.agreements);
+      assert.equal(md.agreements.length, 1);
+      assert.deepEqual(md.agreements[0], {
+        moo: 'Milk cows'
+      });
     });
 
     controller.set('model', model);


### PR DESCRIPTION
Agreements metadata is added to the blob when a user does their own submission or approves a submission.

In order to test, use the docker environment to perform a submission and approve a submission. Check the metadata blob in both cases for the 'agreements'.

Closes #908 