### PR TITLE
Try adding and removing repos when necessary

### DIFF
--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -1,8 +1,20 @@
 import Component from '@ember/component';
-import { Promise, } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 
+/**
+ * This component is responsible for displaying a table of grants that are relevant to
+ * the current submission. The list of grants is loaded here and is determined by
+ * the "submitter" of the current submission.
+ *
+ * This step entirely determines the policies that may be applied to the submission,
+ * which appear in a subsequent workflow step. Because of this, any change to selected
+ * grants necessarily must change policies applied to the submission. Adding a grant
+ * MUST trigger a recalculation of applied policies just as much as removing grants.
+ * We can implement this by simply clearing `submission.effectivePolicies` every time we
+ * make a change to grants in this stage. **We could also naively just clear
+ * `effectivePolicies` every time we load into the Policies step...**
+ */
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -25,7 +25,7 @@ import { inject as service, } from '@ember/service';
  *
  * "required", "optional", and "choice groups" are arrays of objects that look like:
  *  repoInfo: {
- *    funders: {}, // string
+ *    funders: '', // string
  *    repository: {}, // Repository object
  *  }
  */

--- a/app/routes/submissions/new/policies.js
+++ b/app/routes/submissions/new/policies.js
@@ -32,6 +32,7 @@ export default CheckSessionRoute.extend({
     //     policies.push(res);
     //   }
     // });
+    this.clearEffectivePolicies(submission);
 
     const policies = await this.get('policyService').getPolicies(submission);
 
@@ -42,6 +43,10 @@ export default CheckSessionRoute.extend({
       preLoadedGrant: parentModel.preLoadedGrant,
       policies: Promise.all(policies)
     });
+  },
+
+  clearEffectivePolicies(submission) {
+    submission.get('effectivePolicies').clear();
   },
 
   actions: {

--- a/app/routes/submissions/new/policies.js
+++ b/app/routes/submissions/new/policies.js
@@ -32,6 +32,11 @@ export default CheckSessionRoute.extend({
     //     policies.push(res);
     //   }
     // });
+
+    /**
+     * Remove current effectivePolicies from the submission because
+     * it will be recalculated and added back in this step.
+     */
     this.clearEffectivePolicies(submission);
 
     const policies = await this.get('policyService').getPolicies(submission);

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -11,6 +11,26 @@ export default Service.extend({
   schemaService: Ember.inject.service('metadata-schema'),
 
   /**
+   * Remove the specified grant from the given submission.
+   *
+   * There is some complexity behind the operation of changing grants associated with a
+   * submission. Since the grants directly or indirectly determing several properties of
+   * the submission such as policies and repositories, some care needs to be taken when
+   * adding or removing grants. There are separate steps in the workflow dealing with each
+   * of these properties that are isolated from one another - each step may not have enough
+   * information to determine
+   *
+   * Adding grants should not pose much of a risk to the submission, as the UI will render
+   *
+   *
+   * @param {Grant} grant the grant object to remove
+   * @param {Submission} submission the submission from which the grant will be removed
+   */
+  removeGrant(grant, submission) {
+
+  },
+
+  /**
    * _getSubmissionView - Internal method which returns the URL to view a submission.
    *
    * @param  {Submission} submission

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -11,26 +11,6 @@ export default Service.extend({
   schemaService: Ember.inject.service('metadata-schema'),
 
   /**
-   * Remove the specified grant from the given submission.
-   *
-   * There is some complexity behind the operation of changing grants associated with a
-   * submission. Since the grants directly or indirectly determing several properties of
-   * the submission such as policies and repositories, some care needs to be taken when
-   * adding or removing grants. There are separate steps in the workflow dealing with each
-   * of these properties that are isolated from one another - each step may not have enough
-   * information to determine
-   *
-   * Adding grants should not pose much of a risk to the submission, as the UI will render
-   *
-   *
-   * @param {Grant} grant the grant object to remove
-   * @param {Submission} submission the submission from which the grant will be removed
-   */
-  removeGrant(grant, submission) {
-
-  },
-
-  /**
    * _getSubmissionView - Internal method which returns the URL to view a submission.
    *
    * @param  {Submission} submission


### PR DESCRIPTION
Addresses part of #982 

This PR has multiple changes centered around modifying effective policies and repositories on an active submission in a workflow. Description of the buggy behavior can be seen in the linked ticket. A few changes were made to get around the issue:

* The Policies step will now fully refresh `submission.effectivePolicies` every time the Policy step is run based solely on the results of the policy service
  * The route clears effective policies before invoking the policy service. Any policy will appropriately be added back to the submission during this step. This removal and (re)adding of policies is done entirely client side in the Ember store, then persisted when the user clicks the Next button.
* The Repositories step is now changed to compare `submission.repositories` to the repo list from the policy service, taking the policy service results as truth.
  * Repositories on the submission that do not appear in the results will be removed from the submission
  * Repositories that are not present on the submission, but appear as `required` will be automatically added to the submission.

There is a downside to the approach taken here: if for some reason a user removes a grant from the submission, then clicks Next to save the draft and leaves the workflow, the draft submission will be in a sort of limbo state, where `effectivePolicies` and `repositories` would not have been updated. However, current implementation of editing draft submissions forces the user to step through the entire workflow, so those inaccuracies would be taken care of as soon as they make it to the appropriate step.