### PR TITLE
Address inconsistencies with adding grants

### DIFF
--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -18,6 +18,7 @@ import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),
+
   pageNumber: 1,
   pageCount: 0,
   pageSize: 10,
@@ -121,20 +122,27 @@ export default Component.extend({
       }
     },
     addGrant(grant, event) {
+      const workflow = this.get('workflow');
       const submission = this.get('submission');
+
       if (grant) {
         submission.get('grants').pushObject(grant);
-        this.get('workflow').setMaxStep(2);
+        // submissionHandler.getRepositoriesFromGrant(grant).forEach(repo => workflow.addRepo(repo));
+        workflow.addGrant(grant);
+        workflow.setMaxStep(2);
       } else if (event && event.target.value) {
         this.get('store').findRecord('grant', event.target.value).then((g) => {
           g.get('primaryFunder.policy'); // Make sure policy is loaded in memory
           submission.get('grants').pushObject(g);
-          this.get('workflow').setMaxStep(2);
+          workflow.addGrant(g);
+          workflow.setMaxStep(2);
           Ember.$('select')[0].selectedIndex = 0;
         });
       }
     },
     async removeGrant(grant) {
+      const workflow = this.get('workflow');
+
       // if grant is grant passed in from grant detail page remove query parms
       if (grant === this.get('preLoadedGrant')) {
         this.set('preLoadedGrant', null);
@@ -142,8 +150,9 @@ export default Component.extend({
       const submission = this.get('submission');
       submission.get('grants').removeObject(grant);
 
+      workflow.removeGrant(grant);
       // undo progress, make user redo metadata step.
-      this.get('workflow').setMaxStep(2);
+      workflow.setMaxStep(2);
     },
 
     abortSubmission() {

--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -1,8 +1,20 @@
 import Component from '@ember/component';
-import { Promise, } from 'rsvp';
 import { inject as service } from '@ember/service';
 import Bootstrap4Theme from 'ember-models-table/themes/bootstrap4';
 
+/**
+ * This component is responsible for displaying a table of grants that are relevant to
+ * the current submission. The list of grants is loaded here and is determined by
+ * the "submitter" of the current submission.
+ *
+ * This step entirely determines the policies that may be applied to the submission,
+ * which appear in a subsequent workflow step. Because of this, any change to selected
+ * grants necessarily must change policies applied to the submission. Adding a grant
+ * MUST trigger a recalculation of applied policies just as much as removing grants.
+ * We can implement this by simply clearing `submission.effectivePolicies` every time we
+ * make a change to grants in this stage. **We could also naively just clear
+ * `effectivePolicies` every time we load into the Policies step...**
+ */
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -69,14 +69,13 @@ export default Component.extend({
       if (opt) {
         opt.forEach((opt) => {
           validRepos.push(opt.repository.get('id'));
-          opt.repository.set('_selected', currentRepos.includes(opt.repository));
+          this.setSelected(opt.repository);
         });
       }
       if (choice) {
         choice.forEach((group) => {
           group.forEach((repoInfo) => {
             validRepos.push(repoInfo.repository.get('id'));
-            // repoInfo.repository.set('_selected', currentRepos.includes(repoInfo.repository));
             this.setSelected(repoInfo.repository);
           });
         });

--- a/app/components/workflow-repositories.js
+++ b/app/components/workflow-repositories.js
@@ -25,7 +25,7 @@ import { inject as service, } from '@ember/service';
  *
  * "required", "optional", and "choice groups" are arrays of objects that look like:
  *  repoInfo: {
- *    funders: {}, // string
+ *    funders: '', // string
  *    repository: {}, // Repository object
  *  }
  */

--- a/app/routes/submissions/new/policies.js
+++ b/app/routes/submissions/new/policies.js
@@ -32,6 +32,7 @@ export default CheckSessionRoute.extend({
     //     policies.push(res);
     //   }
     // });
+    this.clearEffectivePolicies(submission);
 
     const policies = await this.get('policyService').getPolicies(submission);
 
@@ -42,6 +43,10 @@ export default CheckSessionRoute.extend({
       preLoadedGrant: parentModel.preLoadedGrant,
       policies: Promise.all(policies)
     });
+  },
+
+  clearEffectivePolicies(submission) {
+    submission.get('effectivePolicies').clear();
   },
 
   actions: {

--- a/app/routes/submissions/new/policies.js
+++ b/app/routes/submissions/new/policies.js
@@ -32,6 +32,11 @@ export default CheckSessionRoute.extend({
     //     policies.push(res);
     //   }
     // });
+
+    /**
+     * Remove current effectivePolicies from the submission because
+     * it will be recalculated and added back in this step.
+     */
     this.clearEffectivePolicies(submission);
 
     const policies = await this.get('policyService').getPolicies(submission);

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -11,6 +11,26 @@ export default Service.extend({
   schemaService: Ember.inject.service('metadata-schema'),
 
   /**
+   * Remove the specified grant from the given submission.
+   *
+   * There is some complexity behind the operation of changing grants associated with a
+   * submission. Since the grants directly or indirectly determing several properties of
+   * the submission such as policies and repositories, some care needs to be taken when
+   * adding or removing grants. There are separate steps in the workflow dealing with each
+   * of these properties that are isolated from one another - each step may not have enough
+   * information to determine
+   *
+   * Adding grants should not pose much of a risk to the submission, as the UI will render
+   *
+   *
+   * @param {Grant} grant the grant object to remove
+   * @param {Submission} submission the submission from which the grant will be removed
+   */
+  removeGrant(grant, submission) {
+
+  },
+
+  /**
    * _getSubmissionView - Internal method which returns the URL to view a submission.
    *
    * @param  {Submission} submission

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -11,6 +11,30 @@ export default Service.extend({
   schemaService: Ember.inject.service('metadata-schema'),
 
   /**
+   * Get all repositories associated with grants.
+   *
+   * @param {EmberArray} grant list of Grants
+   * @returns EmberArray with repositories
+   */
+  getRepositoriesFromGrants(grants) {
+    let result = Ember.A();
+
+    grants.forEach((grant) => {
+      const directRepos = grant.get('directFunder.policy.repositories');
+      const primaryRepos = grant.get('primaryFunder.policy.repositories');
+
+      if (Ember.isArray(directRepos)) {
+        result.pushObjects(directRepos);
+      }
+      if (Ember.isArray(primaryRepos)) {
+        result.pushObjects(primaryRepos);
+      }
+    });
+
+    return result.compact().uniqBy('id');
+  },
+
+  /**
    * _getSubmissionView - Internal method which returns the URL to view a submission.
    *
    * @param  {Submission} submission

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -11,26 +11,6 @@ export default Service.extend({
   schemaService: Ember.inject.service('metadata-schema'),
 
   /**
-   * Remove the specified grant from the given submission.
-   *
-   * There is some complexity behind the operation of changing grants associated with a
-   * submission. Since the grants directly or indirectly determing several properties of
-   * the submission such as policies and repositories, some care needs to be taken when
-   * adding or removing grants. There are separate steps in the workflow dealing with each
-   * of these properties that are isolated from one another - each step may not have enough
-   * information to determine
-   *
-   * Adding grants should not pose much of a risk to the submission, as the UI will render
-   *
-   *
-   * @param {Grant} grant the grant object to remove
-   * @param {Submission} submission the submission from which the grant will be removed
-   */
-  removeGrant(grant, submission) {
-
-  },
-
-  /**
    * _getSubmissionView - Internal method which returns the URL to view a submission.
    *
    * @param  {Submission} submission

--- a/app/services/workflow.js
+++ b/app/services/workflow.js
@@ -15,6 +15,8 @@ export default Service.extend({
   filesTemp: [],
   defaultRepoLoaded: false, // you only want to load the default setting on first access, after that is should respect he user's choice.
 
+  addedGrants: Ember.A([]),
+
   resetWorkflow() {
     this.setCurrentStep(0);
     this.setMaxStep(1);
@@ -22,6 +24,7 @@ export default Service.extend({
     this.setFilesTemp([]);
     this.setDoiInfo({});
     this.setDefaultRepoLoaded(false);
+    this.clearAddedGrants();
   },
   getCurrentStep() {
     return this.get('currentStep');
@@ -70,5 +73,17 @@ export default Service.extend({
   },
   isDataFromCrossref() {
     return this.get('dataFromCrossref');
+  },
+  getAddedGrants() {
+    return this.get('addedGrants');
+  },
+  addGrant(grant) {
+    this.get('addedGrants').pushObject(grant);
+  },
+  removeGrant(repo) {
+    this.get('addedGrants').removeObject(grant);
+  },
+  clearAddedGrants() {
+    this.get('addedGrants').clear();
   }
 });


### PR DESCRIPTION
Closes #982 

This issue ballooned out a bit, addressing not only `submission.effectivePolicies` not being updated, but also `submission.repositories` not being updated properly. As described in the ticket, this occurred when the user goes through the workflow, then goes back to change the grant selection. It also shows up when editing a draft submission and the user changes the grant selection.

## Changes

* workflow service: Can now be used to track grants that are added to the submission. Since data here only survives through one pass through the submission workflow, this information can be compared to the grants list on the submission to determine whether a grant was recently added.
* grants step: the Grants step now adds the grant to the workflow service, as well as the submission object. This way, subsequent steps can determine if a grant was just added, or if it existed on the submission already. This effects the selection status of repositories, for example.
* policies step: effective policies are now simply recalculated every time this step is completed
* repositories step: various factors are used to determine the selection status of `optional` and `choice` repositories
  * Repositories can now be added or removed from the submission, which was not the case before

