### PR TITLE
Remove 'external-submissions' from metadata blob

### DIFF
--- a/app/components/submission-repo-details.js
+++ b/app/components/submission-repo-details.js
@@ -62,7 +62,7 @@ export default Component.extend({
    * (e.g. US Dept of Education submission system ERIC)
    */
   isExternalRepo: Ember.computed('repo', function () {
-    return this.get('repo.integrationType') === 'web-link';
+    return this.get('repo._isWebLink');
   }),
 
   isSubmitted: Ember.computed('submission.submitted', function () {

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -180,20 +180,12 @@ export default Component.extend({
    *
    * IMPL NOTE:
    * The final metadata blob will include some extra data sourced from outside the metadata
-   * forms, include (browser) agent info and "external repository" info.
+   * forms, include (browser) agent info.
    */
   finalizeMetadata() {
     this.updateMetadata({
       agent_information: this.getBrowserInfo()
     });
-
-    // Add metadata for external submissions only if the user is the submitter
-    const externalRepos = this.get('metadataService').getExternalReposBlob(this.get('submission.repositories'));
-    const isSubmitter = this.get('submission.submitter.id') === this.get('currentUser.user.id');
-
-    if (isSubmitter && externalRepos['external-submissions'].length > 0) {
-      this.updateMetadata(externalRepos);
-    }
 
     const finalMetadata = this.get('metadata');
     this.set('submission.metadata', JSON.stringify(finalMetadata));

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -30,7 +30,6 @@ export default Component.extend({
   }),
   weblinkRepos: Ember.computed('submission.repositories', function () {
     const repos = this.get('submission.repositories').filter(repo => repo.get('_isWebLink'));
-    // debugger
     repos.forEach(repo => (this.get('externalRepoMap')[repo.get('id')] = false)); // eslint-disable-line
     return repos;
   }),
@@ -130,10 +129,14 @@ export default Component.extend({
               showCancelButton: true,
             }).then((result) => {
               if (result.value) {
-                // Update repos to reflect repos that user agreed to deposit
+                /*
+                 * Update repos to reflect repos that user agreed to deposit
+                 * It is assumed that the user has done the necessary steps for each web-link repository,
+                 * so those are also kept in the list
+                 */
                 this.set('submission.repositories', this.get('submission.repositories').filter((repo) => {
                   if (repo.get('_isWebLink')) {
-                    return false;
+                    return true;
                   }
                   let temp = reposWithAgreementText.map(x => x.id).includes(repo.get('name'));
                   if (!temp) {

--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -24,15 +24,7 @@ export default Component.extend({
     }
     return newArr;
   }),
-  // metadata: Ember.computed('submission.metadata', function () {
-  //   return JSON.parse(this.get('submission.metadata'));
-  // }),
-  // metadataBlobNoKeys: Ember.computed(
-  //   'submission.metadata',
-  //   function () {
-  //     return this.get('metadataService').getDisplayBlob(this.get('submission.metadata'));
-  //   }
-  // ),
+
   hasVisitedWeblink: Ember.computed('externalRepoMap', function () {
     return Object.values(this.get('externalRepoMap')).every(val => val === true);
   }),

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -19,8 +19,7 @@ export default Controller.extend({
     if (!this.get('model.sub.submitted')) {
       return [];
     }
-
-    return this.get('externalSubmissionMetadata') || [];
+    return this.get('externalSubmissionsMetadata') || [];
   }),
   /**
    * Ugly way to generate data for the template to use.
@@ -86,6 +85,12 @@ export default Controller.extend({
     }
   ),
 
+  /**
+   * Awkward object for use in the UI composing Repository objects with related
+   * Deposit and RepositoryCopy objects.
+   *
+   * Explicitly exclude 'web-link' repositories.
+   */
   repoMap: Ember.computed('model.deposits', 'model.repoCopies', function () {
     let hasStuff = false;
     const repos = this.get('model.repos');
@@ -95,7 +100,7 @@ export default Controller.extend({
       return null;
     }
     let map = {};
-    repos.forEach((r) => {
+    repos.filter(repo => !repo.get('_isWebLink')).forEach((r) => {
       (map[r.get('id')] = {
         repo: r
       });

--- a/app/models/repository.js
+++ b/app/models/repository.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 
 export default DS.Model.extend({
   name: DS.attr('string'),
@@ -6,15 +7,13 @@ export default DS.Model.extend({
   url: DS.attr('string'),
   formSchema: DS.attr('string'),
   integrationType: DS.attr('string'),
-  weblinkOnly: Ember.computed('name', function () {
-    return this.get('name');
-  }),
   agreementText: DS.attr('string', {
     defaultValue: false
   }),
   repositoryKey: DS.attr('string'),
 
-  _selected: DS.attr('boolean')
-  // policy: DS.belongsTo('policy'),
-  // submissions: DS.hasMany('submission', { async: true }),
+  _selected: DS.attr('boolean'),
+  _isWebLink: computed('integrationType', function () {
+    return this.get('integrationType') === 'web-link';
+  })
 });

--- a/app/services/metadata-blob.js
+++ b/app/services/metadata-blob.js
@@ -24,36 +24,6 @@ export default Service.extend({
   },
 
   /**
-   * Get a metadata blob containing information about external repositories. The resulting
-   * object can be merged into the larger metadata blob with #mergeBlobs.
-   *
-   * result['external-submissions'] array will always be defined.
-   *
-   * @param {object} repositories list of Repository model objects
-   * @returns {
-   *    'external-repositories': [
-   *      {
-   *        message: '',  // Message to show to the user about this repo
-   *        name: '', // Name of this external repository
-   *        url: '' // URL of this external repository
-   *      }
-   *    ]
-   * }
-   */
-  getExternalReposBlob(repositories) {
-    const result = [];
-    const externalRepos = repositories.filter(repo => repo.get('integrationType') === 'web-link');
-    externalRepos.forEach(repo => result.push({
-      message: `Deposit into ${repo.get('name')} was prompted`,
-      name: repo.get('name'),
-      url: repo.get('url')
-    }));
-    return {
-      'external-submissions': result
-    };
-  },
-
-  /**
    * Get a metadata blob containing information about repository agreements. The resulting
    * object can be merged into the larger metadata blob with #mergeBlobs.
    *

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -162,36 +162,6 @@ export default Service.extend({
   },
 
   /**
-   * _getExternalSubmissionsMetadata - If the submission is submitted, return
-   *  external-submissions object from metadata. Otherwise generate what it
-   *  should be from external repositories.
-   *
-   * @param  {Submission} submission
-   * @returns {Object}          Object with external-submissions key.
-   */
-  _getExternalSubmissionsMetadata(submission) {
-    if (submission.get('submitted')) {
-      const metadata = JSON.parse(submission.get('metadata'));
-      let values = Ember.A();
-
-      // TODO Hack for old style metadata blob. Should remove later.
-      if (Array.isArray(metadata)) {
-        values = metadata.filter(x => x.id === 'external-submissions');
-
-        if (values.length == 0) {
-          return null;
-        }
-
-        return values[0];
-      }
-
-      return metadata;
-    }
-
-    return this.get('metadataService').getExternalReposBlob(submission.get('repositories'));
-  },
-
-  /**
    * approveSubmission - Submitter approves submission. Metadata is added to
    *  external-submissions for all web-link repos and those repos are removed.
    *  Attaches a SubmissionEvent of type submitted with the given comment and
@@ -202,6 +172,7 @@ export default Service.extend({
    * @returns {Promise}        Promise which performs the operation.
    */
   approveSubmission(submission, comment) {
+<<<<<<< HEAD
     const extmd = this._getExternalSubmissionsMetadata(submission);
 
     // Add external submissions metadata
@@ -226,6 +197,8 @@ export default Service.extend({
       submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
     );
 
+=======
+>>>>>>> Remove 'external-submissions' from workflow
     let se = this.get('store').createRecord('submissionEvent', {
       submission,
       performedBy: this.get('currentUser.user'),

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -56,11 +56,6 @@ export default Service.extend({
         submission.set('metadata', JSON.stringify(md));
       }
 
-      submission.set(
-        'repositories',
-        submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
-      );
-
       subEvent.set('performerRole', 'submitter');
       subEvent.set('eventType', 'submitted');
     } else {
@@ -172,16 +167,6 @@ export default Service.extend({
    * @returns {Promise}        Promise which performs the operation.
    */
   approveSubmission(submission, comment) {
-<<<<<<< HEAD
-    const extmd = this._getExternalSubmissionsMetadata(submission);
-
-    // Add external submissions metadata
-    if (extmd) {
-      let md = JSON.parse(submission.get('metadata'));
-      this.get('metadataService').mergeBlobs(md, extmd);
-      submission.set('metadata', JSON.stringify(md));
-    }
-
     // Add agreements metadata
     const agreemd = this.get('metadataService').getAgreementsBlob(submission.get('repositories'));
 
@@ -191,14 +176,6 @@ export default Service.extend({
       submission.set('metadata', JSON.stringify(md));
     }
 
-    // Remove external repositories
-    submission.set(
-      'repositories',
-      submission.get('repositories').filter(repo => (repo.get('integrationType') !== 'web-link'))
-    );
-
-=======
->>>>>>> Remove 'external-submissions' from workflow
     let se = this.get('store').createRecord('submissionEvent', {
       submission,
       performedBy: this.get('currentUser.user'),

--- a/app/templates/components/nav-bar.hbs
+++ b/app/templates/components/nav-bar.hbs
@@ -40,7 +40,6 @@
                 size=30
                 retina=true}}
               </span>
-                {{log currentUser}}
               {{currentUser.user.displayName}}
             </a>
             <div class="dropdown-menu dropdown-menu-right">

--- a/app/templates/components/submission-repo-details.hbs
+++ b/app/templates/components/submission-repo-details.hbs
@@ -21,16 +21,16 @@
         <div class="row">
           <strong class="col-5 px-0">Deposit status: </strong>
           {{#if isExternalRepo}}
-            {{#if isSubmitted}}
+            {{!-- {{#if isSubmitted}}
               <span class="col">Deposit into {{repo.name}} was prompted.</span>
             {{else}}
               <span class="col">Deposit into {{repo.name}} will be prompted.</span>
-            {{/if}}
+            {{/if}} --}}
           {{else}}
             <div class="col">
               {{#if tooltip}}
                 <span class="{{status}}" tooltip-position="left" tooltip="{{tooltip}}">
-                  <i class="fas fa-info-circle"></i> 
+                  <i class="fas fa-info-circle"></i>
                   {{#if (eq status "not-submitted")}}
                     n&#47;a
                   {{else}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -122,7 +122,6 @@
               </td>
             </tr>
             {{/if}}
-            {{debugger}}
             {{#if externalSubmission}}
             <tr>
               <td><strong>External Submission Repositories</strong></td>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -122,6 +122,7 @@
               </td>
             </tr>
             {{/if}}
+            {{debugger}}
             {{#if externalSubmission}}
             <tr>
               <td><strong>External Submission Repositories</strong></td>

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -157,8 +157,8 @@ module('Integration | Component | workflow review', (hooks) => {
 
     assert.equal(submitted, true);
 
-    // Submission to full repo only
-    assert.equal(submission.get('repositories.length'), 1);
+    // Submission to full repo and web-link repo
+    assert.equal(submission.get('repositories.length'), 2);
     assert.equal(submission.get('repositories.firstObject.id'), repo1.id);
   });
 

--- a/tests/integration/components/workflow-review-test.js
+++ b/tests/integration/components/workflow-review-test.js
@@ -93,10 +93,18 @@ module('Integration | Component | workflow review', (hooks) => {
     assert.ok(controller);
 
     let repo1 = Ember.Object.create({
-      id: 'test:repo1', integrationType: 'full', agreementText: 'Cows are the best', name: 'repo1'
+      id: 'test:repo1',
+      integrationType: 'full',
+      agreementText: 'Cows are the best',
+      name: 'repo1',
+      _isWebLink: false
     });
     let repo2 = Ember.Object.create({
-      id: 'test:repo2', integrationType: 'web-link', url: '', name: 'repo2'
+      id: 'test:repo2',
+      integrationType: 'web-link',
+      url: '',
+      name: 'repo2',
+      _isWebLink: true
     });
     let submitted = false;
 
@@ -158,7 +166,12 @@ module('Integration | Component | workflow review', (hooks) => {
     let controller = this.owner.lookup('controller:submissions/new/review');
     assert.ok(controller);
 
-    let repo2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link', name: 'repo2' });
+    let repo2 = Ember.Object.create({
+      id: 'test:repo2',
+      integrationType: 'web-link',
+      name: 'repo2',
+      _isWebLink: true
+    });
     let submitted = false;
 
     this.owner.register('service:current-user', Ember.Object.extend({

--- a/tests/unit/controllers/submissions/new-test.js
+++ b/tests/unit/controllers/submissions/new-test.js
@@ -35,9 +35,17 @@ module('Unit | Controller | submissions/new', (hooks) => {
     }));
 
     let repository1 = Ember.Object.create({
-      id: 'test:repo1', integrationType: 'full', name: 'moo', agreementText: 'Milk cows'
+      id: 'test:repo1',
+      integrationType: 'full',
+      name: 'moo',
+      agreementText: 'Milk cows',
+      _isWebLink: false
     });
-    let repository2 = Ember.Object.create({ id: 'test:repo2', integrationType: 'web-link' });
+    let repository2 = Ember.Object.create({
+      id: 'test:repo2',
+      integrationType: 'web-link',
+      _isWebLink: true
+    });
 
     let submission = Ember.Object.create({
       id: 'sub:0',
@@ -86,8 +94,8 @@ module('Unit | Controller | submissions/new', (hooks) => {
       assert.equal(submission.submitted, true);
       assert.equal(submission.submissionStatus, 'submitted');
 
-      // check web-linked repo is removed
-      assert.equal(submission.repositories.length, 1);
+      // check web-linked repo is NOT removed
+      assert.equal(submission.repositories.length, 2);
       assert.equal(submission.repositories[0].id, 'test:repo1');
 
       assert.equal(submissionEvent.submission.submitter.id, 'submitter:test-id');

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -180,10 +180,10 @@ module('Unit | Service | submission-handler', (hooks) => {
       assert.equal(submission.get('submitted'), true);
       assert.equal(submission.get('submissionStatus'), 'submitted');
 
-      // web-link repo should be removed and external-submissions added
-      assert.equal(submission.get('repositories.length'), 1);
+      // web-link repo should NOT be removed and external-submissions added not on metadata
+      assert.equal(submission.get('repositories.length'), 2);
       assert.equal(submission.get('repositories.firstObject.id'), repo1.id);
-      assert.ok(submission.get('metadata').includes('external-submissions'));
+      assert.notOk(submission.get('metadata').includes('external-submissions'));
 
       assert.equal(submissionEvent.get('eventType'), 'submitted');
       assert.equal(submissionEvent.get('performerRole'), 'submitter');

--- a/tests/unit/services/submission-handler-test.js
+++ b/tests/unit/services/submission-handler-test.js
@@ -126,8 +126,8 @@ module('Unit | Service | submission-handler', (hooks) => {
       assert.equal(submission.get('submitted'), true);
       assert.equal(submission.get('submissionStatus'), 'submitted');
 
-      // web-link repo should be removed
-      assert.equal(submission.get('repositories.length'), 1);
+      // web-link repo should NOT be removed
+      assert.equal(submission.get('repositories.length'), 2);
       assert.equal(submission.get('repositories.firstObject.id'), repo1.id);
 
       assert.equal(submissionEvent.get('eventType'), 'submitted');


### PR DESCRIPTION
Closes #924 

Removes a legacy `external-submissions` property from the metadata blob that would not pass schema validation