### PR TITLE
Tracking grants, take two

### DIFF
--- a/app/components/workflow-grants.js
+++ b/app/components/workflow-grants.js
@@ -51,6 +51,7 @@ export default Component.extend({
     }
 
     // Init selected grants to grants already attached to submission
+    this.get('_selectedGrants').clear();
     this.get('_selectedGrants').addObjects(this.get('submission.grants'));
   },
 

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -24,10 +24,10 @@ export default Service.extend({
       const primaryRepos = grant.get('primaryFunder.policy.repositories');
 
       if (Ember.isArray(directRepos)) {
-        result.pushObjects(directRepos);
+        result.pushObjects(directRepos.toArray());
       }
       if (Ember.isArray(primaryRepos)) {
-        result.pushObjects(primaryRepos);
+        result.pushObjects(primaryRepos.toArray());
       }
     });
 

--- a/app/templates/components/workflow-grants.hbs
+++ b/app/templates/components/workflow-grants.hbs
@@ -35,6 +35,7 @@
     pageSize=pageSize
     multipleSelect=true
     selectedItems=submission.grants
+    displayDataChangedAction=(action "dataChange")
   }}
 
   {{#if (gt pageCount "1")}}

--- a/tests/integration/components/workflow-grants-test.js
+++ b/tests/integration/components/workflow-grants-test.js
@@ -1,26 +1,106 @@
 import { setupRenderingTest } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
+import { render, settled, click } from '@ember/test-helpers';
+import { run } from '@ember/runloop';
 
 module('Integration | Component | workflow grants', (hooks) => {
   setupRenderingTest(hooks);
 
-  test('it renders', function (assert) {
-    let submission = Ember.Object.create({
-      repositories: [],
-      grants: []
-    });
-    let preLoadedGrant = Ember.Object.create({});
-    this.set('submission', submission);
-    this.set('preLoadedGrant', preLoadedGrant);
+  const knownGrant = Ember.Object.create({ id: 2, awardNumber: '2', projectName: 'Moo 2' });
+
+  hooks.beforeEach(function () {
     this.set('loadPrevious', (actual) => {});
     this.set('loadNext', (actual) => {});
 
-    this.render(hbs`{{workflow-grants
+    const submission = Ember.Object.create({
+      grants: Ember.A(),
+      submitter: Ember.Object.create({ id: '00' })
+    });
+    this.set('submission', submission);
+
+    const grants = Ember.A([
+      Ember.Object.create({ id: 1, awardNumber: '1', projectName: 'Moo 1' }),
+      knownGrant,
+      Ember.Object.create({ id: 3, awardNumber: '3', projectName: 'Moo 3' }),
+      Ember.Object.create({ id: 4, awardNumber: '4', projectName: 'Moo 4' })
+    ]);
+
+    run(() => {
+      this.owner.unregister('service:store');
+      this.owner.register('service:store', Ember.Service.extend({
+        query(type, query) {
+          return Promise.resolve(grants);
+        },
+        findRecord(type, id) {
+          return Promise.resolve(grants.findBy('id', id));
+        }
+      }));
+    });
+  });
+
+  test('it renders', async function (assert) {
+    await render(hbs`{{workflow-grants
       submission=submission
       preLoadedGrant=preLoadedGrant
       next=(action loadNext)
       back=(action loadPrevious)}}`);
-    assert.ok(true);
+    // Settled is required to let the call to store.query return before
+    // checking the rendered component
+    await settled();
+
+    const rows = this.element.querySelectorAll('#grants-selection-table table tbody tr');
+    assert.equal(rows.length, 4, 'Should be 4 rows displayed');
+  });
+
+  test('Pre-loaded grant is selected on render', async function (assert) {
+    this.set('preLoadedGrant', knownGrant);
+
+    await render(hbs`{{workflow-grants
+      submission=submission
+      preLoadedGrant=preLoadedGrant
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
+    await settled();
+
+    const selectedRows = this.element.querySelector('h5').nextElementSibling
+      .querySelectorAll('tbody tr');
+    assert.equal(selectedRows.length, 1, 'Should be 1 grant in this table');
+    assert.ok(selectedRows[0].textContent.includes('Remove'), 'Should have a "Remove" button');
+    assert.ok(selectedRows[0].textContent.includes('Moo 2'));
+
+    const rows = this.element.querySelectorAll('#grants-selection-table table tbody tr');
+    assert.equal(rows.length, 4, 'Should be 4 rows');
+
+    const row2 = rows[1];
+    assert.ok(row2.getAttribute('class').includes('selected-row'));
+    assert.ok(row2.querySelector('i[class="fa fa-check-square"]'));
+  });
+
+  test('Selecting a grant adds it', async function (assert) {
+    assert.expect(4);
+
+    this.owner.register('service:workflow', Ember.Service.extend({
+      setMaxStep: (step) => {},
+      addGrant: (grant) => { assert.ok(grant); }
+    }));
+
+    await render(hbs`{{workflow-grants
+      submission=submission
+      preLoadedGrant=preLoadedGrant
+      next=(action loadNext)
+      back=(action loadPrevious)}}`);
+    await settled();
+
+    const rows = this.element.querySelectorAll('#grants-selection-table table tbody tr');
+    assert.equal(rows.length, 4, 'Should be 4 rows');
+
+    await click(rows[0]);
+
+    const selectedRows = this.element.querySelector('h5').nextElementSibling
+      .querySelectorAll('tbody tr');
+    assert.equal(selectedRows.length, 1);
+    assert.ok(selectedRows[0].textContent.includes('Moo 1'), 'Only "Moo 1" should be selected');
+    // debugger
   });
 });


### PR DESCRIPTION
Closes #995 

A few changes, mostly around the `workflow-grants` component.  It was found that toggling grants on and off the submission using the "grant selection table" in the Grants step of the workflow did not use the add and remove actions in the `workflow-grants` component. Because of this, unintended behavior could occur  when modifying grant selection. 

It was intended that when the grants selection changed, that forward navigation would be restricted to the user, forcing them to step through subsequent steps in order for various properties to be calculated and added to the submission correctly. Because of the other mechanism used by the "grants selection table" to toggle grants on or off the submission, this navigation restriction was not enforced in some cases, allowing the user to first change the grants selection, then skip one or more steps in the workflow. For an example, see the scenario in the linked issue. This would cause an error to be thrown, not allowing the user to proceed with the submission.

The changes here (while messy) attempt to bring together the two mechanism for toggling grants so that grants are tracked properly through the workflow and navigation is updated as intended.

Some tests were added to test some behaviors of the `workflow-grants` component.

Notes:

The "grants selection table" is able to directly manipulate `submission.grants`, so that changing the selection status directly changed the grants attached to the submission. However, the "Remove" button provided on the "selected grants" table used the `removeGrant` action in the component. This PR adds an extra `dataChange` action in the component that triggers every time the "grants selection table" display changes. This action then tries to determine whether a grant has been selected or deselected, based on a prior selection state. When this status is determined, it can call the appropriate function to track the grant and modify the navigation.