### PR TITLE
Fix bug causing UI to be unusable if review popup was cancelled

### DIFF
--- a/app/components/workflow-review.js
+++ b/app/components/workflow-review.js
@@ -150,9 +150,9 @@ export default Component.extend({
               return false;
             }));
 
-            $('.block-user-input').css('display', 'block');
-
             this.sendAction('submit');
+          } else {
+            $('.block-user-input').css('display', 'none');
           }
         } else {
           // there were repositories, but the user didn't sign any of the agreements
@@ -166,6 +166,7 @@ export default Component.extend({
             html: `You declined to agree to the deposit agreement(s) for ${JSON.stringify(reposUserDidNotAgreeToDeposit.map(repo => repo.id)).replace(/[\[\]']/g, '')}. Therefore, this submission cannot be submitted.`,
             confirmButtonText: 'Ok',
           });
+          $('.block-user-input').css('display', 'none');
         }
       } else {
         // no repositories associated with the submission
@@ -174,7 +175,11 @@ export default Component.extend({
           html: 'No repositories are associated with this submission. \n Return to the submission and edit it to include a repository.',
           confirmButtonText: 'Ok',
         });
+        $('.block-user-input').css('display', 'none');
       }
+    } else {
+      // User has cancelled out of the popup
+      $('.block-user-input').css('display', 'none');
     }
   }),
 

--- a/tests/acceptance/nih-submission-test.js
+++ b/tests/acceptance/nih-submission-test.js
@@ -168,6 +168,14 @@ module('Acceptance | submission', function (hooks) {
 
     await waitFor(document.querySelector('#swal2-title'));
     assert.dom(document.querySelector('#swal2-title')).includesText('Deposit requirements for JScholarship');
+
+    await click(document.querySelector('.swal2-modal').parentElement);
+    assert.dom('#swal2-title').doesNotExist();
+
+    await click('[data-test-workflow-review-submit]');
+
+    await waitFor(document.querySelector('#swal2-title'));
+    assert.dom(document.querySelector('#swal2-title')).includesText('Deposit requirements for JScholarship');
     await click(document.querySelector('#swal2-checkbox'));
     await click(document.querySelector('.swal2-confirm'));
 


### PR DESCRIPTION
This is a Draft PR because there are no automated tests yet to check for this issue.

The issue seems to be caused by a lack of handling of cancellations of the SweetAlert popups in the Review step.

When a user clicks the Submit button, an element is made visible that blocks all user interaction with the UI. In "normal" submissions, this is handled after the submission is completed. However, if a user cancels out of the agreement popup, or doesn't click the Agree checkbox, the popups will disappear as expected, but this blocking element will never be removed. The user now cannot interact with the application.

Please feel free to take ownership of this PR and mark as ready for review when it's good to go.