### PR TITLE
Fix some DOI related user messages

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -209,7 +209,7 @@ export default Component.extend({
       publication.set('doi', doi);
       this.set('inFlight', true);
 
-      toastr.info('Please wait while we lookup information about your DOI', '', {
+      toastr.info('Please wait while we look up information about your DOI', '', {
         timeOut: 0,
         extendedTimeOut: 0
       });

--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -209,7 +209,7 @@ export default Component.extend({
       publication.set('doi', doi);
       this.set('inFlight', true);
 
-      toastr.info('Please wait while we information about your DOI', '', {
+      toastr.info('Please wait while we lookup information about your DOI', '', {
         timeOut: 0,
         extendedTimeOut: 0
       });

--- a/app/templates/components/workflow-basics.hbs
+++ b/app/templates/components/workflow-basics.hbs
@@ -69,9 +69,7 @@
     {{if (and publication.doi (not isValidDOI)) 'Please provide a valid DOI'}}
   </div>
   {{#if doiServiceError}}
-    <div class="text-danger">
-      {{doiServiceError}}
-    </div>
+    <div class="text-danger">{{{doiServiceError}}}</div>
   {{/if}}
 </div>
 <div class="form-group">


### PR DESCRIPTION
Closes #1034, #1035 

* No longer escape HTML in error message
* Fix grammar mistake in pending DOI message

To test, first make sure you don't have another Docker stack running. Pull these changes, navigate to the `.docker/` directory, then run `docker-compose up -d` and optionally run `docker-compose logs -f` to monitor Docker. Start a new submission and try messing with the DOI input field to see what happens.