### PR TITLE
DOI lookup happens if draft submission has empty metadata

### DIFF
--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -53,8 +53,8 @@
   {{input
     class=doiClass
     value=publication.doi
-    keyUp=(action "lookupDOI")
-    mouseUp=(action "lookupDOI")
+    keyUp=(action "lookupDOI" true)
+    mouseUp=(action "lookupDOI" true)
     id="doi"
     placeholder="Leave blank if your manuscript or article has not yet been assigned a DOI"
   }}


### PR DESCRIPTION
Closes #944 

This was a little more convoluted that I had hoped. We do need to invoke the DOI service if submission metadata is empty or invalid. For draft submissions that already have a Publication, but no valid metadata, we must make the call to the DOI service, but ignore the Publication object that it returns. Even though the returned Publication object will have identical contents to the object already on the submission, we want to prevent the creation of duplicate objects in Fedora. By ignoring the Publication object from the DOI service, the Publication object is created on the client side, but never persisted to the back end.

`#lookupDOI(setPublication)` this function signature has changed to include a boolean argument telling whether or not the publication returned by the DOI service should be used or ignored. Calls to this action will have the argument of `true` when issued from the HBS template. Otherwise, it depends on the current value of the publication property on the submission.