### PR TITLE
Update queries to ignore cancelled submissions

### DIFF
--- a/app/routes/grants/detail.js
+++ b/app/routes/grants/detail.js
@@ -19,8 +19,9 @@ export default CheckSessionRoute.extend({
     let grant = this.get('store').findRecord('grant', params.grant_id);
 
     const query = {
-      term: {
-        grants: params.grant_id
+      bool: {
+        must: { term: { grants: params.grant_id } },
+        must_not: { term: { submissionStatus: 'cancelled' } }
       },
       size: 500
     };

--- a/app/routes/grants/index.js
+++ b/app/routes/grants/index.js
@@ -61,7 +61,16 @@ export default CheckSessionRoute.extend({
       });
 
       // Then search for all Submissions associated with the returned Grants
-      this.get('store').query('submission', { query: { terms: { grants: grantIds } }, size: querySize }).then((subs) => {
+      const query = {
+        query: {
+          bool: {
+            must: { terms: { grants: grantIds } },
+            must_not: { term: { submissionStatus: 'cancelled' } }
+          }
+        },
+        size: querySize
+      };
+      this.get('store').query('submission', query).then((subs) => {
         subs.forEach((submission) => {
           submission.get('grants').forEach((grant) => {
             let match = results.find(res => res.grant.get('id') === grant.get('id'));


### PR DESCRIPTION
Closes #979, #984 

Update ES queries in the routes for the grants table and grant details page to explicitly ignore any submission the `submissionStatus: 'cancelled'`