### PR TITLE
More properties should be added to the list of 'valid' fields to take from Crossref

### DIFF
--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -110,9 +110,24 @@ export default Service.extend({
 
     schemas.map(schema => this.alpacafySchema(schema))
       .forEach((schema) => {
-        Object.keys(schema.options.fields)
+        Object.keys(schema.schema.properties)
           .filter(key => !fields.includes(key))
           .forEach(key => fields.push(key));
+      });
+
+    /**
+     * Add fields from properties defined in schema.allOf
+     * Make sure the top level `schema.additionalProperties` is not explicitly set to FALSE
+     */
+    schemas.filter(schema => (schema.additionalProperties !== false) && schema.allOf)
+      .map(schema => schema.allOf)
+      .forEach((allOf) => {
+        allOf.filter(schema => schema.properties)
+          .map(schema => schema.properties)
+          .forEach((props) => {
+            Object.keys(props).filter(key => !fields.includes(key))
+              .forEach(key => fields.push(key));
+          });
       });
 
     return fields;

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -161,4 +161,12 @@ module('Unit | Service | metadata-schema', (hooks) => {
     const errors = service.getErrors();
     assert.equal(1, errors.length, 'Should have found 1 error');
   });
+
+  test('Get fields includes \'allOf\' properties', function (assert) {
+    const service = this.owner.lookup('service:metadata-schema');
+    const result = service.getFields([this.get('mockSchema')]);
+
+    assert.ok(result, 'No results found');
+    assert.ok(result.includes('issns'));
+  });
 });


### PR DESCRIPTION
Closes #936 

A single very quick submission suggested that this fix at least adds DOI to the metadata blob. Unit tests and probably more testing is required to verify.

This takes the first approach outlined in the ticket to automatically try to inspect the given set of schema for properties to add.

* [x] Write tests to capture this behavior