### PR TITLE
UPW bugfixes

### DIFF
--- a/app/components/found-manuscripts/template.hbs
+++ b/app/components/found-manuscripts/template.hbs
@@ -1,81 +1,86 @@
 {{#if this.setupManuscripts.isIdle}}
- {{#if (and (not @disabled) (gt this.foundManuscriptsToDisplay.length 0))}}
-    <div class="border p-4" data-test-foundmss-component>
-      {{#if @disabled}}<h1>Disabled</h1>{{/if}}
+  {{#unless @disabled}}
+    {{#if (eq this.foundManuscriptsToDisplay.length 0)}}
       <p class="text-muted">
-        We found the following OA copies of your manuscript/article. Please select only a peer-reviewed copy
-        for inclusion in this submission. If you need help determining the appropriate copy to submit to PASS,
-        please <a href="{{assetsUri}}contact.html" target="_blank">contact JHU's Office of Scholarly Communications</a>.
+        We could not find any existing open access copies for your manuscript/article. Please upload your own copy.
       </p>
-      <p class="text-muted mb-0">
-        Click the <i class="fa fa-plus" aria-hidden="true"></i> icon beside a file name
-        to add it to your submission.
-      </p>
-      <p class="text-muted">
-        Click the <i class="fa fa-cloud-download" aria-hidden="true"></i> icon to open the file so you can see it first.
-      </p>
-      {{#each this.foundManuscriptsToDisplay as |manuscript index|}}
-        <div class="d-flex flex-row {{if (eq index 0) "border-top "}} border-bottom m-auto p-2 align-items-center justify-content-between">
-          <div class="d-flex flex-row flex-shrink-1 align-items-center pr-4">
-            {{#unless this.addFileTaskInstance.isRunning}}
-              <a
-                href="javascript:;"
-                class="p-2 {{if (contains manuscript.url this.manuscriptsWithErrors) 'text-danger'}}"
-                title="Add this manuscript to your submission"
-                {{on "click" (fn this.addFile manuscript)}}
-                data-test-add-file-link
-              >
-                  {{#if (contains manuscript.url this.manuscriptsWithErrors)}}
-                    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
-                  {{else}}
-                    <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
-                  {{/if}}
-                  <span class="pl-2">{{manuscript.name}}</span>
-                  {{#if manuscript.repositoryLabel}}
-                    <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
-                  {{/if}}
-                  {{#if (contains manuscript.url this.manuscriptsWithErrors)}}
-                    <small class="d-flex flex text-danger">We weren't able to add the file to your submission, please retry.</small>
-                  {{/if}}
-              </a>
-            {{else}}
-              {{#if (eq manuscript.url this.selectedManuscript.url)}}
-                <div class="d-flex flex text-center">
-                  <div class="lds-dual-ring-sm mt-0"></div>
-                </div>
-                <div class="d-flex flex text-center">
-                  <button
-                    type="button"
-                    class="btn btn-link"
-                    {{on "click" (fn this.cancelAddFile)}}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              {{else}}
+    {{else}}
+      <div class="border p-4" data-test-foundmss-component>
+        <p class="text-muted">
+          We found the following OA copies of your manuscript/article. Please select only a peer-reviewed copy
+          for inclusion in this submission. If you need help determining the appropriate copy to submit to PASS,
+          please <a href="{{assetsUri}}contact.html" target="_blank">contact JHU's Office of Scholarly Communications</a>.
+        </p>
+        <p class="text-muted mb-0">
+          Click the <i class="fa fa-plus" aria-hidden="true"></i> icon beside a file name
+          to add it to your submission.
+        </p>
+        <p class="text-muted">
+          Click the <i class="fa fa-cloud-download" aria-hidden="true"></i> icon to open the file so you can see it first.
+        </p>
+        {{#each this.foundManuscriptsToDisplay as |manuscript index|}}
+          <div class="d-flex flex-row {{if (eq index 0) "border-top "}} border-bottom m-auto p-2 align-items-center justify-content-between">
+            <div class="d-flex flex-row flex-shrink-1 align-items-center pr-4">
+              {{#unless this.addFileTaskInstance.isRunning}}
                 <a
                   href="javascript:;"
-                  class="p-2 text-muted"
+                  class="p-2 {{if (contains manuscript.url this.manuscriptsWithErrors) 'text-danger'}}"
                   title="Add this manuscript to your submission"
+                  {{on "click" (fn this.addFile manuscript)}}
+                  data-test-add-file-link
                 >
-                  <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
-                  <span class="pl-2">{{manuscript.name}}</span>
-                  {{#if manuscript.repositoryLabel}}
-                    <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
-                  {{/if}}
+                    {{#if (contains manuscript.url this.manuscriptsWithErrors)}}
+                      <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    {{else}}
+                      <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
+                    {{/if}}
+                    <span class="pl-2">{{manuscript.name}}</span>
+                    {{#if manuscript.repositoryLabel}}
+                      <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
+                    {{/if}}
+                    {{#if (contains manuscript.url this.manuscriptsWithErrors)}}
+                      <small class="d-flex flex text-danger">We weren't able to add the file to your submission, please retry.</small>
+                    {{/if}}
                 </a>
-              {{/if}}
-            {{/unless}}
+              {{else}}
+                {{#if (eq manuscript.url this.selectedManuscript.url)}}
+                  <div class="d-flex flex text-center">
+                    <div class="lds-dual-ring-sm mt-0"></div>
+                  </div>
+                  <div class="d-flex flex text-center">
+                    <button
+                      type="button"
+                      class="btn btn-link"
+                      {{on "click" (fn this.cancelAddFile)}}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                {{else}}
+                  <a
+                    href="javascript:;"
+                    class="p-2 text-muted"
+                    title="Add this manuscript to your submission"
+                  >
+                    <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
+                    <span class="pl-2">{{manuscript.name}}</span>
+                    {{#if manuscript.repositoryLabel}}
+                      <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
+                    {{/if}}
+                  </a>
+                {{/if}}
+              {{/unless}}
+            </div>
+            <div class="d-flex flex flex-grow-1 ml-sm-4 border-left">
+              <a href="{{manuscript.url}}" target="_blank" class="px-4 py-2" title="Download this manuscript">
+                <i class="fa fa-lg fa-cloud-download" aria-hidden="true"></i>
+              </a>
+            </div>
           </div>
-          <div class="d-flex flex flex-grow-1 ml-sm-4 border-left">
-            <a href="{{manuscript.url}}" target="_blank" class="px-4 py-2" title="Download this manuscript">
-              <i class="fa fa-lg fa-cloud-download" aria-hidden="true"></i>
-            </a>
-          </div>
-        </div>
-      {{/each}}
-    </div>
-  {{/if}}
+        {{/each}}
+      </div>
+    {{/if}}
+  {{/unless}}
 {{else}}
   <div class="text-center">
     <div class="lds-dual-ring mt-0"></div>

--- a/app/components/found-manuscripts/template.hbs
+++ b/app/components/found-manuscripts/template.hbs
@@ -34,7 +34,7 @@
                     {{else}}
                       <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
                     {{/if}}
-                    <span class="pl-2">{{manuscript.name}}</span>
+                    <span class="pl-2">{{manuscript.url}}</span>
                     {{#if manuscript.repositoryLabel}}
                       <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
                     {{/if}}
@@ -63,7 +63,7 @@
                     title="Add this manuscript to your submission"
                   >
                     <i class="fa fa-lg fa-plus" aria-hidden="true"></i>
-                    <span class="pl-2">{{manuscript.name}}</span>
+                    <span class="pl-2">{{manuscript.url}}</span>
                     {{#if manuscript.repositoryLabel}}
                       <span class="font-italic"> - {{manuscript.repositoryLabel}}</span>
                     {{/if}}

--- a/tests/integration/components/found-manuscripts/component-test.js
+++ b/tests/integration/components/found-manuscripts/component-test.js
@@ -46,7 +46,7 @@ module('Integration | Component | found-manuscripts', (hooks) => {
 
     await render(hbs`<FoundManuscripts />`);
 
-    assert.ok(this.element.textContent.includes('This is a moo'));
+    assert.ok(this.element.textContent.includes('http://moo.example.com'));
   });
 
   test('Nothing renders when disabled', async function (assert) {
@@ -88,13 +88,14 @@ module('Integration | Component | found-manuscripts', (hooks) => {
 
     await render(hbs`<FoundManuscripts @handleExternalMs={{this.mockAction}}/>`);
 
-    assert.dom('[data-test-add-file-link]').includesText('This is a moo');
+    assert.dom('[data-test-add-file-link]').includesText('http://moo.example.com');
 
     await click('[data-test-add-file-link]');
   });
 
   test('Message should appear if NOT disabled AND no files found', async function (assert) {
     const expected = 'We could not find any existing open access copies for your manuscript/article. Please upload your own copy.';
+
     this.owner.register('service:oa-manuscript-service', Service.extend({
       lookup(doi) {
         assert.ok(doi, 'DOI still needs to be present');

--- a/tests/integration/components/found-manuscripts/component-test.js
+++ b/tests/integration/components/found-manuscripts/component-test.js
@@ -30,13 +30,6 @@ module('Integration | Component | found-manuscripts', (hooks) => {
     }));
   });
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
-    await render(hbs`<FoundManuscripts />`);
-    assert.equal(this.element.textContent.trim(), '');
-  });
-
   test('An OA MS is displayed', async function (assert) {
     // Mock the download service
     const mockMsService = Service.extend({
@@ -57,7 +50,8 @@ module('Integration | Component | found-manuscripts', (hooks) => {
   });
 
   test('Nothing renders when disabled', async function (assert) {
-    await render(hbs`<FoundManuscripts @disabled="true" />`);
+    set(this, 'disabled', true);
+    await render(hbs`<FoundManuscripts @disabled={{this.disabled}} />`);
     assert.equal(this.element.childElementCount, 0);
   });
 
@@ -97,5 +91,18 @@ module('Integration | Component | found-manuscripts', (hooks) => {
     assert.dom('[data-test-add-file-link]').includesText('This is a moo');
 
     await click('[data-test-add-file-link]');
+  });
+
+  test('Message should appear if NOT disabled AND no files found', async function (assert) {
+    const expected = 'We could not find any existing open access copies for your manuscript/article. Please upload your own copy.';
+    this.owner.register('service:oa-manuscript-service', Service.extend({
+      lookup(doi) {
+        assert.ok(doi, 'DOI still needs to be present');
+        return Promise.resolve([]);
+      }
+    }));
+
+    await render(hbs`<FoundManuscripts />`);
+    assert.ok(this.element.textContent.includes(expected));
   });
 });

--- a/tests/integration/components/workflow-files-test.js
+++ b/tests/integration/components/workflow-files-test.js
@@ -182,7 +182,7 @@ module('Integration | Component | workflow files', (hooks) => {
     assert.dom('[data-test-foundmss-component]').exists();
 
     assert.dom('[data-test-add-file-link]').exists();
-    assert.dom('[data-test-add-file-link]').includesText('This is a moo');
+    assert.dom('[data-test-add-file-link]').includesText('http://example.com/moo.pdf');
 
     await click('[data-test-add-file-link]');
     await waitFor('[data-test-added-manuscript-row]');


### PR DESCRIPTION
Fixes #1078 

* Add message to user when no OA manuscripts are found
  * Previous behavior was to show nothing, leading to inconsistent messaging
* Display full file URL, instead of file name to disambiguate files with the same name

### Testing

* Use DOI: `10.1039/c7an01256j` to check the _Files_ step when with a DOI that has no OA manuscript files
* Use DOI: `10.1038/nature12373` to check behavior with a DOI that has more than one OA manuscript file