### PR TITLE
Update coPIs list in grant details again

### DIFF
--- a/app/controllers/grants/detail.js
+++ b/app/controllers/grants/detail.js
@@ -9,14 +9,6 @@ export default Controller.extend({
 
   grant: alias('model.grant'),
 
-  coPIs: computed('grant.coPis', function () {
-    const coPis = this.get('grant.coPis');
-    if (coPis) {
-      return coPis.mapBy('displayName').toArray().join(', ');
-    }
-    return '';
-  }),
-
   // Columns displayed depend on the user role
   columns: computed('currentUser', {
     get() {

--- a/app/templates/grants/detail.hbs
+++ b/app/templates/grants/detail.hbs
@@ -23,7 +23,7 @@
       <li><strong>PI:</strong> {{grant.pi.displayName}}</li>
       <li><strong>Co-PI(s) / Co-I(s):</strong>
         <ul>
-          {{coPIs}}
+          {{#each model.grant.coPis as |person index|}}{{#if index}}, {{/if}}{{person.displayName}}{{/each}}
         </ul>
       </li>
     </ul>

--- a/app/templates/grants/detail.hbs
+++ b/app/templates/grants/detail.hbs
@@ -23,7 +23,7 @@
       <li><strong>PI:</strong> {{grant.pi.displayName}}</li>
       <li><strong>Co-PI(s) / Co-I(s):</strong>
         <ul>
-          {{#each model.grant.coPis as |person index|}}{{#if index}}, {{/if}}{{person.displayName}}{{/each}}
+          {{#each grant.coPis as |person index|}}{{#if index}}, {{/if}}{{person.displayName}}{{/each}}
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
Computing the display string in the controller was buggy due to how Ember was (not) loading objects in the `coPis` array. Moved logic back to the template.

I would normally have had the `{{each}}` and `{{if}}` declarations on separate lines for readability, but this was adding an extra white-space to the rendered page.