### PR TITLE
First draft at polling ES for changes

### DIFF
--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -71,6 +71,7 @@ export default Controller.extend({
     },
     abort() {
       const submission = this.get('model.newSubmission');
+      const ignoreList = this.get('searchHelper');
 
       swal({
         title: 'Discard Draft',
@@ -81,7 +82,9 @@ export default Controller.extend({
       }).then(async (result) => {
         if (result.value) {
           await this.get('submissionHandler').deleteSubmission(submission);
-          await this.get('searchHelper').waitForES(submission.get('id'), 'submission', { submissionStatus: 'cancelled' });
+          // Clear the shared ignore list, then add the 'deleted' submission ID
+          ignoreList.clearIgnore();
+          ignoreList.ignore(submission.get('id'));
           this.transitionToRoute('submissions');
         }
       });

--- a/app/controllers/submissions/new.js
+++ b/app/controllers/submissions/new.js
@@ -7,6 +7,8 @@ export default Controller.extend({
   currentUser: service('current-user'),
   workflow: service('workflow'),
   submissionHandler: service('submission-handler'),
+  searchHelper: service('search-helper'),
+
   comment: '', // Holds the comment that will be added to submissionEvent in the review step.
   uploading: false,
   waitingMessage: '',
@@ -76,10 +78,11 @@ export default Controller.extend({
         confirmButtonText: 'Abort',
         confirmButtonColor: '#f86c6b',
         showCancelButton: true
-      }).then((result) => {
+      }).then(async (result) => {
         if (result.value) {
-          this.get('submissionHandler').deleteSubmission(submission)
-            .then(() => this.transitionToRoute('submissions'));
+          await this.get('submissionHandler').deleteSubmission(submission);
+          await this.get('searchHelper').waitForES(submission.get('id'), 'submission', { submissionStatus: 'cancelled' });
+          this.transitionToRoute('submissions');
         }
       });
     }

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -36,15 +36,15 @@ export default CheckSessionRoute.extend({
       }],
       query: {
         match_all: {},
-        must_not: {
-          term: { submissionStatus: 'cancelled' }
-        }
+        must_not: [
+          { term: { submissionStatus: 'cancelled' } }
+        ]
       },
       size: 500
     };
 
     if (ignoreList && ignoreList.length > 0) {
-      query.query.bool.must_not.push({ terms: { '@id': ignoreList } });
+      query.query.must_not.push({ terms: { '@id': ignoreList } });
     }
 
     return this.store.query('submission', query);

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -50,15 +50,10 @@ export default CheckSessionRoute.extend({
         bool: {
           should: [
             {
-              term: {
-                submitter: user.get('id')
-
-              }
+              term: { submitter: user.get('id') }
             },
             {
-              term: {
-                preparers: user.get('id')
-              }
+              term: { preparers: user.get('id') }
             },
           ],
           must_not: {

--- a/app/routes/submissions/index.js
+++ b/app/routes/submissions/index.js
@@ -4,8 +4,9 @@ import { inject as service } from '@ember/service';
 
 export default CheckSessionRoute.extend({
   currentUser: service('current-user'),
+  searchHelper: service('search-helper'),
 
-  model() {
+  async model() {
     const user = this.get('currentUser.user');
 
     let submissions = null;
@@ -16,13 +17,17 @@ export default CheckSessionRoute.extend({
       submissions = this._doSubmitter(user);
     }
 
+    submissions.then(() => this.get('searchHelper').clearIgnore());
+
     return RSVP.hash({
       submissions
     });
   },
 
   _doAdmin() {
-    return this.store.query('submission', {
+    const ignoreList = this.get('searchHelper').getIgnoreList();
+
+    const query = {
       sort: [{
         submittedDate: {
           missing: '_last',
@@ -36,11 +41,19 @@ export default CheckSessionRoute.extend({
         }
       },
       size: 500
-    });
+    };
+
+    if (ignoreList && ignoreList.length > 0) {
+      query.query.bool.must_not.push({ terms: { '@id': ignoreList } });
+    }
+
+    return this.store.query('submission', query);
   },
 
   _doSubmitter(user) {
-    return this.store.query('submission', {
+    const ignoreList = this.get('searchHelper').getIgnoreList();
+
+    const query = {
       sort: [
         { submitted: { missing: '_last', order: 'asc' } },
         { submittedDate: { missing: '_last', order: 'desc' } },
@@ -49,19 +62,21 @@ export default CheckSessionRoute.extend({
       query: {
         bool: {
           should: [
-            {
-              term: { submitter: user.get('id') }
-            },
-            {
-              term: { preparers: user.get('id') }
-            },
+            { term: { submitter: user.get('id') } },
+            { term: { preparers: user.get('id') } },
           ],
-          must_not: {
-            term: { submissionStatus: 'cancelled' }
-          }
+          must_not: [
+            { term: { submissionStatus: 'cancelled' } }
+          ]
         }
       },
       size: 500
-    });
+    };
+
+    if (ignoreList && ignoreList.length > 0) {
+      query.query.bool.must_not.push({ terms: { '@id': ignoreList } });
+    }
+
+    return this.store.query('submission', query);
   },
 });

--- a/app/services/search-helper.js
+++ b/app/services/search-helper.js
@@ -1,5 +1,5 @@
 import Service from '@ember/service';
-import { defer } from 'rsvp';
+// import { defer } from 'rsvp';
 
 /**
  * This service can be referenced by components that rely on Elasticsearch query results
@@ -53,11 +53,9 @@ export default Service.extend({
     }
 
     const list = this.get('ignoreList');
-    if (!list.includes('id')) {
-      return;
+    if (list.includes(id)) {
+      this.get('ignoreList').splice(list.indexOf(id), 1);
     }
-
-    this.set('ignoreList', list.splice(list.indexOf(id), 1));
   },
 
   getIgnoreList() {

--- a/app/services/search-helper.js
+++ b/app/services/search-helper.js
@@ -8,8 +8,13 @@ import { defer } from 'rsvp';
  * situation is known in advance, a component can refer to this service to know about
  * any object IDs that have changed that may not appear in the ES results.
  *
+ * An ignore list is maintained here. Components can declare that certain model IDs
+ * should be ignored through a transition, then other components can check against this
+ * list after the transtition.
+ *
  * #waitForES : polls ES a few times and looks for a known change to appear in the ES
- *              result
+ *              result. This was a less desirable option due to it's performance and
+ *              networking hit.
  */
 export default Service.extend({
   store: Ember.inject.service('store'),
@@ -21,7 +26,9 @@ export default Service.extend({
     this.clearIgnore();
   },
 
-  /** Clear the ignore list */
+  /**
+   * Clear the ignore list.
+   */
   clearIgnore() {
     this.set('ignoreList', []);
   },
@@ -71,37 +78,36 @@ export default Service.extend({
    * @returns {Promise} resolves when the known change is observed in the ES results
    *                    rejects if max number of retries is reached
    */
-  waitForES(id, type, change) {
-    const promise = defer();
-    let count = 0;
+  // waitForES(id, type, change) {
+  //   const promise = defer();
+  //   let count = 0;
 
-    const store = this.get('store');
+  //   const store = this.get('store');
 
-    const timer = window.setInterval(() => {
-      console.log(`%cWaiting for ES to change. ${id} : (${JSON.stringify(change)}) [Step ${count}]`, 'color:orange;');
-      store.query(type, { term: { '@id': id } }).then((objs) => {
-        const changeFound = (obj) => {
-          for (let key in change) {
-            if (obj.get(key) !== change[key]) {
-              return false;
-            }
-          }
-          return true;
-        };
+  //   const timer = window.setInterval(() => {
+  //     store.query(type, { term: { '@id': id } }).then((objs) => {
+  //       const changeFound = (obj) => {
+  //         for (let key in change) {
+  //           if (obj.get(key) !== change[key]) {
+  //             return false;
+  //           }
+  //         }
+  //         return true;
+  //       };
 
-        if (objs.any(obj => changeFound(obj))) {
-          window.clearInterval(timer);
-          promise.resolve();
-        }
+  //       if (objs.any(obj => changeFound(obj))) {
+  //         window.clearInterval(timer);
+  //         promise.resolve();
+  //       }
 
-        if (count++ >= 10) {
-          window.clearInterval(timer);
-          promise.reject('Max retries reached');
-        }
-      });
-    }, 500);
+  //       if (count++ >= 10) {
+  //         window.clearInterval(timer);
+  //         promise.reject('Max retries reached');
+  //       }
+  //     });
+  //   }, 500);
 
-    return promise.promise;
-  }
+  //   return promise.promise;
+  // }
 
 });

--- a/app/services/search-helper.js
+++ b/app/services/search-helper.js
@@ -1,0 +1,107 @@
+import Service from '@ember/service';
+import { defer } from 'rsvp';
+
+/**
+ * This service can be referenced by components that rely on Elasticsearch query results
+ * to populate their models. In some cases, ES results may contain old (incorrect) data
+ * because of the lag time between changes in Fedora and reindexing in ES. If such a
+ * situation is known in advance, a component can refer to this service to know about
+ * any object IDs that have changed that may not appear in the ES results.
+ *
+ * #waitForES : polls ES a few times and looks for a known change to appear in the ES
+ *              result
+ */
+export default Service.extend({
+  store: Ember.inject.service('store'),
+  /** List of object IDs to ignore */
+  ignoreList: [],
+
+  init() {
+    this._super(...arguments);
+    this.clearIgnore();
+  },
+
+  /** Clear the ignore list */
+  clearIgnore() {
+    this.set('ignoreList', []);
+  },
+
+  /**
+   * Add an ID to the ignore list
+   *
+   * @param {string} id model object ID
+   */
+  ignore(id) {
+    if (typeof id !== 'string') {
+      console.log('%cYou can only add ID strings to the ignore list', 'color: red;');
+      return;
+    }
+    this.get('ignoreList').push(id);
+  },
+
+  unignore(id) {
+    if (typeof id !== 'string') {
+      console.log('%cYou can only remove ID \'strings\' to the ignore list', 'color: red;');
+      return;
+    }
+
+    const list = this.get('ignoreList');
+    if (!list.includes('id')) {
+      return;
+    }
+
+    this.set('ignoreList', list.splice(list.indexOf(id), 1));
+  },
+
+  getIgnoreList() {
+    return this.get('ignoreList');
+  },
+
+  shouldIgnore(id) {
+    return this.get('ignoreList').includes(id);
+  },
+
+  /**
+   * Wait for Elasticsearch to be reindexed with the given value.
+   * If no property is provided, assume that the object was deleted.
+   *
+   * @param {string} id object ID
+   * @param {string} type model type
+   * @param {object} change { key: value } the updated property key/value
+   * @returns {Promise} resolves when the known change is observed in the ES results
+   *                    rejects if max number of retries is reached
+   */
+  waitForES(id, type, change) {
+    const promise = defer();
+    let count = 0;
+
+    const store = this.get('store');
+
+    const timer = window.setInterval(() => {
+      console.log(`%cWaiting for ES to change. ${id} : (${JSON.stringify(change)}) [Step ${count}]`, 'color:orange;');
+      store.query(type, { term: { '@id': id } }).then((objs) => {
+        const changeFound = (obj) => {
+          for (let key in change) {
+            if (obj.get(key) !== change[key]) {
+              return false;
+            }
+          }
+          return true;
+        };
+
+        if (objs.any(obj => changeFound(obj))) {
+          window.clearInterval(timer);
+          promise.resolve();
+        }
+
+        if (count++ >= 10) {
+          window.clearInterval(timer);
+          promise.reject('Max retries reached');
+        }
+      });
+    }, 500);
+
+    return promise.promise;
+  }
+
+});

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -259,22 +259,18 @@ export default Service.extend({
   },
 
   /**
-   * Simply set submission.submissionStatus to 'cancelled'
+   * Simply set submission.submissionStatus to 'cancelled'. This operation is
+   * distinct from `#cancelSubmission` because this does not create a
+   * SubmissionEvent
    *
    * All other objects associated with the submission (Publication, Files, etc)
    * will remain intact.
-   *
-   * TODO: Are deleted submissions important enough to track for audit purposes?
-   * If so, we can use #cancelSubmission() above to issue a SubmissionEvent.
    *
    * @param {Submission} submission submission to delete
    * @returns {Promise} that returns once the submission deletion is persisted
    */
   async deleteSubmission(submission) {
     submission.set('submissionStatus', 'cancelled');
-    // this.cancelSubmission(submission).then(() => {
-    //   submission.unloadRecord();
-    // });
     return submission.save().then(() => {
       submission.unloadRecord();
     });

--- a/tests/unit/routes/submissions/index-test.js
+++ b/tests/unit/routes/submissions/index-test.js
@@ -1,12 +1,61 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 
 module('Unit | Route | submissions/index', (hooks) => {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function (assert) {
-    let route = this.owner.lookup('route:submissions/index');
-    assert.ok(route);
+  test('Make sure ignore list is included in ES query for a submitter', async function (assert) {
+    assert.expect(2);
+    const route = this.owner.lookup('route:submissions/index');
+
+    route.set('currentUser', Ember.Object.create({
+      user: Ember.Object.create({
+        id: 'Moo',
+        isSubmitter: true
+      })
+    }));
+    route.set('searchHelper', Ember.Object.create({
+      getIgnoreList: () => ['ID-3'],
+      clearIgnore: () => {}
+    }));
+    route.set('store', Ember.Object.create({
+      query: (type, query) => {
+        const filter = query.query.bool.must_not;
+        assert.equal(filter.length, 2, 'Should be two "must_not" terms');
+        assert.deepEqual(filter[1].terms, { '@id': ['ID-3'] });
+
+        return Promise.resolve(Ember.A());
+      }
+    }));
+
+    await route.model();
+  });
+
+  test('Make sure ignore list is included in ES query for a admin', async function (assert) {
+    assert.expect(2);
+    const route = this.owner.lookup('route:submissions/index');
+
+    route.set('currentUser', Ember.Object.create({
+      user: Ember.Object.create({
+        id: 'Moo',
+        isAdmin: true
+      })
+    }));
+    route.set('searchHelper', Ember.Object.create({
+      getIgnoreList: () => ['ID-3'],
+      clearIgnore: () => {}
+    }));
+    route.set('store', Ember.Object.create({
+      query: (type, query) => {
+        const filter = query.query.must_not;
+        assert.equal(filter.length, 2, 'Should be two "must_not" terms');
+        assert.deepEqual(filter[1].terms, { '@id': ['ID-3'] });
+
+        return Promise.resolve(Ember.A());
+      }
+    }));
+
+    await route.model();
   });
 });

--- a/tests/unit/services/search-helper-test.js
+++ b/tests/unit/services/search-helper-test.js
@@ -1,12 +1,24 @@
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-moduleFor('service:search-helper', 'Unit | Service | search helper', {
-  // Specify the other units that are required for this test.
-  // needs: ['service:foo']
-});
+module('Unit | Service | search helper', (hooks) => {
+  setupTest(hooks);
 
-// Replace this with your real tests.
-test('it exists', function (assert) {
-  let service = this.subject();
-  assert.ok(service);
+  /**
+   * Actually a bad test because it exercises 3 different service functions :)
+   */
+  test('unignore an ID', function (assert) {
+    const service = this.owner.lookup('service:search-helper');
+
+    const ignore = ['ID-1', 'ID-2', 'ID-3', 'ID-4'];
+    ignore.forEach(id => service.ignore(id));
+
+    // Make sure all IDs made it into the ignore list
+    ignore.map(id => service.shouldIgnore(id)).every(result => assert.ok(result));
+
+    const badId = 'ID-3';
+    service.unignore(badId);
+
+    assert.notOk(service.shouldIgnore(badId));
+  });
 });

--- a/tests/unit/services/search-helper-test.js
+++ b/tests/unit/services/search-helper-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:search-helper', 'Unit | Service | search helper', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function (assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Closes #955 

A shared service is created that can be used to maintain an "ignore list" that can be referenced before and after a route transition. This is sometimes necessary because of the lag time of reindexing in Elasticsearch.

This work focuses on "Aborting" draft submissions from the workflow. The draft submission is added to the ignore list, then this list is seen by the `submissions` route and added to the ES query to prevent the given ID from appearing in the ES results.