### PR TITLE
Fix submitter email bug

### DIFF
--- a/app/components/workflow-basics.js
+++ b/app/components/workflow-basics.js
@@ -22,7 +22,7 @@ export default Component.extend({
   }),
   inputSubmitterEmail: computed('submission.submitterEmail', {
     get(key) {
-      return this.get('submission.submitterEmail').replace('mailto:', '');
+      return this.get('submission.submitterEmailDisplay');
     },
     set(key, value) {
       this.set('submission.submitterEmail', `mailto:${value}`);
@@ -169,7 +169,7 @@ export default Component.extend({
     },
     updateSubmitterModel(isProxySubmission, submitter) {
       this.get('workflow').setMaxStep(1);
-      this.set('submission.submitterEmail', '');
+      this.set('submission.submitterEmail', null);
       this.set('submission.submitterName', '');
       if (isProxySubmission) {
         this.set('submission.submitter', submitter);

--- a/app/controllers/submissions/detail.js
+++ b/app/controllers/submissions/detail.js
@@ -181,7 +181,7 @@ export default Controller.extend({
     }
   ),
 
-  displaySubmitterName: computed('model.sub', function () {
+  displaySubmitterName: computed('model.sub', 'model.sub.submitter.firstName', function () {
     if (this.get('model.sub.submitter.displayName')) {
       return this.get('model.sub.submitter.displayName');
     } else if (this.get('model.sub.submitter.firstName')) {
@@ -192,7 +192,7 @@ export default Controller.extend({
     return '';
   }),
 
-  displaySubmitterEmail: computed('model.sub', function () {
+  displaySubmitterEmail: computed('model.sub', 'model.sub.submitter.email', function () {
     if (this.get('model.sub.submitter.email')) {
       return this.get('model.sub.submitter.email');
     } else if (this.get('model.sub.submitterEmail')) {

--- a/app/models/submission.js
+++ b/app/models/submission.js
@@ -12,7 +12,9 @@ export default DS.Model.extend({
   submitted: DS.attr('boolean', { defaultValue: false }),
   submissionStatus: DS.attr('string'),
   submitterName: DS.attr('string'),
-  submitterEmail: DS.attr('string'), // format: "mailto:jane@example.com"
+  submitterEmail: DS.attr('string', {
+    defaultValue: null
+  }), // format: "mailto:jane@example.com"
   submitter: DS.belongsTo('user'),
   preparers: DS.hasMany('user'),
   publication: DS.belongsTo('publication'),


### PR DESCRIPTION
- due to some surprising behavior based on the type of submitterEmail field in fedora (@id not a string), sending an empty string to fedora for this field will result in the submission resource being set as the value
- this occured when making a proxy sub on behalf of an exisiting user
- to avoid this we should always send a null value (rather than empty string) if we do not intend for fedora to set this field
- this allows for the field to be null'able and sets a default value as null on the model and explicitly in certain areas where the value was being set to an empty string
- this also cleans up the computeds on the submission detail to watch the correct properties so they're populated corretly once promises are resolved

Addresses: https://github.com/OA-PASS/general-issues/issues/142