### PR TITLE
Stale metadata no longer appears in workflow

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -1,14 +1,6 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 
-/**
- * Any metadata field presented by Crossref is made read-only, preventing any changes
- * to those metadata fields. However, a user may enter extra metadata on top of the Crossref fields.
- * It is safe to lookup the DOI in Crossref, then always merge the metadata currently in the
- * submission with the Crossref results. Lookup Crossref whenever the user enters the submission
- * workflow lets us see which fields came from Crossref. With that record, we will have enough
- * information about specific fields to set to read-only in the subsequent metadata step.
- */
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -58,12 +58,16 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
+
+    let md;
     try {
-      const md = JSON.parse(this.get('submission.metadata'));
+      md = JSON.parse(this.get('submission.metadata'));
+    } catch (e) {
+      // Do nothing
+    } finally {
       this.set('metadata', md || {});
       this.setReadOnly({});
-    // eslint-disable-next-line no-empty
-    } catch (e) {}
+    }
   },
 
   async willRender() {
@@ -78,6 +82,7 @@ export default Component.extend({
       // Load schemas by calling the Schema service
       try {
         const schemas = await this.get('schemaService').getMetadataSchemas(repos);
+        // this.clearUnsavedMetadata();
 
         const doiInfo = this.get('doiInfo');
         const journal = await this.get('publication.journal');
@@ -94,7 +99,7 @@ export default Component.extend({
         }
 
         this.updateMetadata(metadataFromDoi);
-
+        // debugger
         this.set('schemas', schemas);
         this.set('currentFormStep', 0);
       } catch (e) {

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -82,7 +82,6 @@ export default Component.extend({
       // Load schemas by calling the Schema service
       try {
         const schemas = await this.get('schemaService').getMetadataSchemas(repos);
-        // this.clearUnsavedMetadata();
 
         const doiInfo = this.get('doiInfo');
         const journal = await this.get('publication.journal');
@@ -99,7 +98,7 @@ export default Component.extend({
         }
 
         this.updateMetadata(metadataFromDoi);
-        // debugger
+
         this.set('schemas', schemas);
         this.set('currentFormStep', 0);
       } catch (e) {

--- a/tests/integration/components/workflow-metadata-test.js
+++ b/tests/integration/components/workflow-metadata-test.js
@@ -365,16 +365,16 @@ module('Integration | Component | workflow-metadata', (hooks) => {
   });
 
   test('Metadata merges should be able to remove fields', async function (assert) {
-    const component = this.owner.lookup('component:workflow-metadata');
-
     await render(hbs`{{workflow-metadata submission=submission publication=publication}}`);
 
-    assert.ok('journal-NLMTA-ID' in component.get('metadata'), 'journal-NLMTA-ID should be in metadata');
+    const nlmtaIn = this.element.querySelector('input[name="journal-NLMTA-ID"]');
+    assert.ok(nlmtaIn, 'No NLMTA-ID input field found');
+    assert.ok(nlmtaIn.value.includes('triumph'), 'Unexpected value found for NLMTA-ID');
 
     await fillIn('input[name="journal-NLMTA-ID"]', '');
     await click('button[data-key="Next"]');
 
-    assert.notOk('journal-NLMTA-ID' in component.get('metadata'), 'journal-NLMTA-ID should no longer be in metadata');
+    assert.notOk(this.element.querySelector('input[name="journal-NLMTA-ID"]').value.includes('triumph'));
   });
 
   test('Single schema displays no title', async function (assert) {


### PR DESCRIPTION
Closes #976 

Previous behavior as described in the linked ticket had stale data from a previous run through the workflow appear in the metadata forms of a new submission that had no DOI. This was ultimately caused by somewhat faulty logic used to purge the metadata.

Steps to test can be seen in the linked ticket.