### PR TITLE
'authors' property now required for J10P

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - activemq
 
   schemaservice:
-    image: oapass/schema-service:v0.5.0@sha256:98c6bc91a4660746d8eda54f4d410f402e161429817284722c407a2b253ee7e8
+    image: oapass/schema-service:v0.5.2@sha256:572dcfe965c5588564de22accd1ecaca3d3b141ba1097c9830026420ca3557c4
     container_name: schemaservice
     env_file: .env
     ports:

--- a/app/components/metadata-form.js
+++ b/app/components/metadata-form.js
@@ -19,14 +19,14 @@ export default Ember.Component.extend({
           label: 'Next',
           styles: 'pull-right btn btn-primary next',
           click() {
-            that.nextForm(this.getValue());
+            that.nextForm(that.stripEmptyArrays(this.getValue()));
           },
         },
         Back: {
           title: 'Back',
           styles: 'pull-left btn btn-outline-primary',
           click() {
-            that.previousForm(this.getValue());
+            that.previousForm(that.stripEmptyArrays(this.getValue()));
           },
         },
         Abort: {
@@ -41,5 +41,17 @@ export default Ember.Component.extend({
 
     $('#schemaForm').empty();
     $('#schemaForm').alpaca(newForm);
+  },
+
+  /**
+   * Remove empty array values from a JSON object. Keys that have a value of an empty
+   * array will be removed. Does not dive into object values.
+   *
+   * @param {JSONObject} object
+   */
+  stripEmptyArrays(object) {
+    Object.keys(object).filter(key => Array.isArray(object[key]) && object[key].length === 0)
+      .forEach((key) => { delete object[key]; });
+    return object;
   }
 });

--- a/app/components/workflow-metadata.js
+++ b/app/components/workflow-metadata.js
@@ -136,7 +136,7 @@ export default Component.extend({
         swal({
           type: 'error',
           title: 'Form Validation Error',
-          text: this.validationErrorMsg(schemaService.getErrors())
+          html: this.validationErrorMsg(schemaService.getErrors())
         });
         return;
       }

--- a/tests/integration/components/metadata-form-test.js
+++ b/tests/integration/components/metadata-form-test.js
@@ -39,4 +39,28 @@ module('Integration | Component | metadata-form', (hooks) => {
       'There should be three form control buttons (prev, abort, next)'
     );
   });
+
+  test('Test "stripEmptyArrays"', function (assert) {
+    const component = this.owner.lookup('component:metadata-form');
+
+    const obj = {
+      one: [],
+      two: ['moo'],
+      three: undefined,
+      four: [''],
+      five: [{}],
+      six: {},
+      seven: { moo: [] }
+    };
+    const result = component.stripEmptyArrays(obj);
+
+    assert.notOk('one' in result);
+    assert.ok('two' in result);
+    assert.ok('three' in result);
+    assert.ok('four' in result);
+    assert.ok('five' in result);
+    assert.ok('six' in result);
+    assert.ok('seven' in result);
+    assert.ok('moo' in result.seven);
+  });
 });


### PR DESCRIPTION
Closes #1001 

Changes:
* Update schema service version
* Make sure empty array values in Alpaca are not counted in metadata, otherwise validation will not work
* Don't escape HTML in error messages