### PR TITLE
Fix grants table pagination

### DIFF
--- a/app/components/workflow-grants/index.js
+++ b/app/components/workflow-grants/index.js
@@ -161,7 +161,7 @@ export default class WorkflowGrants extends Component {
 
     if (i > 1) {
       set(this, 'pageNumber', i - 1);
-      this.updateGrants();
+      this.updateGrants.perform();
     }
   }
 
@@ -171,7 +171,7 @@ export default class WorkflowGrants extends Component {
 
     if (i < this.pageCount) {
       set(this, 'pageNumber', i + 1);
-      this.updateGrants();
+      this.updateGrants.perform();
     }
   }
 


### PR DESCRIPTION
- some references to updateGrants in the pagination controls were not using task syntax rendering the buttons unusable
- this updates to use task perform helper