### PR TITLE
Workaround the double (required) labels

### DIFF
--- a/app/services/metadata-schema.js
+++ b/app/services/metadata-schema.js
@@ -122,12 +122,24 @@ export default Service.extend({
   /**
    * Map a JSON schema to on that Alpaca will recognize.
    *
+   * If a field of `type: 'array'` is marked as `required` in the schema, remove that
+   * required status only for the alpacafied schema.
+   *
    * @param {object} schema JSON schema from the schema service
    */
   alpacafySchema(schema) {
     if (!schema.hasOwnProperty('definitions')) {
       return schema;
     }
+
+    Object.keys(schema.definitions.form.properties).filter(key => schema.definitions.form.properties[key].type === 'array')
+      .forEach((key) => {
+        const req = schema.definitions.form.required;
+        if (Array.isArray(req) && req.includes(key)) {
+          req.splice(req.indexOf(key), 1);
+        }
+      });
+
     return {
       schema: schema.definitions.form,
       options: schema.definitions.options || schema.definitions.form.options


### PR DESCRIPTION
Closes #1009 

This PR tries a workaround for an issue dealing with Alpaca's `(required)` labels that it automatically adds to _required_ fields. The linked issue describes how child fields of an array field will automatically gain `(required)` labels if the parent array field is marked as _required_ in the schema. It was determined that this only seems to occur when array data is pre-loaded into the Alpaca schema prior to rendering. This workaround simply removes the _required_ status of the parent array field IFF it has data to pre-load. This change only effects the schema meant for Alpaca rendering, thus should not effect any JSON schema validation.

Still needs some tests