### PR TITLE
Fix removal of 'new' files

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -70,6 +70,8 @@ export default Component.extend({
       let files = this.get('newFiles');
       files.removeObject(file);
       this.set('files', files);
+
+      this.get('submissionHandler').deleteFile(file);
     },
     cancel() {
       this.sendAction('abort');


### PR DESCRIPTION
Make sure that files that have just been added to the submission can be removed as well. This is necessary because there is an artificial distinction between files that existed on a submission from before/after the start of the workflow. This means that files already on a draft submission before the start of editing are treated differently from files that have been added to the submission during the editing workflow.