### PR TITLE
Show a message for COVID submissions

### DIFF
--- a/app/components/workflow-files.js
+++ b/app/components/workflow-files.js
@@ -80,6 +80,8 @@ export default Component.extend({
           }
 
           this.get('submissionHandler').deleteFile(file);
+
+          document.querySelector('#file-multiple-input').value = null;
         }
       });
     },

--- a/app/templates/submissions/detail.hbs
+++ b/app/templates/submissions/detail.hbs
@@ -94,6 +94,17 @@
                 {{submission-status submissionStatus=model.sub.submissionStatus}}
               </td>
             </tr>
+            {{#if this.model.sub.isCovid}}
+              <tr class="font-weight-bold">
+                <td></td>
+                <td>
+                  <div class="">
+                    This submission was marked as pertaining to COVID-19 research
+                    <a href="/faq.html#covid-19" target="_blank">(What does this mean?)</a>
+                  </div>
+                </td>
+              </tr>
+            {{/if}}
             <tr>
               <td><strong>Grants</strong></td>
               <td>


### PR DESCRIPTION
Fixes #1079 

* Adds a message to the user on the details page for a submission showing if a submission is related to COVID research

![image](https://user-images.githubusercontent.com/5167587/81738135-36ca6e80-9467-11ea-9d8e-09122e9c510e.png)
