### PR TITLE
Rollback jQuery update, bump alpaca version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "ms": {
@@ -1453,9 +1453,9 @@
       "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I="
     },
     "alpaca": {
-      "version": "1.5.24",
-      "resolved": "https://registry.npmjs.org/alpaca/-/alpaca-1.5.24.tgz",
-      "integrity": "sha512-U7qF6wdND/2FL3N8RZsgbCKP3azdY16gjuI4VFIrgCAZYzEgD8tvfyWbtqP/sHiXa3vnleNNqvicZ6K9r1AxMw=="
+      "version": "1.5.27",
+      "resolved": "https://registry.npmjs.org/alpaca/-/alpaca-1.5.27.tgz",
+      "integrity": "sha512-NLiH923aL0Tv/EvyhmFSjJsOGKyR5/EhO/UYqlfCztcwZFDy6mmhCRiKiWvWXKyUMNQ5vEBm3WoX5RlkIyJb8A=="
     },
     "amd-name-resolver": {
       "version": "1.2.0",
@@ -3912,7 +3912,35 @@
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
       "requires": {
         "array-to-error": "^1.0.0",
+        "clean-css": "^3.4.5",
         "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "3.4.28",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
       }
     },
     "clean-up-path": {
@@ -7871,7 +7899,7 @@
         },
         "regenerator-runtime": {
           "version": "0.9.6",
-          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
           "integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
         }
       }
@@ -8776,7 +8804,7 @@
     },
     "ember-source": {
       "version": "2.18.2",
-      "resolved": "http://registry.npmjs.org/ember-source/-/ember-source-2.18.2.tgz",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.18.2.tgz",
       "integrity": "sha1-ddAO71SIv+UEBEsCXHUrqSTq+H8=",
       "requires": {
         "broccoli-funnel": "^2.0.1",
@@ -11453,6 +11481,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -13513,7 +13546,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
@@ -14623,7 +14656,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "resolve": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@coreui/ajax": "1.0.10",
-    "alpaca": "^1.5.24",
+    "alpaca": "1.5.27",
     "bootstrap": "^4.3.1",
     "broccoli-asset-rev": "^2.7.0",
     "ember-ajax": "^3.1.0",
@@ -78,7 +78,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
-    "jquery": "^3.4.1",
+    "jquery": "^3.3.1",
     "loader.js": "^4.7.0",
     "popper.js": "^1.14.5",
     "sweetalert2": "^7.29.0"


### PR DESCRIPTION
Turns out that jQuery is breaking Alpaca. We will have to find a fix or workaround later