### PR TITLE
Let policy service URL be configured

### DIFF
--- a/.docker/.env
+++ b/.docker/.env
@@ -70,6 +70,7 @@ METADATA_SCHEMA_URI=https://oa-pass.github.io/metadata-schemas/jhu/global.json
 # Policy Service
 POLICY_SERVICE_PORT=8088
 POLICY_FILE=docker.json
+POLICY_SERVICE_URL=https://pass.local/policyservice
 
 # DOI Service
 PASS_DOI_SERVICE_PORT=8090

--- a/app/services/policies.js
+++ b/app/services/policies.js
@@ -16,8 +16,22 @@ export default Service.extend({
 
     // this.set('base', ENV.policyService.url);
     const policyConf = ENV.policyService;
-    this.set('policyUrl', `${policyConf.url}${policyConf.policySuffix}`);
-    this.set('repoUrl', `${policyConf.url}${policyConf.repoSuffix}`);
+
+    let policyUrl;
+    if (policyConf.policyEndpoint) {
+      policyUrl = policyConf.policyEndpoint;
+    } else {
+      policyUrl = `${policyConf.url}${policyConf.policySuffix}`;
+    }
+    this.set('policyUrl', policyUrl);
+
+    let repoUrl;
+    if (policyConf.repositoryEndpoint) {
+      repoUrl = policyConf.repositoryEndpoint;
+    } else {
+      repoUrl = `${policyConf.url}${policyConf.repoSuffix}`;
+    }
+    this.set('repoUrl', repoUrl);
   },
 
   /**

--- a/config/environment.js
+++ b/config/environment.js
@@ -57,16 +57,6 @@ module.exports = function (environment) {
     };
   }
 
-  if (environment === 'surge') {
-    // Application deployed as /pass
-    // ENV.rootURL = '/pass/';
-    ENV.contentSecurityPolicy = {
-      'style-src': "'self' 'unsafe-inline'",
-      'script-src': "'self' 'unsafe-eval' http://pass-jhu.surge.sh",
-      'connect-src': "'self' http://pass-jhu.surge.sh"
-    };
-  }
-
   ENV.fedora = {
     base: 'http://localhost:8080/fcrepo/rest/',
     context: 'https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld',
@@ -86,10 +76,11 @@ module.exports = function (environment) {
   };
 
   ENV.policyService = {
-    // url: 'https://pass.local:8088',
     url: 'https://pass.local/policyservice',
     policySuffix: '/policies',
-    repoSuffix: '/repositories'
+    repoSuffix: '/repositories',
+    // policyEndpoint: 'https://pass.local/policyservice/policies',
+    // repositoryEndpoint: 'https://pass.local/policyservice/repositories'
   };
 
   ENV.metadataSchemaUri = 'https://oa-pass.github.io/metadata-schemas/jhu/global.json';
@@ -128,6 +119,18 @@ module.exports = function (environment) {
 
   if (process.env.METADATA_SCHEMA_URI) {
     ENV.metadataSchemaUri = process.env.METADATA_SCHEMA_URI;
+  }
+
+  if (process.env.POLICY_SERVICE_URL) {
+    ENV.policyService.url = process.env.POLICY_SERVICE_URL;
+  }
+
+  if (process.env.POLICY_SERVICE_POLICY_ENDPOINT) {
+    ENV.policyService.policyEndpoint = process.env.POLICY_SERVICE_POLICY_ENDPOINT;
+  }
+
+  if (process.env.POLICY_SERVICE_REPOSITORY_ENDPOINT) {
+    ENV.policyService.repositoryEndpoint = process.env.POLICY_SERVICE_REPOSITORY_ENDPOINT;
   }
 
   if ('FEDORA_ADAPTER_USER_NAME' in process.env) {


### PR DESCRIPTION
Closes #942 

I was able to see configuration changes in the UI, but only after refreshing the `ember` dev image, which, I believe, rebuilds the development site