### PR TITLE
Update metadata forms layout

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - activemq
 
   schemaservice:
-    image: oapass/schema-service:v0.2.1-1-gb28397@sha256:3a2435f58e7125ff2f5ad150c40fe6767ab1e1be428401b225f5204ed4d8cdda
+    image: oapass/schema-service:v0.3.1@sha256:9276b5262e964f19ee0bc9be9eedb82c237349afe6d934ba84b5a152bab44bc5
     container_name: schemaservice
     env_file: .env
     ports:

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -317,49 +317,20 @@ td {
   content: "\f05a";
 }
 
-.alpaca-field-array .alpaca-container-label {
-  font-size: 1em!important;
-}
-.alpaca-array-actionbar-bottom {
-  margin-top:-25px;
-}
-.alpaca-vertical {
-  margin-bottom: 20px;
-}
-
-.alpaca-array-actionbar-top {
-  float: right;
-  margin-right: -130px;
-  display: inline-flex!important;
-}
-[data-alpaca-container-item-name*="authors_"] {
+.alpaca-container {
   width: 100%;
+}
+.alpaca-container .md-pubtype {
+  label {
+    display: block;
+  }
+  .radio label {
+    margin-left: 12px;
+  }
 }
 
 .help-block {
   display: none;
-}
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div  {
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-}
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div > div:nth-child(odd)   {
-  margin-right: 2px;
-}
-[data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div > div:nth-child(even)   {
-  margin-left: 2px;
-}
-
-@media (max-width: 1200px) {
-  .alpaca-array-actionbar-top {
-    float: left;
-    margin-right: 0;
-    margin-bottom: 3px;
-  }
-  [data-alpaca-container-item-name*="authors_"] > div > div:nth-child(2) > div  {
-    width: 100%;
-  }
 }
 
 .form-control:disabled, .form-control[readonly] {


### PR DESCRIPTION
Closes #938 

Streamlines some of the layout issues in the metadata forms.

* [x] Requires an updated `schemaservice` Docker image
  * [x] Issue a Github release of modified schema service
  * [x] Update `pass-docker` and `pass-ember` docker compose configs to use newly released schema service image