### PR TITLE
Grab publication date from DOI data

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - activemq
 
   schemaservice:
-    image: oapass/schema-service:v0.4.0@sha256:f6662809566184c9332d394465bea2cf93080aa018cf8ef322d0d6cb99982f17
+    image: oapass/schema-service:v0.4.0-1-g5227dd7@sha256:aff04c21f70d13bb9a9113e9b83b93b2a6e0b52c6d01fd322769379359c96c60
     container_name: schemaservice
     env_file: .env
     ports:

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -114,7 +114,7 @@ export default Component.extend({
   actions: {
     nextForm(metadata) {
       const step = this.get('currentFormStep');
-      this.updateMetadata(metadata);
+      this.updateMetadata(metadata, true);
 
       const schemaService = this.get('schemaService');
       const schema = this.get('schemas')[this.get('currentFormStep')];
@@ -176,17 +176,41 @@ export default Component.extend({
    * blob.
    *
    * Impl note:
-   * - The structure of the 'newMetadata' blob is determined by 'components/metadata-form.js'. It's
+   * - The structure of the 'newMetadata' blob is determined by 'components/metadata-form.js'. Its
    * metadata is provided to the #nextForm function call.
    * - Merging current and new blobs together is done in 'services/metadata-schema.js'
    *
    * @param {object} newMetadata metadata blob from a single metadata form
+   * @param {boolean} allowDelete let the blob merge delete fields
    */
-  updateMetadata(newMetadata) {
-    const mergedBlob = this.get('schemaService').mergeBlobs(
+  updateMetadata(newMetadata, allowDelete) {
+    let mergedBlob;
+
+    let deletableFields;
+
+    /**
+     * TODO: We need a comprehensive definition of how to merge metadata blobs.
+     * The current implementation does not work! For example, it will not allow
+     * the deletion of data, so if a user removes some info from a metadata form,
+     * it will not be removed from the blob :(
+     */
+
+    if (allowDelete) {
+      /**
+       * For field deletion, we should look at what fields are displayed in the current schema
+       * then for each of those fields, if no value is present, remove that key from the
+       * metadata blob. Using 'rendered' fields as valid deletable fields should work around
+       * the need to explicitly ignore '$schema'
+       */
+      deletableFields = this.get('schemaService').getFields([this.get('currentSchema')], true);
+    }
+
+    mergedBlob = this.get('schemaService').mergeBlobs(
       this.get('metadata'),
-      newMetadata
+      newMetadata,
+      deletableFields
     );
+
     this.set('metadata', mergedBlob);
   },
 

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -140,7 +140,7 @@ export default Service.extend({
     }
     if (doiCopy.issued && doiCopy.issued['date-parts']) {
       const parts = doiCopy.issued['date-parts'];
-      doiCopy.publicationDate = parts.join('-');
+      doiCopy.publicationDate = parts.flat().join('-');
     }
 
     doiCopy.doi = doiCopy.DOI;
@@ -154,20 +154,6 @@ export default Service.extend({
     doiCopy.$schema = this.get('metadataSchemaUri');
 
     return doiCopy;
-    // Manual mapping of DOI data to fields expected by our metadata forms
-    // return {
-    //   abstract: doiInfo.abstract,
-    //   authors: doiInfo.authors,
-    //   issns,
-    //   'journal-NLMTA-ID': doiInfo.nlmta,
-    //   doi: doiInfo.DOI,
-    //   publisher: doiInfo.publisher,
-    //   'journal-title-short': doiInfo['container-title-short'],
-    //   'journal-title': doiInfo['journal-title'],
-    //   title: doiInfo.title,
-    //   issue: doiInfo.issue,
-    //   volume: doiInfo.volume
-    // };
   },
 
   getJournalTitle(doiInfo) {

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -138,6 +138,10 @@ export default Service.extend({
     if (doiCopy['container-title-short']) {
       doiCopy['journal-title-short'] = doiCopy['container-title-short'];
     }
+    if (doiCopy.issued && doiCopy.issued['date-parts']) {
+      const parts = doiCopy.issued['date-parts'];
+      doiCopy.publicationDate = parts.join('-');
+    }
 
     doiCopy.doi = doiCopy.DOI;
 

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -213,8 +213,16 @@ export default Service.extend({
 
   /**
    * Merge data from metadata blob2 into metadata blob1 and output the result as a new
-   * object (this operation will not mutate either input objects). Broken out here in
-   * case special logic needs to be assigned.
+   * object (this operation will not mutate either input objects). Think of this merge
+   * as overwriting values from 'blob2' in 'blob1' to get the output blob.
+   *
+   * A list of fields can be provided specifying the field keys that can be deleted
+   * during this merge - it is possible to have keys that are _required_ for various
+   * business logic reasons. Defining this list will make it so that if a key is NOT
+   * present in 'blob2' and IS present in the 'deletableFields' list, then that key
+   * will be deleted from the merged blob. If you do not want _any_ fields to be
+   * able to be deleted from the merged blob, 'deletableFields' can be UNDEFINED or
+   * an empty array.
    *
    * Impl note: each blob now has a default value set of an empty object because
    * Object.assign will die if any arguments is undefined

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
-import { click, render } from '@ember/test-helpers';
+import { click, render, fillIn } from '@ember/test-helpers';
 
 module('Integration | Component | workflow-metadata', (hooks) => {
   setupRenderingTest(hooks);
@@ -362,5 +362,18 @@ module('Integration | Component | workflow-metadata', (hooks) => {
       assert.ok(metadata, 'No component metadata found');
       assert.notOk(metadata.badMoo, 'metadata.badMoo property should not be found on the metadata object');
     });
+  });
+
+  test('Metadata merges should be able to remove fields', async function (assert) {
+    const component = this.owner.lookup('component:workflow-metadata');
+
+    await render(hbs`{{workflow-metadata submission=submission publication=publication}}`);
+
+    assert.ok('journal-NLMTA-ID' in component.get('metadata'), 'journal-NLMTA-ID should be in metadata');
+
+    await fillIn('input[name="journal-NLMTA-ID"]', '');
+    await click('button[data-key="Next"]');
+
+    assert.notOk('journal-NLMTA-ID' in component.get('metadata'), 'journal-NLMTA-ID should no longer be in metadata');
   });
 });

--- a/tests/unit/services/metadata-schema-test.js
+++ b/tests/unit/services/metadata-schema-test.js
@@ -175,6 +175,14 @@ module('Unit | Service | metadata-schema', (hooks) => {
     assert.ok(result.includes('issns'));
   });
 
+  test('Get fields does not include \'allOf\' properties when told not to', function (assert) {
+    const service = this.owner.lookup('service:metadata-schema');
+    const result = service.getFields([this.get('mockSchema')], true);
+
+    assert.ok(result, 'No results found');
+    assert.notOk(result.includes('issns'));
+  });
+
   test('Get field to title map', function (assert) {
     const service = this.owner.lookup('service:metadata-schema');
 
@@ -224,5 +232,29 @@ module('Unit | Service | metadata-schema', (hooks) => {
     const expected = [];
 
     assert.deepEqual(result, expected);
+  });
+
+  test('mergeBlobs does not delete data normally', function (assert) {
+    const service = this.owner.lookup('service:metadata-schema');
+
+    const b1 = { one: '1 moo', two: '2 moo' };
+    const b2 = { two: 'moo too' };
+
+    const expected = { one: '1 moo', two: 'moo too' };
+
+    assert.deepEqual(service.mergeBlobs(b1, b2), expected);
+  });
+
+  test('mergeBlobs can delete only specified fields', function (assert) {
+    const service = this.owner.lookup('service:metadata-schema');
+
+    const b1 = { one: '1 moo', two: '2 moo' };
+    const b2 = { two: 'moo too' };
+
+    const list = ['one', 'two'];
+
+    const expected = { two: 'moo too' };
+
+    assert.deepEqual(service.mergeBlobs(b1, b2, list), expected);
   });
 });


### PR DESCRIPTION
Closes #964 

This implementation relies on an updated schema service, as it changes `publicationDate` to a string, from a date format.

* Map crossref `issued['date-part']` field to `publicationDate`
* Temporarily bump schema service version, will be updated once the new version is released

This is actually in a state that can be tested, simply pull these changes, bring up the `pass-ember` docker environment, start a new submission with a DOI of your choice, proceed through the submission workflow. Publication date should now appear in the metadata forms, and it should not trigger any validation errors.