### PR TITLE
Handle unencoded submission ids without double slashes

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -24,7 +24,7 @@ export default CheckSessionRoute.extend({
    * the current history with the encoded version.
    */
   beforeModel(transition) {
-    const intent = transition.intent.url;
+    let intent = transition.intent.url;
 
     if (!intent) {
       return;
@@ -38,6 +38,11 @@ export default CheckSessionRoute.extend({
       prefix = '/submissions/';
     } else {
       return;
+    }
+
+    // Work around ember collapsing // into /
+    if (intent.includes('https:/') && !intent.includes('https://')) {
+      intent = intent.replace('https:/', 'https://');
     }
 
     // Ensure that route parameter is encoded


### PR DESCRIPTION
Work around issue where application tries to access a submission whose id is not encoded in the URL and double slashes after https: have been turned into a single slash. Ember is responsible for the slash compression.

In order to test, create a submission and try to access with the id portion of the URL unencoded.

See #1086 