### PR TITLE
Re-enable ability to edit draft submissions

### DIFF
--- a/app/components/display-metadata-keys.js
+++ b/app/components/display-metadata-keys.js
@@ -6,7 +6,14 @@ export default Component.extend({
   ignoreList: ['agent_information', 'external-submissions'],
 
   metadata: Ember.computed('submission', function () {
-    return JSON.parse(this.get('submission.metadata'));
+    try {
+      return JSON.parse(this.get('submission.metadata'));
+    } catch (e) {
+      /**
+       * We just need to handle the case where 'submission.metadata' does not exist.
+       */
+      return {};
+    }
   }),
 
   // TODO: could be changed to get the real label from relevant metadata schema!

--- a/app/components/submission-action-cell.js
+++ b/app/components/submission-action-cell.js
@@ -15,6 +15,10 @@ export default Component.extend({
     return this.get('currentUser.user.id') === this.get('record.submitter.id');
   }),
 
+  submissionIsDraft: Ember.computed('record', function () {
+    return this.get('record.isDraft');
+  }),
+
   actions: {
     /**
      * Delete the specified submission record from Fedora.

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -38,8 +38,10 @@ export default Component.extend({
      * If a Journal object exists in the model, then we have loaded an existing Submission
      * with a Publication and a Journal. We need to make sure that this journal makes it
      * into 'doiInfo' so it can be used in later steps.
+     *
+     * Only do this if there is no publication DOI, as the DOI lookup will cover this case.
      */
-    if (this.get('journal')) {
+    if (!this.get('publication.doi') && this.get('journal')) {
       this.send('selectJournal', this.get('journal'));
     }
   },

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -48,7 +48,12 @@ export default Component.extend({
      * See IMPL NOTE above regarding the existance of submission metadata
      */
     try {
-      JSON.parse(this.get('submission.metadata'));
+      /**
+       * Set workflow doiInfo because of some weird timing between `routes/submissions/new/index#beforeModel`
+       * and `routes/submissions/new#model()` causing the doiInfo in 'workflow' to reset after it is
+       * defined by the incoming submission
+       */
+      this.get('workflow').setDoiInfo(JSON.parse(this.get('submission.metadata')));
     } catch (e) {
       /**
        * Either 'metadata' is missing or malformed

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -422,7 +422,9 @@ export default Controller.extend({
         showCancelButton: true
       }).then((result) => {
         if (result.value) {
-          this.get('submissionHandler').deleteSubmission(submission);
+          this.get('submissionHandler').deleteSubmission(submission).then(() => {
+            this.transitionToRoute('submissions');
+          });
         }
       });
     }

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -96,6 +96,13 @@ export default Controller.extend({
           }
         }
       }
+
+      // After validation, we can save the publication to the Submission
+      const publication = this.get('publication');
+      publication.save().then(() => {
+        this.set('submission.publication', publication);
+      });
+
       this.send('loadTab', gotoRoute);
     },
     validateTitle() {

--- a/app/controllers/submissions/new/basics.js
+++ b/app/controllers/submissions/new/basics.js
@@ -8,6 +8,7 @@ export default Controller.extend({
   publication: alias('model.publication'),
   preLoadedGrant: alias('model.preLoadedGrant'),
   submissionEvents: alias('model.submissionEvents'),
+  journal: alias('model.journal'),
   parent: Ember.inject.controller('submissions.new'),
 
   // these errors start as false since you don't want to immediately have all fields turn red

--- a/app/models/journal.js
+++ b/app/models/journal.js
@@ -15,9 +15,5 @@ export default DS.Model.extend({
   }),
   isMethodB: Ember.computed('pmcParticipation', function () {
     return this.get('pmcParticipation') ? this.get('pmcParticipation').toLowerCase() === 'b' : false;
-  }),
-
-  // TODO MUST REMOVE
-  // Artifact of incomplete data - once Journal data is updated this must be removed
-  name: DS.attr('string')
+  })
 });

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -7,7 +7,7 @@ export default DS.Model.extend({
   }),
   submittedDate: DS.attr('date'),
   source: DS.attr('string', { defaultValue: 'pass' }),
-  metadata: DS.attr('string', { defaultValue: '[]' }), // Stringified JSON
+  metadata: DS.attr('string'), // Stringified JSON
   submitted: DS.attr('boolean', { defaultValue: false }),
   submissionStatus: DS.attr('string'),
   submitterName: DS.attr('string'),

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -82,8 +82,7 @@ export default DS.Model.extend({
    * @returns {boolean} is this a draft submission?
    */
   isDraft: Ember.computed('submitted', 'submissionStatus', function () {
-    // TODO: after model update, we can just check if submission status === 'draft'
-    // return this.get('record.submissinoStatus') === 'draft';
-    return !this.get('submitted') && !this.get('submissionStatus');
+    return this.get('submissionStatus') === 'draft';
+    // return !this.get('submitted') && !this.get('submissionStatus');
   })
 });

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -75,8 +75,7 @@ export default CheckSessionRoute.extend({
       });
     }
     newSubmission = this.get('store').createRecord('submission', {
-      submissionStatus: 'draft',
-      publication
+      submissionStatus: 'draft'
     });
     const h = Ember.RSVP.hash({
       repositories,

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -65,7 +65,9 @@ export default CheckSessionRoute.extend({
         });
       });
     }
-    newSubmission = this.get('store').createRecord('submission');
+    newSubmission = this.get('store').createRecord('submission', {
+      submissionStatus: 'draft'
+    });
     const h = Ember.RSVP.hash({
       repositories,
       newSubmission,

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -37,7 +37,7 @@ export default CheckSessionRoute.extend({
 
     if (params.submission) {
       return this.get('store').findRecord('submission', params.submission).then((sub) => {
-        newSubmission = this.get('store').findRecord('submission', params.submission);
+        newSubmission = sub;
         publication = sub.get('publication');
         const journal = publication.get('journal');
         submissionEvents = this.get('store').query('submissionEvent', {
@@ -75,7 +75,8 @@ export default CheckSessionRoute.extend({
       });
     }
     newSubmission = this.get('store').createRecord('submission', {
-      submissionStatus: 'draft'
+      submissionStatus: 'draft',
+      publication
     });
     const h = Ember.RSVP.hash({
       repositories,

--- a/app/routes/submissions/new.js
+++ b/app/routes/submissions/new.js
@@ -39,6 +39,7 @@ export default CheckSessionRoute.extend({
       return this.get('store').findRecord('submission', params.submission).then((sub) => {
         newSubmission = this.get('store').findRecord('submission', params.submission);
         publication = sub.get('publication');
+        const journal = publication.get('journal');
         submissionEvents = this.get('store').query('submissionEvent', {
           sort: [
             { performedDate: 'asc' }
@@ -54,6 +55,13 @@ export default CheckSessionRoute.extend({
             submission: sub.get('id')
           }
         });
+
+        // Also seed workflow.doiInfo with metadata from the Submission
+        const metadata = sub.get('metadata');
+        if (metadata) {
+          this.get('workflow').setDoiInfo(JSON.parse(metadata));
+        }
+
         return Ember.RSVP.hash({
           repositories,
           newSubmission,
@@ -61,7 +69,8 @@ export default CheckSessionRoute.extend({
           publication,
           policies,
           preLoadedGrant,
-          files
+          files,
+          journal
         });
       });
     }

--- a/app/services/workflow.js
+++ b/app/services/workflow.js
@@ -17,7 +17,7 @@ export default Service.extend({
     this.setMaxStep(1);
     this.setPmcPublisherDeposit(false);
     this.setFilesTemp([]);
-    this.setDoiInfo([]);
+    this.setDoiInfo({});
     this.setDefaultRepoLoaded(false);
   },
   getCurrentStep() {

--- a/app/templates/components/submission-action-cell.hbs
+++ b/app/templates/components/submission-action-cell.hbs
@@ -18,8 +18,8 @@
   {{#link-to "submissions.detail" record.id class="btn btn-outline-primary"}}
     Review submission
   {{/link-to}}
-{{else if record.isDraft}}
-  {{#link-to "submissions.new" (query-params submission=record.id) disabled=true class="btn btn-outline-primary w-100 mb-2"}}
+{{else if submissionIsDraft}}
+  {{#link-to "submissions.new" (query-params submission=record.id) class="btn btn-outline-primary w-100 mb-2"}}
     Edit
   {{/link-to}}
   <a class="btn btn-outline-danger text-danger w-100 delete-button" {{action "deleteSubmission" record}}>

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -51,13 +51,12 @@
   </p>
 
   {{input
-  class=doiClass
-  value=publication.doi
-  keyUp=(action "lookupDOI")
-  mouseUp=(action "lookupDOI")
-  id="doi"
-  placeholder="Leave blank if your manuscript or article has not yet been assigned a DOI"
-  readonly=submission.id
+    class=doiClass
+    value=publication.doi
+    keyUp=(action "lookupDOI")
+    mouseUp=(action "lookupDOI")
+    id="doi"
+    placeholder="Leave blank if your manuscript or article has not yet been assigned a DOI"
   }}
   <div class="text-danger">
     {{if (and publication.doi (not isValidDOI)) 'Please provide a valid DOI'}}

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -57,7 +57,6 @@
   <div class="lds-dual-ring mx-auto"></div>
 </div>
 <div class="row mb-2">
-  {{debugger}}
   <div class="col-6">
     {{#link-to 'submissions' class="btn btn-small back-arrow" }}<i class="fa fa-arrow-left fa-lg"></i>{{/link-to}}
     <h2 class="font-weight-light d-inline-block">Submission Detail</h2>
@@ -68,12 +67,12 @@
         Finish submission
       {{/link-to}}
     {{else if model.sub.isDraft}}
-      {{#link-to 'submissions.new' (query-params submission=model.sub.id) disabled=true class="btn btn-outline-primary text-right"}}
+      {{#link-to 'submissions.new' (query-params submission=model.sub.id) class="btn btn-outline-primary text-right"}}
         Edit submission
       {{/link-to}}
-      {{#link-to (action 'deleteSubmission' model.sub) class="btn btn-outline-danger text-right"}}
+      <button {{action "deleteSubmission" model.sub}} class="btn btn-outline-danger text-right">
         Delete
-      {{/link-to}}
+      </button>
     {{/if}}
   </div>
 </div>
@@ -237,8 +236,6 @@
                         {{file.description}}
                       </td>
                     </tr>
-                    {{else}}
-                    <div class="text-center">Loading files...</div>
                     {{/each}}
                   </tbody>
                 </table>

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -57,6 +57,7 @@
   <div class="lds-dual-ring mx-auto"></div>
 </div>
 <div class="row mb-2">
+  {{debugger}}
   <div class="col-6">
     {{#link-to 'submissions' class="btn btn-small back-arrow" }}<i class="fa fa-arrow-left fa-lg"></i>{{/link-to}}
     <h2 class="font-weight-light d-inline-block">Submission Detail</h2>

--- a/app/templates/submissions/new/basics.hbs
+++ b/app/templates/submissions/new/basics.hbs
@@ -9,6 +9,7 @@
   publication=publication
   preLoadedGrant=preLoadedGrant
   doiInfo=doiInfo
+  journal=journal
   flaggedFields=flaggedFields
   validateTitle=(action "validateTitle")
   validateJournal=(action "validateJournal")

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -1,7 +1,7 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
-import { click, fillIn, triggerKeyEvent, render } from '@ember/test-helpers';
+import { fillIn, render, waitUntil } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 
 module('Integration | Component | workflow basics', (hooks) => {
@@ -58,7 +58,8 @@ module('Integration | Component | workflow basics', (hooks) => {
             doi: '1234/4321',
             issue: 1,
             title: 'Quantitative profiling of carbonyl metabolites directly in crude biological extracts using chemoselective tagging and nanoESI-FTMS',
-            volume: '143'
+            volume: '143',
+            journal: Ember.Object.create({ journalName: 'moo-title' })
           })
         });
       },
@@ -70,18 +71,6 @@ module('Integration | Component | workflow basics', (hooks) => {
       },
       getJournalTitle() {
         return 'moo-title';
-      }
-    });
-
-    const mockNlmta = Ember.Service.extend({
-      getNlmtaFromIssn() {
-        return {
-          nlmta: 'nl-moo-ta',
-          'issn-map': {
-            '0003-2654': { 'pub-type': 'print' },
-            '1364-5528': { 'pub-type': 'electronic' }
-          }
-        };
       }
     });
 
@@ -102,31 +91,12 @@ module('Integration | Component | workflow basics', (hooks) => {
       this.owner.unregister('service:doi');
       this.owner.register('service:doi', mockDoiService);
 
-      this.owner.unregister('service:nlmta');
-      this.owner.register('service:nlmta', mockNlmta);
-
       this.owner.unregister('service:store');
       this.owner.register('service:store', mockStore);
     });
   });
 
-  // eslint-disable-next-line prefer-arrow-callback
-  test('it renders', async function (assert) {
-    await render(hbs`{{workflow-basics
-      submission=submission
-      preLoadedGrant=preLoadedGrant
-      publication=publication
-      doiInfo=doiInfo
-      flaggedFields=flaggedFields
-      validateTitle=(action validateTitle)
-      validateJournal=(action validateJournal)
-      validateSubmitterEmail=(action validateSubmitterEmail)
-      next=(action loadNext)}}`);
-    assert.ok(true);
-  });
-
   test('lookupDOI should set doiInfo and publication', async function (assert) {
-    // this.set('lookupDOI', () => assert.ok(true));
     this.set('validateTitle', () => assert.ok(true));
 
     await render(hbs`{{workflow-basics
@@ -146,5 +116,103 @@ module('Integration | Component | workflow basics', (hooks) => {
     assert.equal(this.get('doiInfo').DOI, '10.1039/c7an01256j');
     assert.equal(this.get('publication.doi'), '1234/4321');
     assert.equal(this.get('publication.issue'), '1');
+  });
+
+  /**
+   * Test case:
+   *  - Draft submission
+   *  - Publication has a DOI
+   *
+   * Expect:
+   * DOI, title, and journal should be added to the UI inputs when things settle
+   */
+  test('Info is filled in when a submission is provided with a publication and DOI', async function (assert) {
+    const publication = this.get('publication');
+    const submission = this.get('submission');
+
+    submission.set('publication', publication);
+
+    await render(hbs`{{workflow-basics
+      submission=submission
+      publication=publication
+      preLoadedGrant=preLoadedGrant
+      doiInfo=doiInfo
+      flaggedFields=flaggedFields
+      validateTitle=(action validateTitle)
+      validateJournal=(action validateJournal)
+      validateSubmitterEmail=(action validateSubmitterEmail)
+      next=(action loadNext)}}`);
+    assert.ok(this.element);
+
+    // await waitUntil(() => new Promise(resolve => setTimeout(() => { debugger; resolve(); }, 1000)));
+    // 2 inputs, 1 textarea
+    const inputs = this.element.querySelectorAll('input');
+    const title = this.element.querySelector('textarea');
+
+    assert.equal(inputs.length, 2, 'There should be two input elements');
+    assert.ok(title, 'No "title" textarea element found');
+
+    assert.ok(title.textLength > 0, 'No title value found');
+    inputs.forEach((inp) => {
+      const msg = `No value found for input "${inp.parentElement.parentElement.querySelector('label').textContent}"`;
+      assert.ok(!!inp.value, msg);
+    });
+  });
+
+  /**
+   * Test this by first adding metadata to the submission with some fields containing values that
+   * differ from equivalent fields defined in the mock DOI service.
+   */
+  test('Draft submission metadata is not overwritten by DOI data', async function (assert) {
+    // First override the DOI service to ensure that it isn't called
+    this.set('doiService', {
+      resolveDOI: () => assert.ok(false, 'resolveDOI should not be called'),
+      formatDOI: () => asssert.ok(false, 'formatDOI should not be called'),
+      isValidDOI: () => assert.ok(false, 'isValidDOI should not be called')
+    });
+
+    const pub = Ember.Object.create({
+      doi: 'ThisIsADOI',
+      title: 'Moo title',
+      journal: Ember.Object.create({ journalName: 'Moo Journal' })
+    });
+    this.set('publication', pub);
+
+    // Add metadata to submission
+    const submission = Ember.Object.create({
+      publication: pub,
+      metadata: JSON.stringify({ title: 'You better use this' })
+    });
+    this.set('submission', submission);
+
+    await render(hbs`{{workflow-basics
+      submission=submission
+      publication=publication
+      preLoadedGrant=preLoadedGrant
+      doiInfo=doiInfo
+      flaggedFields=flaggedFields
+      validateTitle=(action validateTitle)
+      validateJournal=(action validateJournal)
+      validateSubmitterEmail=(action validateSubmitterEmail)
+      next=(action loadNext)}}`);
+    assert.ok(this.element);
+
+    // Check values of various inputs
+    const inputs = this.element.querySelectorAll('input');
+    const title = this.element.querySelector('textarea');
+
+    assert.equal(inputs.length, 2, 'There should be two input elements');
+    assert.ok(title, 'No "title" textarea element found');
+
+    assert.ok(title.textLength > 0, 'No title value found');
+    inputs.forEach((inp) => {
+      const msg = `No value found for input "${inp.parentElement.parentElement.querySelector('label').textContent}"`;
+      assert.ok(!!inp.value, msg);
+    });
+
+    // Check submission metadata
+    const md = JSON.parse(this.get('submission.metadata'));
+    assert.ok(md, 'no metadata found');
+    assert.equal(md.title, 'You better use this', 'Unexpected metadata!');
   });
 });

--- a/tests/unit/controllers/submissions/new/basics-test.js
+++ b/tests/unit/controllers/submissions/new/basics-test.js
@@ -159,7 +159,7 @@ module('Unit | Controller | submissions/new/basics', (hooks) => {
   });
 
   test('check validateAndLoadTab accepts complete information', function (assert) {
-    assert.expect(10);
+    assert.expect(11);
 
     let subSaved = false;
 
@@ -179,6 +179,10 @@ module('Unit | Controller | submissions/new/basics', (hooks) => {
       title: 'Test publication title',
       journal: {
         id: 'journal:id'
+      },
+      save() {
+        assert.ok(true);
+        return Promise.resolve();
       }
     });
     let model = {
@@ -210,7 +214,7 @@ module('Unit | Controller | submissions/new/basics', (hooks) => {
    * action is sent to the controller.
    */
   test('make sure submission is saved', function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     const controller = this.owner.lookup('controller:submissions/new/basics');
     const model = {
@@ -218,7 +222,8 @@ module('Unit | Controller | submissions/new/basics', (hooks) => {
         title: 'This is the moo-iest',
         journal: Ember.Object.create({
           id: 'journal:id'
-        })
+        }),
+        save: () => Promise.resolve(assert.ok(true))
       }),
       newSubmission: Ember.Object.create({
         save: () => Promise.resolve(assert.ok(true))

--- a/tests/unit/routes/submissions/new-test.js
+++ b/tests/unit/routes/submissions/new-test.js
@@ -4,9 +4,97 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Route | submissions/new', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let service = this.owner.lookup('route:submissions/new');
-    assert.ok(service);
+  /*
+   * Ended up mocking the Store in each test (instead of beforeEach()) in order to put
+   * test assertions in store calls
+   */
+  hooks.beforeEach(function () {
+    this.set('journal', Ember.Object.create({ journalName: 'International Moonthly' }));
+    this.set('publication', Ember.Object.create({
+      title: 'Test Publication',
+      journal: this.get('journal')
+    }));
+    this.set('submission', Ember.Object.create({
+      submissionStatus: 'draft',
+      publication: this.get('publication'),
+      metadata: '{ "moo": "This is a moo" }'
+    }));
+  });
+
+  test('fresh submission returned by model() when no ID is provided', async function (assert) {
+    assert.expect(4);
+
+    const route = this.owner.lookup('route:submissions/new');
+
+    route.set('store', {
+      createRecord(type, data) {
+        switch (type) {
+          case 'publication':
+            assert.ok(true);
+            return Promise.resolve(Ember.Object.create({ title: 'MockMoo' }));
+          case 'submission': // Submission - fall through to default
+            assert.ok(true);
+          // eslint-disable-next-line no-fallthrough
+          default:
+            return Promise.resolve(Ember.Object.create(data));
+        }
+      },
+      findRecord: (type, id) => Promise.resolve(Ember.Object.create()),
+      query: () => Promise.resolve(Ember.A())
+    });
+
+    const result = await route.model({});
+
+    assert.ok(result, 'no model found');
+    assert.notOk(result.newSubmission.get('publication'), 'There should be no publication on this submission');
+  });
+
+  /**
+   * Test case: submission ID is included in URL, grant ID NOT included in URL
+   *
+   * Expect that createRecord and findRecord are each called once and that
+   */
+  test('The mock submission returned from model() when it\'s ID is included', async function (assert) {
+    assert.expect(7);
+
+    const mockSub = this.get('submission');
+
+    const route = this.owner.lookup('route:submissions/new');
+
+    route.set('store', {
+      createRecord(type, data) {
+        switch (type) {
+          case 'publication':
+            assert.ok(true);
+            return Promise.resolve(Ember.Object.create({ title: 'MockMoo' }));
+          default:
+            assert.ok(false, `unexpected 'createRecord' type found: ${type}`);
+            return Promise.resolve(Ember.Object.create(data));
+        }
+      },
+      findRecord(type, id) {
+        switch (type) {
+          case 'submission':
+            assert.ok(true);
+            return Promise.resolve(mockSub);
+          default:
+            assert.ok(false, `unexpected 'createRecord' type found: ${type}`);
+            return Promise.resolve(Ember.Object.create());
+        }
+      },
+      query: () => Promise.resolve(Ember.A())
+    });
+    route.set('workflow', {
+      setDoiInfo(data) {
+        assert.ok(data);
+        assert.equal(data.moo, 'This is a moo');
+      }
+    });
+
+    const result = await route.model({ submission: 'moo' });
+
+    assert.ok(result, 'no model found');
+    assert.ok(result.newSubmission.get('publication'), 'There should be a publication on this submission');
+    assert.equal(result.newSubmission.get('publication.title'), 'Test Publication');
   });
 });


### PR DESCRIPTION
Closes #905 

No tests yet!

My biggest concern is the way Journal data is loaded in the case of a draft submission with a Publication with no DOI. This is handled similarly to how DOI would be loaded into the widget: if applicable, it will send the `selectJournal` action to kick off it's logic and add the Journal metadata to the workflow service. Applicability here is if a Journal object is passed to the component from the `submission/new` route, which should happen only when loading draft submissions.