### PR TITLE
Proxy sub review buttons should now disappear correctly after approving the submission

### DIFF
--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -171,6 +171,7 @@ export default Controller.extend({
   submissionNeedsSubmitter: Ember.computed(
     'currentUser.user',
     'model',
+    'model.sub.submissionStatus',
     function () {
       return (
         this.get('model.sub.submissionStatus') === 'approval-requested' ||


### PR DESCRIPTION
## Bug
When a _submitter_ goes to review a prepared submission and approves it in the submission details page, the `Review, Request Changes, Edit, Cancel` buttons would stay on the page.

## Change
* The UI flag that toggled the visibility of these buttons now tracks the appropriate model property

## Testing
In order to create a proxy submission, see these instructions: https://github.com/OA-PASS/pass-ember/wiki/Testing-Proxy-Submission

To test this PR
* login as the _submitter_ and review the submission
* Click the Submit button
* Click through the various prompts
* See if inappropriate buttons are on page