### PR TITLE
Add spacing between Alpaca radio input and label text

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -324,8 +324,8 @@ td {
   label {
     display: block;
   }
-  .radio label {
-    margin-left: 12px;
+  .radio input[type="radio"] {
+    margin: 0 8px;
   }
 }
 


### PR DESCRIPTION
Previous CSS rule actually didn't effect spacing between radio input and label