### PR TITLE
Fix an issue preventing DOI data from clearing sometimes

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -104,7 +104,7 @@ export default Component.extend({
     const workflow = this.get('workflow');
 
     if (workflow.isDataFromCrossref()) {
-      this.get('workflow').setFromCrossref(false);
+      workflow.setFromCrossref(false);
       this.set('doiInfo', {});
       this.set('submission.metadata', '{}');
       this.clearPublication(doi);
@@ -191,9 +191,6 @@ export default Component.extend({
       if (!publication || !publication.get('doi')) {
         // Note that any metadata now does NOT come from Xref
         this.clearDoiData();
-        return;
-      } else if (publication.get('doi') === this.get('workflow').getDoiInfo().DOI) {
-        // Stop issuing requests when the current DOI is the same as the recorded DOI
         return;
       }
 


### PR DESCRIPTION
PR title is fairly self explanatory. Publication data is supposed to clear when the user clears deletes the DOI. There was a bug that prevented this from happening by skipping the call to the DOI service