### PR TITLE
Update schema service to use merged schema when possible

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - activemq
 
   schemaservice:
-    image: oapass/schema-service:v0.4.0-1-g5227dd7@sha256:aff04c21f70d13bb9a9113e9b83b93b2a6e0b52c6d01fd322769379359c96c60
+    image: oapass/schema-service:v0.5.0@sha256:98c6bc91a4660746d8eda54f4d410f402e161429817284722c407a2b253ee7e8
     container_name: schemaservice
     env_file: .env
     ports:

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -41,6 +41,10 @@ export default Component.extend({
   }),
   currentFormStep: 0, // Current step #
 
+  onlySingleSchema: Ember.computed('schemas', function () {
+    return this.get('schemas').length === 1;
+  }),
+
   displayFormStep: Ember.computed('currentFormStep', function () {
     return this.get('currentFormStep') + 1;
   }),
@@ -158,9 +162,14 @@ export default Component.extend({
   /**
    * Process schema before displaying it to the user. Tasks during processing includes pre-populating
    * appropriate data fields from current metadata, setting read-only fields, etc.
+   *  - Remove title of schema if there is only a single one to display
    */
   preprocessSchema(schema) {
     const service = this.get('schemaService');
+
+    if (this.get('onlySingleSchema')) {
+      schema = service.untitleSchema(schema);
+    }
 
     let processed = service.alpacafySchema(schema);
 

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -134,6 +134,16 @@ export default Service.extend({
     };
   },
 
+  /**
+   * Remove the schema's title to avoid showing it in the UI
+   *
+   * @param {object} schema JSON schema
+   */
+  untitleSchema(schema) {
+    delete schema.definitions.form.title;
+    return schema;
+  },
+
   validate(schema, data) {
     return this.get('validator').validate(schema, data);
   },

--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -38,6 +38,11 @@ export default Service.extend({
   },
 
   /**
+   * First try to get a single merged schema that combines all repository schema.
+   * If that request fails, retry the request, but without trying to merge the schema.
+   *
+   * If the schema service fails to merge, it should return a 409 error. Any other error
+   * will likely have an unknown cause and may not be recoverable.
    *
    * @param {array} repositories list of repository URIs
    * @returns {array} list of schemas relevant to the given repositories
@@ -49,15 +54,34 @@ export default Service.extend({
       repositories = repositories.map(repo => repo.get('id'));
     }
     const url = this.get('schemaService.url');
+    const urlWithMerge = `${url}?merge=true`;
 
-    return this.get('ajax').request(url, {
+    const options = {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json; charset=utf-8'
       },
       processData: false,
       data: repositories
-    });
+    };
+
+    // TODO: would be nice if this used Fetch API, but current tests are written for AJAX
+    return this.get('ajax')
+      .request(urlWithMerge, options)
+      .catch((response, jqXHR, payload) => {
+        /**
+         * error handling with `ember-ajax`: https://github.com/ember-cli/ember-ajax#access-the-response-in-case-of-error
+         * jqXHR info : https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest
+         */
+        if (jqXHR.status !== 409) {
+          // Unknown error
+          const msg = `Unknown error fetching merged metadata schema: ${jqXHR.statusText}`;
+          // console.log(`msg \n${response}`, 'color:red;');
+          throw new Error(msg);
+        }
+
+        return this.get('ajax').request(url, options);
+      });
   },
 
   /**

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -376,4 +376,39 @@ module('Integration | Component | workflow-metadata', (hooks) => {
 
     assert.notOk('journal-NLMTA-ID' in component.get('metadata'), 'journal-NLMTA-ID should no longer be in metadata');
   });
+
+  test('Single schema displays no title', async function (assert) {
+    const mockAjax = Ember.Service.extend({
+      request() {
+        return Promise.resolve([
+          {
+            id: 'common',
+            definitions: {
+              form: {
+                title: 'Common schema title moo',
+                type: 'object',
+                properties: {
+                  'journal-NLMTA-ID': { type: 'string' },
+                  ISSN: { type: 'string' }
+                },
+                options: {
+                  fields: {
+                    'journal-NLMTA-ID': { type: 'text', label: 'Journal NLMTA ID', placeholder: '' },
+                    ISSN: { type: 'text', label: 'ISSN', placeholder: '' }
+                  }
+                }
+              }
+            }
+          },
+        ]);
+      }
+    });
+    // Override previously mocked AJAX service
+    this.owner.register('service:ajax', mockAjax);
+
+    await render(hbs`{{workflow-metadata submission=submission publication=publication}}`);
+
+    const text = this.element.textContent;
+    assert.notOk(text.includes('Common schema'), 'Schema title should not be displayed');
+  });
 });


### PR DESCRIPTION
Closes #968 

## Changes 

* Schema service will now try to get merged schema, then retry unmerged schemas on failure
* Schema `title` no longer displayed if there is only a single schema to show - this _should_ happen only if schemas have been merged