### PR TITLE
Set metadata provided to metadata step as readonly in forms

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -97,9 +97,23 @@ export default Component.extend({
     if (workflow.isDataFromCrossref()) {
       this.get('workflow').setFromCrossref(false);
       this.set('doiInfo', {});
-      // debugger
-      console.log('Reset Crossref stuff');
+      this.clearPublication();
     }
+  },
+
+  /**
+   * Remove all data from the current Publication
+   */
+  clearPublication() {
+    this.get('publication').setProperties({
+      doi: '',
+      title: '',
+      abstract: '',
+      volume: '',
+      issue: '',
+      pmid: '',
+      journal: undefined
+    });
   },
 
   actions: {

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -45,30 +45,6 @@ export default Component.extend({
     const hasPublication = !!(publication && publication.get('doi'));
 
     this.lookupDoiAndJournal(!hasPublication);
-    /**
-     * See IMPL NOTE above regarding the existance of submission metadata
-     */
-    // try {
-    //   const md = JSON.parse(this.get('submission.metadata'));
-
-    //   /**
-    //    * Set workflow doiInfo because of some weird timing between `routes/submissions/new/index#beforeModel`
-    //    * and `routes/submissions/new#model()` causing the doiInfo in 'workflow' to reset after it is
-    //    * defined by the incoming submission
-    //    */
-    //   this.get('workflow').setDoiInfo(md);
-
-    //   /**
-    //    * Check to see if incoming metadata is an empty object. If metadata is an empty object, then
-    //    * we still need to load DOI, but may not have to set the returned Publication object.
-    //    */
-    //   if (Object.entries(md).length === 0 && md.constructor === Object) {
-    //     this.lookupDoiAndJournal(!hasPublication);
-    //   }
-    // } catch (e) {
-    //   // Either 'metadata' is missing or malformed
-    //   this.lookupDoiAndJournal(!hasPublication);
-    // }
   },
 
   /**

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -2,23 +2,12 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
 /**
- * IMPL NOTE:
- * An interesting thing to consider: say a user goes through the submission workflow and ends up filling
- * out some custom values in the metadata fields presented to them. The user then leaves the workflow
- * leaving us with a 'draft' submission that can be resumed later. When we re-enter the submission
- * workflow, we don't want to clobber the user-entered metadata.
- *
- * If submission metadata exists, it means the user at least made it past the metadata details step
- * in the workflow. In this case, we should trust this metadata over data from the DOI service. Since
- * data from the DOI is used to seed the metadata step, we can be sure that this data already exists
- * in the submission metadata.
- *
- * If we find either NO metadata or an empty object, then we must look up the DOI to get the
- * metadata, but NOT act on the Publication or Journal objects received from the doi service.
- *
- * TODO: these cumulative issues require pretty ugly and round-about fixes making the code
- * hard to follow. This component needs to be cleaned up so these workaround pathways are not
- * required.
+ * Any metadata field presented by Crossref is made read-only, preventing any changes
+ * to those metadata fields. However, a user may enter extra metadata on top of the Crossref fields.
+ * It is safe to lookup the DOI in Crossref, then always merge the metadata currently in the
+ * submission with the Crossref results. Lookup Crossref whenever the user enters the submission
+ * workflow lets us see which fields came from Crossref. With that record, we will have enough
+ * information about specific fields to set to read-only in the subsequent metadata step.
  */
 export default Component.extend({
   store: service('store'),
@@ -54,30 +43,32 @@ export default Component.extend({
 
     const publication = this.get('submission.publication');
     const hasPublication = !!(publication && publication.get('doi'));
+
+    this.lookupDoiAndJournal(!hasPublication);
     /**
      * See IMPL NOTE above regarding the existance of submission metadata
      */
-    try {
-      const md = JSON.parse(this.get('submission.metadata'));
+    // try {
+    //   const md = JSON.parse(this.get('submission.metadata'));
 
-      /**
-       * Set workflow doiInfo because of some weird timing between `routes/submissions/new/index#beforeModel`
-       * and `routes/submissions/new#model()` causing the doiInfo in 'workflow' to reset after it is
-       * defined by the incoming submission
-       */
-      this.get('workflow').setDoiInfo(md);
+    //   /**
+    //    * Set workflow doiInfo because of some weird timing between `routes/submissions/new/index#beforeModel`
+    //    * and `routes/submissions/new#model()` causing the doiInfo in 'workflow' to reset after it is
+    //    * defined by the incoming submission
+    //    */
+    //   this.get('workflow').setDoiInfo(md);
 
-      /**
-       * Check to see if incoming metadata is an empty object. If metadata is an empty object, then
-       * we still need to load DOI, but may not have to set the returned Publication object.
-       */
-      if (Object.entries(md).length === 0 && md.constructor === Object) {
-        this.lookupDoiAndJournal(!hasPublication);
-      }
-    } catch (e) {
-      // Either 'metadata' is missing or malformed
-      this.lookupDoiAndJournal(!hasPublication);
-    }
+    //   /**
+    //    * Check to see if incoming metadata is an empty object. If metadata is an empty object, then
+    //    * we still need to load DOI, but may not have to set the returned Publication object.
+    //    */
+    //   if (Object.entries(md).length === 0 && md.constructor === Object) {
+    //     this.lookupDoiAndJournal(!hasPublication);
+    //   }
+    // } catch (e) {
+    //   // Either 'metadata' is missing or malformed
+    //   this.lookupDoiAndJournal(!hasPublication);
+    // }
   },
 
   /**
@@ -196,7 +187,7 @@ export default Component.extend({
       }
 
       publication.set('doi', doi);
-      this.set('submission.metadata', '{}');
+      // this.set('submission.metadata', '{}');
       this.set('inFlight', true);
 
       doiService.resolveDOI(doi).then(async (result) => {
@@ -205,6 +196,7 @@ export default Component.extend({
         }
 
         this.set('doiInfo', result.doiInfo);
+        this.get('workflow').setFromCrossref(true);
 
         toastr.success("We've pre-populated information from the DOI provided!");
         this.sendAction('validateTitle');

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -41,6 +41,8 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
+    this.get('workflow').setFromCrossref(false);
+
     const publication = this.get('submission.publication');
     const hasPublication = !!(publication && publication.get('doi'));
 
@@ -88,6 +90,18 @@ export default Component.extend({
     }
     return 'form-control is-invalid';
   }),
+
+  clearDoiData() {
+    const workflow = this.get('workflow');
+
+    if (workflow.isDataFromCrossref()) {
+      this.get('workflow').setFromCrossref(false);
+      this.set('doiInfo', {});
+      // debugger
+      console.log('Reset Crossref stuff');
+    }
+  },
+
   actions: {
     proxyStatusToggled(isProxySubmission) {
       // do only if the values indicate a switch of proxy
@@ -151,6 +165,8 @@ export default Component.extend({
 
       const publication = this.get('publication');
       if (!publication || !publication.get('doi')) {
+        // Note that any metadata now does NOT come from Xref
+        this.clearDoiData();
         return;
       }
 

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -97,6 +97,7 @@ export default Component.extend({
     if (workflow.isDataFromCrossref()) {
       this.get('workflow').setFromCrossref(false);
       this.set('doiInfo', {});
+      this.set('submission.metadata', '{}');
       this.clearPublication();
     }
   },

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -54,7 +54,12 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    this.set('metadata', {});
+    try {
+      const md = JSON.parse(this.get('submission.metadata'));
+      this.set('metadata', md || {});
+      this.setReadOnly({});
+    // eslint-disable-next-line no-empty
+    } catch (e) {}
   },
 
   async willRender() {
@@ -80,7 +85,9 @@ export default Component.extend({
           this.get('schemaService').getFields(schemas)
         );
 
-        this.setReadOnly(metadataFromDoi);
+        if (this.get('workflow').isDataFromCrossref()) {
+          this.setReadOnly(metadataFromDoi);
+        }
 
         this.updateMetadata(metadataFromDoi);
 

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -45,7 +45,8 @@ export default Component.extend({
     return this.get('currentFormStep') + 1;
   }),
 
-  setNextReadonly: false,
+  // setNextReadonly: false,
+  readOnlyProperties: [],
 
   schemas: undefined,
 
@@ -79,6 +80,8 @@ export default Component.extend({
           this.get('schemaService').getFields(schemas)
         );
 
+        this.setReadOnly(metadataFromDoi);
+
         this.updateMetadata(metadataFromDoi);
 
         this.set('schemas', schemas);
@@ -88,6 +91,17 @@ export default Component.extend({
         console.log(e);
       }
     }
+  },
+
+  /**
+   * Set the object keys as read-only metadata fields. This assumes that incoming metadata captured
+   * before this component is reached is read-only such as Crossref metadata or title/journal
+   * from the first step of the workflow
+   *
+   * @param {object} metadata
+   */
+  setReadOnly(metadata) {
+    this.set('readOnlyProperties', Object.keys(metadata));
   },
 
   actions: {
@@ -144,7 +158,7 @@ export default Component.extend({
     let processed = service.alpacafySchema(schema);
 
     const metadata = this.get('metadata');
-    const readonly = this.get('setNextReadonly');
+    const readonly = this.get('readOnlyProperties');
 
     return service.addDisplayData(processed, metadata, readonly);
   },

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -130,8 +130,13 @@ export default Service.extend({
     }
 
     // Misc manual translation
-    doiCopy['journal-NLMTA-ID'] = doiCopy.nlmta;
-    doiCopy['journal-title-short'] = doiCopy['container-title-short'];
+    if (doiCopy.nlmta) {
+      doiCopy['journal-NLMTA-ID'] = doiCopy.nlmta;
+    }
+    if (doiCopy['container-title-short']) {
+      doiCopy['journal-title-short'] = doiCopy['container-title-short'];
+    }
+
     doiCopy.doi = doiCopy.DOI;
 
     // Remove "invalid" properties if given a list of valid fields

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -132,6 +132,8 @@ export default Service.extend({
     // Misc manual translation
     if (doiCopy.nlmta) {
       doiCopy['journal-NLMTA-ID'] = doiCopy.nlmta;
+    } else if (journal.get('nlmta')) {
+      doiCopy['journal-NLMTA-ID'] = journal.get('nlmta');
     }
     if (doiCopy['container-title-short']) {
       doiCopy['journal-title-short'] = doiCopy['container-title-short'];

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -24,9 +24,16 @@ export default Service.extend({
      *
      * We could set 'logger' to an object with `log`, `warn`, and `error` functions
      * to handle these things, if there is a need.
+     *
+     * 'addUsedSchema' option allows us to provide the full JSON schema object to the validate function
+     * of AJV without complaints. Without this option, the validate function will report an error because
+     * AJV does not like compiling a JSON schema that it already knows about (based on the schema's '$id').
+     * Speed can be improved if we enable this feature, then selectively add JSON schemas to avoid
+     * the re-compile step.
      */
     this.set('validator', new Ajv({
-      logger: false
+      logger: false,
+      addUsedSchema: false
     }));
   },
 

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -198,7 +198,8 @@ export default Service.extend({
    */
   mergeBlobs(blob1 = {}, blob2 = {}) {
     let blob = Object.assign(blob1, blob2);
-    Object.keys(blob).filter(key => !blob[key]).forEach(key => delete blob[key]);
+    Object.keys(blob).filter(key => !(key in blob)).forEach(key => delete blob[key]);
+
     return blob;
   },
 

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -59,17 +59,17 @@ export default Service.extend({
    *
    * @param {object} schema metadata (form) schema
    * @param {object} data display data to add to the schema
-   * @param {boolean} setReadOnly force updated fields to be read-only in the generated form
+   * @param {array} readonly list of properties that should be marked as read-only
    * @Returns {object} the modified schema
    */
-  addDisplayData(schema, data, setReadOnly) {
+  addDisplayData(schema, data, readonly) {
     if (!schema.data) {
       schema.data = {};
     }
     schema.data = Object.assign(schema.data, data);
 
-    if (setReadOnly) {
-      Object.keys(data).forEach((key) => {
+    if (readonly && readonly.length > 0) {
+      Object.keys(data).filter(key => readonly.includes(key)).forEach((key) => {
         if (schema.options.fields.hasOwnProperty(key)) {
           schema.options.fields[key].readonly = true;
         }

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -73,11 +73,20 @@ export default Service.extend({
     if (!schema.data) {
       schema.data = {};
     }
+    // Will merge 'data' onto 'schema.data'. 'schema.data' values may be overwritten by values from 'data'
     schema.data = Object.assign(schema.data, data);
 
     if (readonly && readonly.length > 0) {
+      /**
+       * For each key in the data object, if they are marked as "read only",
+       * set the field's 'readonly' to true, and 'toolbarSticky' to false iff the
+       * key refers to an array
+       */
       Object.keys(data).filter(key => readonly.includes(key)).forEach((key) => {
-        if (schema.options.fields.hasOwnProperty(key)) {
+        if (key in schema.options.fields) {
+          if (Array.isArray(data[key])) {
+            schema.options.fields[key].toolbarSticky = false;
+          }
           schema.options.fields[key].readonly = true;
         }
       });

--- a/app/services/workflow.js
+++ b/app/services/workflow.js
@@ -8,7 +8,10 @@ export default Service.extend({
    * then PASS must handle the submission for NIH compliance.
    */
   pmcPublisherDeposit: false,
+
   doiInfo: {},
+  dataFromCrossref: false,
+
   filesTemp: [],
   defaultRepoLoaded: false, // you only want to load the default setting on first access, after that is should respect he user's choice.
 
@@ -58,7 +61,14 @@ export default Service.extend({
   getDoiInfo() {
     return this.get('doiInfo');
   },
-  setDoiInfo(doiInfo) {
+  setDoiInfo(doiInfo, fromCrossref) {
     this.set('doiInfo', doiInfo);
+    this.setFromCrossref(!!fromCrossref);
+  },
+  setFromCrossref(fromCrossref) {
+    this.set('dataFromCrossref', fromCrossref);
+  },
+  isDataFromCrossref() {
+    return this.get('dataFromCrossref');
   }
 });

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -84,7 +84,11 @@
 </div>
 {{#link-to 'submissions.index' class="btn btn-outline-primary"}}Back{{/link-to}}
 <button class="btn btn-outline-danger ml-2" {{action 'cancel'}}>Abort</button>
-<button class="btn btn-primary pull-right next" {{action next}}>Next</button>
+{{#if inFlight}}
+  <button class="btn btn-primary pull-right next" disabled>Next</button>
+{{else}}
+  <button class="btn btn-primary pull-right next" {{action next}}>Next</button>
+{{/if}}
 {{#if isShowingUserSearchModal}}
   {{#modal-dialog
      translucentOverlay=true

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -283,9 +283,6 @@ module('Integration | Component | workflow basics', (hooks) => {
     this.owner.unregister('service:doi');
     this.owner.register('service:doi', mockDoiService);
 
-    // const wf = this.owner.lookup('service:workflow');
-    // wf.setFromCrossref(true);
-
     await render(hbs`{{workflow-basics
       submission=submission
       publication=publication
@@ -314,8 +311,13 @@ module('Integration | Component | workflow basics', (hooks) => {
     assert.ok(titleIn);
     assert.notOk(titleIn.hasAttribute('readonly'));
 
-    // Can't check for 'readonly' attribute, because the journal "input"
-    // is actually a PowerSelect div
+    /**
+     * Can't check for 'readonly' attribute, because the journal "input"
+     * is actually a PowerSelect div. The lack of the 'input' does actually
+     * suggest that things are working as intended, because this particular
+     * input should change from a normal text input to a PowerSelect when
+     * theh DOI goes away
+     */
     const journalSelector = this.element.querySelector('div#journal');
     assert.ok(journalSelector, 'Couldn\'t find journal selector');
     assert.notOk(

--- a/tests/integration/components/workflow-basics-test.js
+++ b/tests/integration/components/workflow-basics-test.js
@@ -171,68 +171,6 @@ module('Integration | Component | workflow basics', (hooks) => {
   });
 
   /**
-   * Test this by first adding metadata to the submission with some fields containing values that
-   * differ from equivalent fields defined in the mock DOI service.
-   */
-  test('Draft submission metadata is not overwritten by DOI data', async function (assert) {
-    assert.expect(10);
-
-    // First override the DOI service to ensure that it isn't called
-    this.owner.register('service:doi', Ember.Service.extend({
-      resolveDOI: () => assert.ok(false, 'resolveDOI should not be called'),
-      formatDOI: () => asssert.ok(false, 'formatDOI should not be called'),
-      isValidDOI: () => assert.ok(true, 'isValidDOI should be called')
-    }));
-
-    const pub = Ember.Object.create({
-      doi: 'ThisIsADOI',
-      title: 'Moo title',
-      journal: Ember.Object.create({ journalName: 'Moo Journal' })
-    });
-    this.set('publication', pub);
-
-    // Add metadata to submission
-    const submission = Ember.Object.create({
-      publication: pub,
-      metadata: JSON.stringify({ title: 'You better use this' })
-    });
-    this.set('submission', submission);
-
-    await render(hbs`{{workflow-basics
-      submission=submission
-      publication=publication
-      preLoadedGrant=preLoadedGrant
-      doiInfo=doiInfo
-      flaggedFields=flaggedFields
-      validateTitle=(action validateTitle)
-      validateJournal=(action validateJournal)
-      validateSubmitterEmail=(action validateSubmitterEmail)
-      next=(action loadNext)}}`);
-    assert.ok(this.element);
-
-    // Check values of various inputs
-    const inputs = this.element.querySelectorAll('input');
-    const title = this.element.querySelector('textarea');
-    const journal = this.element.querySelector('#journal');
-
-    assert.equal(inputs.length, 1, 'There should be one input element');
-    assert.ok(title, 'No "title" textarea element found');
-    assert.ok(journal, 'No "title" input element found');
-
-    assert.ok(title.textLength > 0, 'No title value found');
-    inputs.forEach((inp) => {
-      const msg = `No value found for input "${inp.parentElement.parentElement.querySelector('label').textContent}"`;
-      assert.ok(!!inp.value, msg);
-    });
-    assert.ok(journal.textContent.includes('Moo Journal'), 'Journal not found');
-
-    // Check submission metadata
-    const md = JSON.parse(this.get('submission.metadata'));
-    assert.ok(md, 'no metadata found');
-    assert.equal(md.title, 'You better use this', 'Unexpected metadata!');
-  });
-
-  /**
    * - Publication object exists
    * - Journal exists on Publication
    * - No metadata on submission

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -110,15 +110,17 @@ module('Unit | Service | metadata-schema', (hooks) => {
       feedback: 'Feedbag'
     };
 
+    const readonly = ['name'];
+
     const service = this.owner.lookup('service:metadata-schema');
     const schema = service.alpacafySchema(this.get('mockSchema'));
-    const result = service.addDisplayData(schema, data, true);
+    const result = service.addDisplayData(schema, data, readonly);
 
     assert.ok(result, 'No result found');
     assert.ok(result.data, 'No data found in result');
 
     assert.ok(result.options.fields.name.readonly, 'Property \'name\' not marked as read only');
-    assert.ok(result.options.fields.feedback.readonly, 'Property \'feedback\' not marked as read only');
+    assert.notOk(result.options.fields.feedback.readonly, 'Property \'feedback\' marked as read only');
   });
 
   test('Validation should fail when "name" field is not present in data', function (assert) {


### PR DESCRIPTION
Closes #939 
Also Closes #965 

One caveat is provided in the ticket. Alpaca warns about invalid data for _Authors_ and _ISSNs_. This doesn't seem to effect the metadata that gets saved to the submission.

`workflow-metadata` now assigns all keys that appear in the incoming metadata as read-only. When these keys are encountered in any rendered schema, they are marked as read-only in Alpaca. This implementation seems to work for submission with and without DOIs.

## Some test cases
This example test case should exercise basically everything, so is extensive:

1. Start new submission
2. Enter a DOI, example: `10.1039/c7an01256j`
    * There should be a (hopefully) brief popup in the top right saying that we're looking up your DOI
    * The Next button should be greyed out while the DOI is loading
    * After the DOI loads, the Title and Journal fields should be filled in and read-only
3. Click Next, add some grants
4. Proceed through the workflow until you get to Step 5. Details (the metadata forms)
    * There should be plenty of data filled into the metadata forms now. We should verify that:
      - Any value that has been prepopulated from the DOI is read only
      - If there are any authors and/or ISSNs filled in, the user is not able to add or remove any more values in these fields
5. Click Next until you get to the Files step (the metadata will then be saved to the draft submission)
6. Leave the workflow by clicking the Submissions tab in at the top of the page
    * The submission you were working on should now appear at or near the top of the submissions table, be marked as _draft_ and have _Edit_ and _Delete_ options
7. Click Edit to edit the draft submission you just made. You should be taken to Step 1 of the workflow
    * Your DOI should be shown, and Title and Journal should be displayed as read only
    * There should briefly be a popup saying that we are reading your DOI, and the Next button should be disabled
    * Once the DOI service finishes, a green popup should be shown and the Next button will be enabled
8. Click Next until you get to the Details (metadata) step
    * Verify that data is present here as expected - it should look like it did last time you were in the workflow
    * You don't need to keep going, since there are no changes to the metadata
9. Go back to the first step of the workflow, either by clicking Back until you get there, or you can click **1. Basics** tab in the navbar
10. Delete the DOI
    * Title and Journal should be cleared
11. Enter a value for Title, and pick a Journal
12. Proceed through the workflow until you get to the metadata step
    * Article Title and Journal/ISSN info should be filled out, these fields should be editable