### PR TITLE
Fix typo preventing grant adding from working as intended

### DIFF
--- a/app/services/workflow.js
+++ b/app/services/workflow.js
@@ -80,7 +80,7 @@ export default Service.extend({
   addGrant(grant) {
     this.get('addedGrants').pushObject(grant);
   },
-  removeGrant(repo) {
+  removeGrant(grant) {
     this.get('addedGrants').removeObject(grant);
   },
   clearAddedGrants() {


### PR DESCRIPTION
This only fixes part of #995 when a user _removes_ a grant using the Remove button provided in the top table of the Grants step. Toggling a grant off (or on for that matter) from the grants selection table is still broken because the grants selection table uses a different mechanism to add/remove grants that skips that tracking needed to recalculate repositories. This is basically step 1 in a larger fix.

This fix will correct the bug listed in the linked issue: When the user goes back in the workflow and removes the NIH grant as described in the issue (assuming they do so by clicking the Remove button), this change will now correctly prevent the user from skipping forward in the workflow, thus avoid the error seen.