### PR TITLE
Navigating between repo tab and others shouldn't break things anymore

### DIFF
--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -57,16 +57,16 @@ export default Component.extend({
        * as well as any other repositories marked as 'selected'
        */
       if (req) {
-        req.forEach(repoInfo => this.addRepository(repoInfo.repository));
+        req.forEach(repoInfo => this.addRepository(repoInfo.repository, false));
       }
       if (opt) {
         opt.filter(repoInfo => repoInfo.repository.get('_selected'))
-          .forEach(repoInfo => this.addRepository(repoInfo.repository));
+          .forEach(repoInfo => this.addRepository(repoInfo.repository, false));
       }
       if (choice) {
         choice.forEach((group) => {
           group.filter(repoInfo => repoInfo.repository.get('_selected'))
-            .forEach(repoInfo => this.addRepository(repoInfo.repository));
+            .forEach(repoInfo => this.addRepository(repoInfo.repository, false));
         });
       }
     }
@@ -113,23 +113,29 @@ export default Component.extend({
    * Add a repository to the submission only if it is not already included
    *
    * @param {Repository} repository
+   * @param {boolean} setMaxStep should we modify 'maxStep' in the workflow?
    */
-  addRepository(repository) {
+  addRepository(repository, setMaxStep) {
     const subRepos = this.get('submission.repositories');
 
     if (!subRepos.includes(repository)) {
       subRepos.pushObject(repository);
     }
-    this.get('workflow').setMaxStep(4);
+    if (setMaxStep) {
+      this.get('workflow').setMaxStep(4);
+    }
   },
 
   /**
    * Remove a repository from the submission
    *
    * @param {Repository} repository
+   * @param {boolean} setMaxStep should we modify 'maxStep' in the workflow?
    */
-  removeRepository(repository) {
+  removeRepository(repository, setMaxStep) {
     this.get('submission.repositories').removeObject(repository);
-    this.get('workflow').setMaxStep(4);
+    if (setMaxStep) {
+      this.get('workflow').setMaxStep(4);
+    }
   },
 });

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -90,9 +90,9 @@ export default Component.extend({
      */
     toggleRepository(repository, selected, type) {
       if (selected) {
-        this.addRepository(repository);
+        this.addRepository(repository, true);
       } else {
-        this.removeRepository(repository);
+        this.removeRepository(repository, true);
       }
     },
 


### PR DESCRIPTION
Closes #931 

## Bad behavior

* Progress through the submission workflow
* Finish the Repositories step, click Next (this will persist changes)
* Click Back button OR click the Repositories tab to go back to that step
* Bad things happen

This bug may also occur if you finish the Repositories step, go back to a previous step, like Basics, then progress forward again to get to the Repositories step.