### PR TITLE
Handle journal without issns

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   store: service('store'),
   workflow: service('workflow'),
-  submitter: service('submission-handler'),
+  submissionHandler: service('submission-handler'),
   currentUser: service('current-user'),
 
   _getFilesElement() {
@@ -31,7 +31,7 @@ export default Component.extend({
             mFiles.removeObject(file);
           }
 
-          file.destroyRecord();
+          this.get('submissionHandler').deleteFile(file);
         }
       });
     },
@@ -60,7 +60,7 @@ export default Component.extend({
               this.get('newFiles').pushObject(newFile);
 
               // Immediately upload file
-              this.get('submitter').uploadFile(this.get('submission'), newFile);
+              this.get('submissionHandler').uploadFile(this.get('submission'), newFile);
             }
           }
         }

--- a/app/services/doi.js
+++ b/app/services/doi.js
@@ -93,28 +93,30 @@ export default Service.extend({
 
     // Add issns key in expected format by parsing journal issns.
     doiCopy.issns = [];
-    journal.get('issns').forEach((s) => {
-      let i = s.indexOf(':');
-      let value = {};
+    if (Ember.isArray(journal.get('issns'))) {
+      journal.get('issns').forEach((s) => {
+        let i = s.indexOf(':');
+        let value = {};
 
-      if (i == -1) {
-        value.issn = s;
-      } else {
-        let prefix = s.substring(0, i);
+        if (i == -1) {
+          value.issn = s;
+        } else {
+          let prefix = s.substring(0, i);
 
-        if (prefix === 'Print') {
-          value.pubType = 'Print';
-        } else if (prefix === 'Online') {
-          value.pubType = 'Online';
+          if (prefix === 'Print') {
+            value.pubType = 'Print';
+          } else if (prefix === 'Online') {
+            value.pubType = 'Online';
+          }
+
+          value.issn = s.substring(i + 1);
         }
 
-        value.issn = s.substring(i + 1);
-      }
-
-      if (value.issn.length > 0) {
-        doiCopy.issns.push(value);
-      }
-    });
+        if (value.issn.length > 0) {
+          doiCopy.issns.push(value);
+        }
+      });
+    }
 
     // Massage 'authors' information
     // Add expected properties and copy the field from 'author' to 'authors'

--- a/app/services/submission-handler.js
+++ b/app/services/submission-handler.js
@@ -298,5 +298,24 @@ export default Service.extend({
     return submission.save().then(() => {
       submission.unloadRecord();
     });
+  },
+
+  /**
+   * Remove a file from a submission.
+   *
+   * Note this does NOT delete the file from Fedora! It merely strips the
+   * File object's reference to the submission. This is to (for now) avoid
+   * some nasty permissions issues that might crop up during DELETE operations
+   *
+   * @param {File} file
+   * @returns {Promise}
+   */
+  deleteFile(file) {
+    if (!file) {
+      return;
+    }
+
+    file.set('submission', undefined);
+    return file.save().then(() => file.unloadRecord());
   }
 });

--- a/tests/unit/services/doi-test.js
+++ b/tests/unit/services/doi-test.js
@@ -187,4 +187,18 @@ module('Unit | Service | doi', (hooks) => {
       assert.equal(doiInfo.DOI, result.doiInfo.DOI);
     });
   });
+
+  test('Make sure we don\'t choke on journal with no ISSNs', function (assert) {
+    const journal = Ember.Object.create({
+      nlmta: 'NLmooTA'
+    });
+    const doiInfo = this.get('mockDoiInfo');
+    const service = this.owner.lookup('service:doi');
+
+    const result = service.doiToMetadata(doiInfo, journal);
+
+    assert.ok(result);
+    assert.equal(result.issns.length, 0);
+    assert.equal(result['journal-NLMTA-ID'], 'NLmooTA');
+  });
 });


### PR DESCRIPTION
Closes #1004, #1006 

## Changes
* Made adding a journal to submission more defensive to prevent errors when adding a journal that has no ISSNs
* When files are removed from a submission during the workflow, the reference to the submission on the Files object itself is now removed, preventing this file from reappearing on the submission
  * This approach was taking instead of fully deleting the File from Fedora because last time we tried to issue DELETE operations, we would get weird permission errors in TEST

## Testing
* Start a new submission
* Manually enter info: any title, and a journal with no ISSN
  * Example: `Bulletin. Moore-White Medical Foundation, Los Angeles`
* Progress through workflow until you get to the Files step
* Add a file as the `manuscript`
* Remove that file, then add another file as the `manuscript`
* Finish the submission and submit
* Check submission details, make sure that only the 2nd file appears on the submission