### PR TITLE
Modify error handling for DOI service

### DIFF
--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -61,6 +61,11 @@
   <div class="text-danger">
     {{if (and publication.doi (not isValidDOI)) 'Please provide a valid DOI'}}
   </div>
+  {{#if doiServiceError}}
+    <div class="text-danger">
+      {{doiServiceError}}
+    </div>
+  {{/if}}
 </div>
 <div class="form-group">
   <label>Manuscript/Article Title <span class="text-muted">(required)</span></label>


### PR DESCRIPTION
Closes #986 

Errors are now displayed more plainly to the user when bad things are returned by the DOI service (bad things such as service error messages, or Crossref errors). Error messages now displayed under the DOI input field, instead of a Toastr popup in the top corner