### PR TITLE
Submissions deleted from details page shouldn't reappear

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -7,6 +7,7 @@ export default Controller.extend({
   currentUser: service('current-user'),
   store: service('store'),
   submissionHandler: service('submission-handler'),
+  searchHelper: service('search-helper'),
 
   tooltips: function () {
     $(() => {
@@ -421,7 +422,11 @@ export default Controller.extend({
         showCancelButton: true
       }).then((result) => {
         if (result.value) {
+          const ignoreList = this.get('searchHelper');
+
           this.get('submissionHandler').deleteSubmission(submission).then(() => {
+            ignoreList.clearIgnore();
+            ignoreList.ignore(submission.get('id'));
             this.transitionToRoute('submissions');
           });
         }


### PR DESCRIPTION
Closes #961 

Uses the `search-helper` (should rename) to ignore the newly deleted submission so that it does not appear in Elasticsearch results before ES finishes indexing.

The ignore list is already being checked in the submissions table due to a previous PR adding this change to the "Abort" button in the submission workflow